### PR TITLE
Use Lip Gloss for styling in Spinner and Text Input

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.13
 require (
 	github.com/atotto/clipboard v0.1.2
 	github.com/charmbracelet/bubbletea v0.13.1
+	github.com/charmbracelet/lipgloss v0.1.2
 	github.com/lucasb-eyer/go-colorful v1.2.0
 	github.com/mattn/go-runewidth v0.0.12
 	github.com/muesli/reflow v0.2.1-0.20210115123740-9e1d0d53df68
 	github.com/muesli/termenv v0.8.1
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 // indirect
-	golang.org/x/sys v0.0.0-20201020230747-6e5568b54d1a // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/atotto/clipboard v0.1.2 h1:YZCtFu5Ie8qX2VmVTBnrqLSiU9XOWwqNRmdT3gIQzb
 github.com/atotto/clipboard v0.1.2/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/charmbracelet/bubbletea v0.13.1 h1:huvX8mPaeMZ8DLulT50iEWRF+iitY5FNEDqDVLu69nM=
 github.com/charmbracelet/bubbletea v0.13.1/go.mod h1:tp9tr9Dadh0PLhgiwchE5zZJXm5543JYjHG9oY+5qSg=
+github.com/charmbracelet/lipgloss v0.1.2 h1:D+LUMg34W7n2pkuMrevKVxT7HXqnoRHm7IoomkX3/ZU=
+github.com/charmbracelet/lipgloss v0.1.2/go.mod h1:5D8zradw52m7QmxRF6QgwbwJi9je84g8MkWiGN07uKg=
 github.com/containerd/console v1.0.1 h1:u7SFAJyRqWcG6ogaMAx3KjSTy1e3hT9QxqX7Jco7dRc=
 github.com/containerd/console v1.0.1/go.mod h1:XUsP6YE/mKtz6bxc+I8UiKKTP04qjQL4qcS3XoQ5xkw=
 github.com/google/goterm v0.0.0-20190703233501-fc88cf888a3f/go.mod h1:nOFQdrUlIlx6M6ODdSpBj1NVA+VgLC6kmw60mkw34H4=
@@ -34,6 +36,6 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200916030750-2334cc1a136f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201020230747-6e5568b54d1a h1:e3IU37lwO4aq3uoRKINC7JikojFmE5gO7xhfxs8VC34=
-golang.org/x/sys v0.0.0-20201020230747-6e5568b54d1a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 h1:myAQVi0cGEoqQVR5POX+8RR2mrocKqNN1hmeMqhX27k=
+golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/spinner/spinner.go
+++ b/spinner/spinner.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/reflow/ansi"
 	"github.com/muesli/termenv"
 )
@@ -64,17 +65,12 @@ type Model struct {
 	// Spinner settings to use. See type Spinner.
 	Spinner Spinner
 
-	// ForegroundColor sets the background color of the spinner. It can be
-	// a hex code or one of the 256 ANSI colors. If the terminal emulator can't
-	// support the color specified it will automatically degrade (per
-	// github.com/muesli/termenv).
-	ForegroundColor string
-
-	// BackgroundColor sets the background color of the spinner. It can be
-	// a hex code or one of the 256 ANSI colors. If the terminal emulator can't
-	// support the color specified it will automatically degrade (per
-	// github.com/muesli/termenv).
-	BackgroundColor string
+	// Style sets the styling for the spinner. Most of the time you'll just
+	// want foreground and background coloring, and potentially some padding.
+	//
+	// For an introduction to styling with Lip Gloss see:
+	// https://github.com/charmbracelet/lipgloss
+	Style lipgloss.Style
 
 	// MinimumLifetime is the minimum amount of time the spinner can run. Any
 	// logic around this can be implemented in view that implements this
@@ -230,15 +226,7 @@ func (m Model) View() string {
 		frame = strings.Repeat(" ", ansi.PrintableRuneWidth(frame))
 	}
 
-	if m.ForegroundColor != "" || m.BackgroundColor != "" {
-		return termenv.
-			String(frame).
-			Foreground(color(m.ForegroundColor)).
-			Background(color(m.BackgroundColor)).
-			String()
-	}
-
-	return frame
+	return m.Style.Render(frame)
 }
 
 // Tick is the command used to advance the spinner one frame. Use this command

--- a/spinner/spinner.go
+++ b/spinner/spinner.go
@@ -7,7 +7,6 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/reflow/ansi"
-	"github.com/muesli/termenv"
 )
 
 // Spinner is a set of frames used in animating the spinner.
@@ -16,8 +15,8 @@ type Spinner struct {
 	FPS    time.Duration
 }
 
+// Some spinners to choose from. You could also make your own.
 var (
-	// Some spinners to choose from. You could also make your own.
 	Line = Spinner{
 		Frames: []string{"|", "/", "-", "\\"},
 		FPS:    time.Second / 10, //nolint:gomnd
@@ -54,8 +53,6 @@ var (
 		Frames: []string{"🙈", "🙉", "🙊"},
 		FPS:    time.Second / 3, //nolint:gomnd
 	}
-
-	color = termenv.ColorProfile().Color
 )
 
 // Model contains the state for the spinner. Use NewModel to create new models

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -66,7 +66,10 @@ type Model struct {
 	EchoMode      EchoMode
 	EchoCharacter rune
 
-	// Styles.
+	// Styles. These will be applied as inline styles.
+	//
+	// For an introduction to styling with Lip Gloss see:
+	// https://github.com/charmbracelet/lipgloss
 	PromptStyle      lipgloss.Style
 	TextStyle        lipgloss.Style
 	BackgroundStyle  lipgloss.Style


### PR DESCRIPTION
This PR introduces Lip Gloss for styling in the Spinner and Text Input components, allowing for greater range in styling, and simpler code internally.

This update introduces some minor API changes, however functionality remains the same.

## Spinner

`Model.ForegroundColor` and `Model.BackgroundColor` is now simply `Model.Style`.

## TextInput

* `Model.TextColor` is now `Model.TextStyle`, allowing for a greater range in input text styling
* `Model.PlaceholderColor` is now `Model.PlaceholderStyle`, allowing for a greater range in placeholder styling
* `Model.CursorColor` is now `Model.CursorStyle`, allowing for a greater range in cursor styling
* Added `Model.PromptStyle`. Previously, styling the prompt was left as an exercise for the user.