### PR TITLE
Update keybindings after calling InsertItem on the list model

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -340,6 +340,7 @@ func (m *Model) InsertItem(index int, item Item) tea.Cmd {
 	}
 
 	m.updatePagination()
+	m.updateKeybindings()
 	return cmd
 }
 


### PR DESCRIPTION
Hot on the heels of #90, this update fixes a bug in the `list` Bubble where the up/down keybindings would be disabled and hidden in the help if `InsertItem` was called on an empty list.