### PR TITLE
Textinput Cursor Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,4 +91,4 @@ Part of [Charm](https://charm.sh).
 
 <a href="https://charm.sh/"><img alt="The Charm logo" src="https://stuff.charm.sh/charm-badge-unrounded.jpg" width="400"></a>
 
-Charm热爱开源! / Charm loves open source!
+Charm热爱开源 • Charm loves open source

--- a/spinner/spinner.go
+++ b/spinner/spinner.go
@@ -188,10 +188,9 @@ type TickMsg struct {
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case TickMsg:
-
 		// If a tag is set, and it's not the one we expect, reject the message.
 		// This prevents the spinner from receiving too many messages and
-		// this spinning too fast.
+		// thus spinning too fast.
 		if msg.tag > 0 && msg.tag != m.tag {
 			return m, nil
 		}

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -233,9 +233,14 @@ func (m Model) Focused() bool {
 
 // Focus sets the focus state on the model. When the model is in focus it can
 // receive keyboard input and the cursor will be hidden.
-func (m *Model) Focus() {
+func (m *Model) Focus() tea.Cmd {
 	m.focus = true
 	m.blink = m.cursorMode == CursorHide // show the cursor unless we've explicitly hidden it
+
+	if m.cursorMode == CursorBlink && m.focus {
+		return m.blinkCmd()
+	}
+	return nil
 }
 
 // Blur removes the focus state on the model.  When the model is blurred it can


### PR DESCRIPTION
This PR introduces options for textinput cursor behavior and improves subtleties with cursor blinking when multiple textinputs are present.

## New

* Cursors now have three modes: `CursorBlink`, `CursorStatic` and `CursorHide` (all of type `CursorMode`). You can set the cursor mode via `textinput`’s `Model.SetCursor(CursorMode)` and get the cursor mode with `Model.CursorMode() CursorMode`.

## Changed

* `textinput`’s `Model.Focus()` is now `Model.Focus() tea.Cmd`. This will initiate a properly timed cursor blink when focusing on a textinput if the cursor mode is set to blink.

## Fixed

* After their initial cursor blink (initiated by `textinput.Blink() tea.Cmd`), textinputs can now only receive blink messages they sent. This prevents textinputs from receiving other textinputs blink messages when focus changes.
* When cursor blink messages are sent, former blink messages in transit are invalidated, eliminating the change of rogue blinks.