### PR TITLE
Minor textinput improvements

### DIFF
--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -61,7 +61,6 @@ type Model struct {
 	// General settings.
 	Prompt        string
 	Placeholder   string
-	Cursor        string
 	BlinkSpeed    time.Duration
 	EchoMode      EchoMode
 	EchoCharacter rune
@@ -148,6 +147,11 @@ func (m *Model) SetValue(s string) {
 // Value returns the value of the text input.
 func (m Model) Value() string {
 	return string(m.value)
+}
+
+// Cursor returns the cursor position.
+func (m Model) Cursor() int {
+	return m.pos
 }
 
 // SetCursor moves the cursor to the given position. If the position is

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -378,10 +378,15 @@ func (m *Model) deleteWordRight() bool {
 }
 
 // wordLeft moves the cursor one word to the left. Returns whether or not the
-// cursor blink should be reset.
+// cursor blink should be reset. If input is masked, move input to the start
+// so as not to reveal word breaks in the masked input.
 func (m *Model) wordLeft() bool {
 	if m.pos == 0 || len(m.value) == 0 {
 		return false
+	}
+
+	if m.EchoMode != EchoNormal {
+		return m.cursorStart()
 	}
 
 	blink := false
@@ -408,10 +413,15 @@ func (m *Model) wordLeft() bool {
 }
 
 // wordRight moves the cursor one word to the right. Returns whether or not the
-// cursor blink should be reset.
+// cursor blink should be reset. If the input is masked, move input to the end
+// so as not to reveal word breaks in the masked input.
 func (m *Model) wordRight() bool {
 	if m.pos >= len(m.value) || len(m.value) == 0 {
 		return false
+	}
+
+	if m.EchoMode != EchoNormal {
+		return m.cursorEnd()
 	}
 
 	blink := false
@@ -485,7 +495,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 				resetBlink = m.wordRight()
 				break
 			}
-			if m.pos < len(m.value) { // right arrow, ^F, forward one word
+			if m.pos < len(m.value) { // right arrow, ^F, forward one character
 				resetBlink = m.setCursor(m.pos + 1)
 			}
 		case tea.KeyCtrlW: // ^W, delete word left of cursor


### PR DESCRIPTION
This is a minor PR that and improves the textinput API and improves behavior when dealing with masked input, such as password input.

Changed:
* `SetCursor(int)`, `CursorStart()` and `CursorEnd()` no longer return values.
* If `EchoMode` is not `EchoNormal` word-to-word movement instead jumps to the beginning and end. Word-based deletion instead deletes to the beginning and end.

New:
* `Cursor() int` returns the cursor position.

Removed:
* Removed `Cursor string`, which did absolutely nothing.