### PR TITLE
Textinput improvements

### DIFF
--- a/paginator/paginator.go
+++ b/paginator/paginator.go
@@ -40,8 +40,8 @@ type Model struct {
 // used for other things beyond navigating sets. Note that it both returns the
 // number of total pages and alters the model.
 func (m *Model) SetTotalPages(items int) int {
-	if items == 0 {
-		return 0
+	if items < 1 {
+		return m.TotalPages
 	}
 	n := items / m.PerPage
 	if items%m.PerPage > 0 {

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -473,28 +473,24 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 					}
 				}
 			}
-		case tea.KeyLeft:
+		case tea.KeyLeft, tea.KeyCtrlB:
 			if msg.Alt { // alt+left arrow, back one word
 				resetBlink = m.wordLeft()
 				break
 			}
-			if m.pos > 0 {
+			if m.pos > 0 { // left arrow, ^F, back one character
 				resetBlink = m.SetCursor(m.pos - 1)
 			}
-		case tea.KeyRight:
+		case tea.KeyRight, tea.KeyCtrlF:
 			if msg.Alt { // alt+right arrow, forward one word
 				resetBlink = m.wordRight()
 				break
 			}
-			if m.pos < len(m.value) {
+			if m.pos < len(m.value) { // right arrow, ^F, forward one word
 				resetBlink = m.SetCursor(m.pos + 1)
 			}
 		case tea.KeyCtrlW: // ^W, delete word left of cursor
 			resetBlink = m.deleteWordLeft()
-		case tea.KeyCtrlF: // ^F, forward one character
-			fallthrough
-		case tea.KeyCtrlB: // ^B, back one charcter
-			fallthrough
 		case tea.KeyHome, tea.KeyCtrlA: // ^A, go to beginning
 			resetBlink = m.CursorStart()
 		case tea.KeyDelete, tea.KeyCtrlD: // ^D, delete char under cursor

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -17,11 +17,11 @@ const defaultBlinkSpeed = time.Millisecond * 530
 // color is a helper for returning colors.
 var color func(s string) termenv.Color = termenv.ColorProfile().Color
 
-// blinkMsg and blinkCanceled are used to manage cursor blinking
+// blinkMsg and blinkCanceled are used to manage cursor blinking.
 type blinkMsg struct{}
 type blinkCanceled struct{}
 
-// Messages for clipboard events
+// Messages for clipboard events.
 type pasteMsg string
 type pasteErrMsg struct{ error }
 
@@ -43,7 +43,7 @@ const (
 	// EchoOnEdit
 )
 
-// Manages cursor blinking
+// blinkCtx manages cursor blinking.
 type blinkCtx struct {
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -160,10 +160,8 @@ func (m *Model) SetCursor(pos int) bool {
 	// Show the cursor unless it's been explicitly hidden
 	m.blink = m.cursorMode == cursorHide
 
-	if m.cursorMode == cursorBlink {
-		return true
-	}
-	return false
+	// Reset cursor blink if necessary
+	return m.cursorMode == cursorBlink
 }
 
 // CursorStart moves the cursor to the start of the field. Returns whether or
@@ -633,7 +631,7 @@ func (m Model) cursorView(v string) string {
 		String()
 }
 
-// blinkCmd is an internal command used to manage cursor blinking
+// blinkCmd is an internal command used to manage cursor blinking.
 func (m Model) blinkCmd() tea.Cmd {
 	if m.blinkCtx != nil && m.blinkCtx.cancel != nil {
 		m.blinkCtx.cancel()

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -156,7 +156,9 @@ func (m Model) Value() string {
 func (m *Model) SetCursor(pos int) bool {
 	m.pos = clamp(pos, 0, len(m.value))
 	m.handleOverflow()
-	m.blink = false
+
+	// Show the cursor unless it's been explicitly hidden
+	m.blink = m.cursorMode == cursorHide
 
 	if m.cursorMode == cursorBlink {
 		return true
@@ -184,7 +186,7 @@ func (m Model) Focused() bool {
 // Focus sets the focus state on the model.
 func (m *Model) Focus() {
 	m.focus = true
-	m.blink = false
+	m.blink = m.cursorMode == cursorHide // show the cursor unless we've explicitly hidden it
 }
 
 // Blur removes the focus state on the model.
@@ -532,8 +534,11 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		}
 
 	case blinkMsg:
-		m.blink = !m.blink
-		cmd := m.blinkCmd()
+		var cmd tea.Cmd
+		if m.cursorMode == cursorBlink {
+			m.blink = !m.blink
+			cmd = m.blinkCmd()
+		}
 		return m, cmd
 
 	case blinkCanceled: // no-op


### PR DESCRIPTION
* Pause blink while cursor is moving/reset blink timer after cursor stops moving
* `Update` and `View` are now methods on `Model`
* The `Blink` command is now a proper `tea.Cmd` (was a `func(Model) tea.Cmd`)
* `Paste` is now invoked as a command