### PR TITLE
Deprecate NewModel() constructors; use New() instead

### DIFF
--- a/help/help.go
+++ b/help/help.go
@@ -57,8 +57,8 @@ type Model struct {
 	Styles Styles
 }
 
-// NewModel creates a new help view with some useful defaults.
-func NewModel() Model {
+// New creates a new help view with some useful defaults.
+func New() Model {
 	keyStyle := lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{
 		Light: "#909090",
 		Dark:  "#626262",
@@ -89,6 +89,11 @@ func NewModel() Model {
 		},
 	}
 }
+
+// NewModel creates a new help view with some useful defaults.
+//
+// Deprecated. Use New instead.
+var NewModel = New
 
 // Update helps satisfy the Bubble Tea Model interface. It's a no-op.
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {

--- a/list/list.go
+++ b/list/list.go
@@ -149,8 +149,8 @@ type Model struct {
 	delegate ItemDelegate
 }
 
-// NewModel returns a new model with sensible defaults.
-func NewModel(items []Item, delegate ItemDelegate, width, height int) Model {
+// New returns a new model with sensible defaults.
+func New(items []Item, delegate ItemDelegate, width, height int) Model {
 	styles := DefaultStyles()
 
 	sp := spinner.NewModel()
@@ -195,6 +195,11 @@ func NewModel(items []Item, delegate ItemDelegate, width, height int) Model {
 	m.updateKeybindings()
 	return m
 }
+
+// NewModel returns a new model with sensible defaults.
+//
+// Deprecated. Use New instead.
+var NewModel = New
 
 // SetFilteringEnabled enables or disables filtering. Note that this is different
 // from ShowFilter, which merely hides or shows the input view.

--- a/paginator/paginator.go
+++ b/paginator/paginator.go
@@ -96,8 +96,8 @@ func (m Model) OnLastPage() bool {
 	return m.Page == m.TotalPages-1
 }
 
-// NewModel creates a new model with defaults.
-func NewModel() Model {
+// New creates a new model with defaults.
+func New() Model {
 	return Model{
 		Type:              Arabic,
 		Page:              0,
@@ -113,6 +113,11 @@ func NewModel() Model {
 		UseJKKeys:         false,
 	}
 }
+
+// NewModel creates a new model with defaults.
+//
+// Deprecated. Use New instead.
+var NewModel = New
 
 // Update is the Tea update function which binds keystrokes to pagination.
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -154,8 +154,8 @@ type Model struct {
 	scaleRamp bool
 }
 
-// NewModel returns a model with default values.
-func NewModel(opts ...Option) Model {
+// New returns a model with default values.
+func New(opts ...Option) Model {
 	m := Model{
 		id:             nextID(),
 		Width:          defaultWidth,
@@ -175,6 +175,11 @@ func NewModel(opts ...Option) Model {
 	}
 	return m
 }
+
+// NewModel returns a model with default values.
+//
+// Deprecated. Use New instead.
+var NewModel = New
 
 // Init exists satisfy the tea.Model interface.
 func (m Model) Init() tea.Cmd {

--- a/spinner/spinner.go
+++ b/spinner/spinner.go
@@ -193,13 +193,18 @@ func (m Model) Visible() bool {
 	return !m.hidden() && !m.finished()
 }
 
-// NewModel returns a model with default values.
-func NewModel() Model {
+// New returns a model with default values.
+func New() Model {
 	return Model{
 		Spinner: Line,
 		id:      nextID(),
 	}
 }
+
+// NewModel returns a model with default values.
+//
+// Deprecated. Use New instead.
+var NewModel = New
 
 // TickMsg indicates that the timer has ticked and we should render a frame.
 type TickMsg struct {

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -153,7 +153,7 @@ type Model struct {
 }
 
 // NewModel creates a new model with default settings.
-func NewModel() Model {
+func New() Model {
 	return Model{
 		Prompt:           "> ",
 		BlinkSpeed:       defaultBlinkSpeed,
@@ -173,6 +173,11 @@ func NewModel() Model {
 		},
 	}
 }
+
+// NewModel creates a new model with default settings.
+//
+// Deprecated. Use New instead.
+var NewModel = New
 
 // SetValue sets the value of the text input.
 func (m *Model) SetValue(s string) {


### PR DESCRIPTION
This update changes the `NewModel()` convention in all Bubbles to the to the shorter `New()` function, in-line with @caarlos0's excellent work on the new `timer` and `stopwatch` Bubbles.

```go
before := textinput.NewModel()
after := textinput.New()
```