### PR TITLE
Viewport quality-of-life improvements

### DIFF
--- a/viewport/keymap.go
+++ b/viewport/keymap.go
@@ -1,0 +1,42 @@
+package viewport
+
+import "github.com/charmbracelet/bubbles/key"
+
+const spacebar = " "
+
+// KeyMap defines the keybindings for the viewport. Note that you don't
+// necessary need to use keybindings at all; the viewport can be controlled
+// programmatically with methods like Model.LineDown(1). See the GoDocs for
+// details.
+type KeyMap struct {
+	PageDown     key.Binding
+	PageUp       key.Binding
+	HalfPageUp   key.Binding
+	HalfPageDown key.Binding
+	Down         key.Binding
+	Up           key.Binding
+}
+
+// DefaultKeyMap returns a set of pager-like default keybindings.
+func DefaultKeyMap() KeyMap {
+	return KeyMap{
+		PageDown: key.NewBinding(
+			key.WithKeys("pgdown", spacebar, "f"),
+		),
+		PageUp: key.NewBinding(
+			key.WithKeys("pgup", "b"),
+		),
+		HalfPageUp: key.NewBinding(
+			key.WithKeys("u", "ctrl+u"),
+		),
+		HalfPageDown: key.NewBinding(
+			key.WithKeys("d", "ctrl+d"),
+		),
+		Up: key.NewBinding(
+			key.WithKeys("up", "k"),
+		),
+		Down: key.NewBinding(
+			key.WithKeys("down", "j"),
+		),
+	}
+}

--- a/viewport/viewport.go
+++ b/viewport/viewport.go
@@ -9,16 +9,13 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-// NewModel returns a new model with the given width and height as well as
-// default keymappings.
-func NewModel(width, height int) Model {
-	return Model{
-		Width:             width,
-		Height:            height,
-		KeyMap:            DefaultKeyMap(),
-		MouseWheelEnabled: true,
-		MouseWheelDelta:   3,
-	}
+// New returns a new model with the given width and height as well as default
+// keymappings.
+func New(width, height int) (m Model) {
+	m.Width = width
+	m.Height = height
+	m.setInitialValues()
+	return m
 }
 
 // Model is the Bubble Tea model for this viewport element.
@@ -55,7 +52,15 @@ type Model struct {
 	// which is usually via the alternate screen buffer.
 	HighPerformanceRendering bool
 
-	lines []string
+	initialized bool
+	lines       []string
+}
+
+func (m *Model) setInitialValues() {
+	m.KeyMap = DefaultKeyMap()
+	m.MouseWheelEnabled = true
+	m.MouseWheelDelta = 3
+	m.initialized = true
 }
 
 // Init exists to satisfy the tea.Model interface for composability purposes.
@@ -263,6 +268,10 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 // Author's note: this method has been broken out to make it easier to
 // potentially transition Update to satisfy tea.Model.
 func (m Model) updateAsModel(msg tea.Msg) (Model, tea.Cmd) {
+	if !m.initialized {
+		m.setInitialValues()
+	}
+
 	var cmd tea.Cmd
 
 	switch msg := msg.(type) {

--- a/viewport/viewport.go
+++ b/viewport/viewport.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 )
 
 // NewModel returns a new model with the given width and height as well as
@@ -39,6 +40,10 @@ type Model struct {
 	// YPosition is the position of the viewport in relation to the terminal
 	// window. It's used in high performance rendering only.
 	YPosition int
+
+	// Style applies a lipgloss style to the viewport. Realistically, it's most
+	// useful for setting borders, margins and padding.
+	Style lipgloss.Style
 
 	// HighPerformanceRendering bypasses the normal Bubble Tea renderer to
 	// provide higher performance rendering. Most of the time the normal Bubble
@@ -340,7 +345,7 @@ func (m Model) View() string {
 		extraLines = strings.Repeat("\n", max(0, m.Height-len(lines)))
 	}
 
-	return strings.Join(lines, "\n") + extraLines
+	return m.Style.Render(strings.Join(lines, "\n") + extraLines)
 }
 
 // ETC


### PR DESCRIPTION
This update contains a number of improvements to the viewport Bubble to make it more pleasant to work with. Keep in mind that as of this update viewport models are strongly encouraged to be initialized with the new `New(width, height int) Model` function, however it's currently optional to reduce friction when upgrading.

```go
const width, height = 40, 80
vp := viewport.New(width, height)
```

* Viewport models now have a `Style lipgloss.Style` property for setting borders, margins, and padding. No more magic numbers, random constants, and awkward arithmetic!
* Keybindings are now defined via the [`key`](https://github.com/charmbracelet/bubbles#key) Bubble and can now be easily remapped.
* The mouse wheel-based scroll speed can now be customized via the model's `MouseWheelDelta int` property
* The mouse wheel can now be disabled via the model's `MouseWheelEnabled bool` property