### PR TITLE
fix(list): update keybindings when setting items

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -606,7 +606,7 @@ func (m *Model) updateKeybindings() {
 		m.KeyMap.CloseFullHelp.SetEnabled(false)
 
 	default:
-		hasItems := m.items != nil
+		hasItems := len(m.items) != 0
 		m.KeyMap.CursorUp.SetEnabled(hasItems)
 		m.KeyMap.CursorDown.SetEnabled(hasItems)
 

--- a/list/list.go
+++ b/list/list.go
@@ -292,6 +292,7 @@ func (m *Model) SetItems(i []Item) tea.Cmd {
 	}
 
 	m.updatePagination()
+	m.updateKeybindings()
 	return cmd
 }
 


### PR DESCRIPTION
Bug: when calling SetItems when items was previously empty, the keybindings for
up/down do not appear.

Fix: call updateKeybindings in SetItems.