### PR TITLE
Spin Safety

### DIFF
--- a/spinner/spinner.go
+++ b/spinner/spinner.go
@@ -254,8 +254,12 @@ func (m Model) View() string {
 
 // Tick is the command used to advance the spinner one frame. Use this command
 // to effectively start the spinner.
-func Tick() tea.Msg {
-	return TickMsg{Time: time.Now()}
+func (m Model) Tick() tea.Msg {
+	return TickMsg{
+		Time: time.Now(),
+		id:   m.id,
+		tag:  m.tag,
+	}
 }
 
 func (m Model) tick(id, tag int) tea.Cmd {
@@ -266,4 +270,12 @@ func (m Model) tick(id, tag int) tea.Cmd {
 			tag:  tag,
 		}
 	})
+}
+
+// Tick is the command used to advance the spinner one frame. Use this command
+// to effectively start the spinner.
+//
+// This method is deprecated. Use Model.Tick instead.
+func Tick() tea.Msg {
+	return TickMsg{Time: time.Now()}
 }

--- a/spinner/spinner.go
+++ b/spinner/spinner.go
@@ -146,6 +146,11 @@ func (m *Model) Finish() {
 	}
 }
 
+// ID returns the spinner's unique ID.
+func (m Model) ID() int {
+	return m.id
+}
+
 // advancedMode returns whether or not the user is making use of HideFor and
 // MinimumLifetime properties.
 func (m Model) advancedMode() bool {
@@ -200,7 +205,7 @@ func NewModel() Model {
 type TickMsg struct {
 	Time time.Time
 	tag  int
-	id   int
+	ID   int
 }
 
 // Update is the Tea update function. This will advance the spinner one frame
@@ -211,7 +216,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	case TickMsg:
 		// If an ID is set, and the ID doesn't belong to this spinner, reject
 		// the message.
-		if msg.id > 0 && msg.id != m.id {
+		if msg.ID > 0 && msg.ID != m.id {
 			return m, nil
 		}
 
@@ -256,9 +261,15 @@ func (m Model) View() string {
 // to effectively start the spinner.
 func (m Model) Tick() tea.Msg {
 	return TickMsg{
+		// The time at which the tick occurred.
 		Time: time.Now(),
-		id:   m.id,
-		tag:  m.tag,
+
+		// The ID of the spinner that this message belongs to. This can be
+		// helpful when routing messages, however bear in mind that spinners
+		// will ignore messages that don't contain ID by default.
+		ID: m.id,
+
+		tag: m.tag,
 	}
 }
 
@@ -266,7 +277,7 @@ func (m Model) tick(id, tag int) tea.Cmd {
 	return tea.Tick(m.Spinner.FPS, func(t time.Time) tea.Msg {
 		return TickMsg{
 			Time: t,
-			id:   id,
+			ID:   id,
 			tag:  tag,
 		}
 	})


### PR DESCRIPTION
This update associates `spinner.TickMsg`s with with spinners so that spinners will only respond to their own messages. This helps prevent spinners from spinning out of control and allows you to start and stop specific spinners without any logical gymnastics.

As a side effect of this change, the `spinner.Tick` command has been deprecated in favor of `spinner.Model.Tick`:

```go
import `github.com/charmbracelet/bubbles/spinner`

// Deprecated: this will start any spinner that receives the resulting TickMsg
return m, spinner.Tick

// New: start a specific spinner
return m, m.mySpinner.Tick()
```