### PR TITLE
Viewport bugfixes

### DIFF
--- a/viewport/viewport.go
+++ b/viewport/viewport.go
@@ -213,7 +213,7 @@ func (m *Model) GotoTop() (lines []string) {
 
 // GotoBottom sets the viewport to the bottom position.
 func (m *Model) GotoBottom() (lines []string) {
-	m.SetYOffset(len(m.lines) - 1 - m.Height)
+	m.SetYOffset(len(m.lines) - m.Height)
 	return m.visibleLines()
 }
 


### PR DESCRIPTION
These fixes address two `viewport` issues, most likely introduced in 0ac5ecd:

* Fix off-by-one errors with regard to `GotoBottom()`
* Fix a bug where the y-offset could be out of bounds 

Thanks to @IllusionMan1212 and @knipferrc for flagging the bugs and helping fix 'em.