### PR TITLE
Allow `key.Matches` to accept multiple binding arguments

### DIFF
--- a/key/key.go
+++ b/key/key.go
@@ -128,11 +128,13 @@ type Help struct {
 	Desc string
 }
 
-// Matches checks if the given KeyMsg matches a given binding.
-func Matches(k tea.KeyMsg, b Binding) bool {
-	for _, v := range b.keys {
-		if k.String() == v && b.Enabled() {
-			return true
+// Matches checks if the given KeyMsg matches the given bindings.
+func Matches(k tea.KeyMsg, b ...Binding) bool {
+	for _, binding := range b {
+		for _, v := range binding.keys {
+			if k.String() == v && binding.Enabled() {
+				return true
+			}
 		}
 	}
 	return false


### PR DESCRIPTION
`key.Binding` currently allows you to bind against multiple keys:

```go
binding := key.Binding(key.WithKeys("q", "ctrl+c"))
```

However, sometimes you may also want to match on multiple bindings at once:

```go
left := key.Binding(key.WithKeys("h", "left"))
right := key.Binding(key.WithKeys("l", "right"))

case key.Matches(msg, left), key.Matches(msg, right):
```

This update expands `key.Matches` to accept multiple arguments so you can condense the above `case` statement to:

```go
case key.Matches(msg, left, right):
```