### PR TITLE
add a couple alternate key bindings to make the scrolling more intuitive

### DIFF
--- a/viewport/viewport.go
+++ b/viewport/viewport.go
@@ -304,14 +304,14 @@ func Update(msg tea.Msg, m Model) (Model, tea.Cmd) {
 			}
 
 		// Down half page
-		case "d":
+		case "d", "ctrl+d":
 			lines := m.HalfViewDown()
 			if m.HighPerformanceRendering {
 				cmd = ViewDown(m, lines)
 			}
 
 		// Up half page
-		case "u":
+		case "u", "ctrl+u":
 			lines := m.HalfViewUp()
 			if m.HighPerformanceRendering {
 				cmd = ViewUp(m, lines)


### PR DESCRIPTION
When I first started attempting to use Glow to read Markdown, the first thing I did was try to scroll. I've been trained for years to use <C-d>, <C-u> to scroll... This lets those binding work.