### PR TITLE
Progress bar can now optionally animate itself

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/atotto/clipboard v0.1.2
 	github.com/charmbracelet/bubbletea v0.13.1
 	github.com/charmbracelet/lipgloss v0.1.2
-	github.com/fogleman/ease v0.0.0-20170301025033-8da417bf1776 // indirect
+	github.com/fogleman/ease v0.0.0-20170301025033-8da417bf1776
 	github.com/lucasb-eyer/go-colorful v1.2.0
-	github.com/mattn/go-runewidth v0.0.12
+	github.com/mattn/go-runewidth v0.0.13
 	github.com/muesli/reflow v0.2.1-0.20210115123740-9e1d0d53df68
 	github.com/muesli/termenv v0.8.1
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.13
 require (
 	github.com/atotto/clipboard v0.1.2
 	github.com/charmbracelet/bubbletea v0.13.1
+	github.com/charmbracelet/harmonica v0.1.0
 	github.com/charmbracelet/lipgloss v0.1.2
-	github.com/fogleman/ease v0.0.0-20170301025033-8da417bf1776
 	github.com/lucasb-eyer/go-colorful v1.2.0
 	github.com/mattn/go-runewidth v0.0.13
 	github.com/muesli/reflow v0.2.1-0.20210115123740-9e1d0d53df68

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/atotto/clipboard v0.1.2
 	github.com/charmbracelet/bubbletea v0.13.1
 	github.com/charmbracelet/lipgloss v0.1.2
+	github.com/fogleman/ease v0.0.0-20170301025033-8da417bf1776 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0
 	github.com/mattn/go-runewidth v0.0.12
 	github.com/muesli/reflow v0.2.1-0.20210115123740-9e1d0d53df68

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/charmbracelet/lipgloss v0.1.2 h1:D+LUMg34W7n2pkuMrevKVxT7HXqnoRHm7Ioo
 github.com/charmbracelet/lipgloss v0.1.2/go.mod h1:5D8zradw52m7QmxRF6QgwbwJi9je84g8MkWiGN07uKg=
 github.com/containerd/console v1.0.1 h1:u7SFAJyRqWcG6ogaMAx3KjSTy1e3hT9QxqX7Jco7dRc=
 github.com/containerd/console v1.0.1/go.mod h1:XUsP6YE/mKtz6bxc+I8UiKKTP04qjQL4qcS3XoQ5xkw=
+github.com/fogleman/ease v0.0.0-20170301025033-8da417bf1776 h1:VRIbnDWRmAh5yBdz+J6yFMF5vso1It6vn+WmM/5l7MA=
+github.com/fogleman/ease v0.0.0-20170301025033-8da417bf1776/go.mod h1:9wvnDu3YOfxzWM9Cst40msBF1C2UdQgDv962oTxSuMs=
 github.com/google/goterm v0.0.0-20190703233501-fc88cf888a3f/go.mod h1:nOFQdrUlIlx6M6ODdSpBj1NVA+VgLC6kmw60mkw34H4=
 github.com/lucasb-eyer/go-colorful v1.0.3/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHX
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
-github.com/mattn/go-runewidth v0.0.12 h1:Y41i/hVW3Pgwr8gV+J23B9YEY0zxjptBuCWEaxmAOow=
-github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
+github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
+github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/muesli/reflow v0.2.1-0.20210115123740-9e1d0d53df68 h1:y1p/ycavWjGT9FnmSjdbWUlLGvcxrY0Rw3ATltrxOhk=
 github.com/muesli/reflow v0.2.1-0.20210115123740-9e1d0d53df68/go.mod h1:Xk+z4oIWdQqJzsxyjgl3P22oYZnHdZ8FFTHAQQt5BMQ=
 github.com/muesli/termenv v0.7.2/go.mod h1:ct2L5N2lmix82RaY3bMWwVu/jUFc9Ule0KGDCiKYPh8=

--- a/go.sum
+++ b/go.sum
@@ -2,12 +2,12 @@ github.com/atotto/clipboard v0.1.2 h1:YZCtFu5Ie8qX2VmVTBnrqLSiU9XOWwqNRmdT3gIQzb
 github.com/atotto/clipboard v0.1.2/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/charmbracelet/bubbletea v0.13.1 h1:huvX8mPaeMZ8DLulT50iEWRF+iitY5FNEDqDVLu69nM=
 github.com/charmbracelet/bubbletea v0.13.1/go.mod h1:tp9tr9Dadh0PLhgiwchE5zZJXm5543JYjHG9oY+5qSg=
+github.com/charmbracelet/harmonica v0.1.0 h1:lFKeSd6OAckQ/CEzPVd2mqj+YMEubQ/3FM2IYY3xNm0=
+github.com/charmbracelet/harmonica v0.1.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
 github.com/charmbracelet/lipgloss v0.1.2 h1:D+LUMg34W7n2pkuMrevKVxT7HXqnoRHm7IoomkX3/ZU=
 github.com/charmbracelet/lipgloss v0.1.2/go.mod h1:5D8zradw52m7QmxRF6QgwbwJi9je84g8MkWiGN07uKg=
 github.com/containerd/console v1.0.1 h1:u7SFAJyRqWcG6ogaMAx3KjSTy1e3hT9QxqX7Jco7dRc=
 github.com/containerd/console v1.0.1/go.mod h1:XUsP6YE/mKtz6bxc+I8UiKKTP04qjQL4qcS3XoQ5xkw=
-github.com/fogleman/ease v0.0.0-20170301025033-8da417bf1776 h1:VRIbnDWRmAh5yBdz+J6yFMF5vso1It6vn+WmM/5l7MA=
-github.com/fogleman/ease v0.0.0-20170301025033-8da417bf1776/go.mod h1:9wvnDu3YOfxzWM9Cst40msBF1C2UdQgDv962oTxSuMs=
 github.com/google/goterm v0.0.0-20190703233501-fc88cf888a3f/go.mod h1:nOFQdrUlIlx6M6ODdSpBj1NVA+VgLC6kmw60mkw34H4=
 github.com/lucasb-eyer/go-colorful v1.0.3/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -9,6 +9,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/harmonica"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/lucasb-eyer/go-colorful"
 	"github.com/muesli/reflow/ansi"
 	"github.com/muesli/termenv"
@@ -129,7 +130,7 @@ type Model struct {
 	// Settings for rendering the numeric percentage.
 	ShowPercentage  bool
 	PercentFormat   string // a fmt string for a float
-	PercentageStyle *termenv.Style
+	PercentageStyle lipgloss.Style
 
 	// Members for animated transitons.
 	spring        harmonica.Spring
@@ -301,9 +302,7 @@ func (m Model) percentageView(percent float64) string {
 	}
 	percent = math.Max(0, math.Min(1, percent))
 	percentage := fmt.Sprintf(m.PercentFormat, percent*100) //nolint:gomnd
-	if m.PercentageStyle != nil {
-		percentage = m.PercentageStyle.Styled(percentage)
-	}
+	percentage = m.PercentageStyle.Inline(true).Render(percentage)
 	return percentage
 }
 

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -98,6 +98,13 @@ func WithWidth(w int) Option {
 	}
 }
 
