### PR TITLE
Progress bars now statisfy the tea.Model interface

### DIFF
--- a/progress/progress.go
+++ b/progress/progress.go
@@ -176,11 +176,16 @@ func NewModel(opts ...Option) Model {
 	return m
 }
 
+// Init exists satisfy the tea.Model interface.
+func (m Model) Init() tea.Cmd {
+	return nil
+}
+
 // Update is used to animation the progress bar during transitions. Use
 // SetPercent to create the command you'll need to trigger the animation.
 //
 // If you're rendering with ViewAs you won't need this.
-func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case FrameMsg:
 		if msg.id != m.id || msg.tag != m.tag {


### PR DESCRIPTION
This is a minor update to the (imminently released) animatable progress bar for composability purposes.