### PR TITLE
Keep y-offset in bounds when setting content in viewport

### DIFF
--- a/viewport/viewport.go
+++ b/viewport/viewport.go
@@ -71,6 +71,10 @@ func (m Model) ScrollPercent() float64 {
 func (m *Model) SetContent(s string) {
 	s = strings.Replace(s, "\r\n", "\n", -1) // normalize line endings
 	m.lines = strings.Split(s, "\n")
+
+	if m.YOffset > len(m.lines)-1 {
+		m.GotoBottom()
+	}
 }
 
 // Return the lines that should currently be visible in the viewport.


### PR DESCRIPTION
This PR prevents a panic in the viewport that could occur when setting content without resetting the y-offset.

This was discovered in charmbracelet/bubbletea#87.