+func WithSpringOptions(frequency, damping float64) Option {
+	return func(m *Model) {
+		m.SetSpringOptions(frequency, damping)
+		m.springCustomized = true
+	}
+}
+
 // FrameMsg indicates that an animation step should occur.
 type FrameMsg struct {
 	id  int
@@ -130,10 +137,11 @@ type Model struct {
 	PercentageStyle lipgloss.Style
 
 	// Members for animated transitons.
-	spring        harmonica.Spring
-	percent       float64
-	targetPercent float64
-	velocity      float64
+	spring           harmonica.Spring
+	springCustomized bool
+	percent          float64
+	targetPercent    float64
+	velocity         float64
 
 	// Gradient settings
 	useRamp    bool
@@ -158,7 +166,9 @@ func NewModel(opts ...Option) Model {
 		ShowPercentage: true,
 		PercentFormat:  " %3.0f%%",
 	}
-	m.SetSpringOptions(defaultFrequency, defaultDamping)
+	if !m.springCustomized {
+		m.SetSpringOptions(defaultFrequency, defaultDamping)
+	}
 
 	for _, opt := range opts {
 		opt(&m)

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -183,7 +183,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			return m, nil
 		}
 
-		m.spring.Update(&m.percent, &m.velocity, m.targetPercent)
+		m.percent, m.velocity = m.spring.Update(m.percent, m.velocity, m.targetPercent)
 		return m, m.nextFrame()
 
 	default:


### PR DESCRIPTION
This update leverages the newly-released [Harmonica](https://github.com/charmbracelet/harmonica) to animate the progress bar between states as well as some general improvements to the `progress` package.

<img src="https://stuff.charm.sh/bubbles-examples/progress-harmonica.gif" width="1200" alt="Animated Progress Bubble example">

## New

* The progress bar can now be animated:
    * `Model.SetPercent()` starts the animation (as well as `Model.IncrPercent()` and `Model.DecrPercent()`)
    * `FrameMsg`s sent to `Model.Update()` step the animation.
    * Customize animation settings can be set via `SetSpringOptions`. See the [Harmonica README](https://github.com/charmbracelet/harmonica) for details on spring settings.

## Changed

* You can now use [Lip Gloss](https://github.com/charmbracelet/lipgloss) to style the percentage readout: `Model.PercentageStyle` is now of type `lipgloss.Style`.
* `Model.View` is now `Model.ViewAs`. This can be used to render a static progress bar in a “pure” fashion (as was the case prior to this update).
* `NewModel() error` is now `NewModel()`. It no longer returns an error for better usability. As a side effect, incorrect hex colors will simply render as black.