### PR TITLE
Housekeeping

### DIFF
--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -412,7 +412,11 @@ func (m *Model) deleteWordLeft() bool {
 		return m.deleteBeforeCursor()
 	}
 
-	oldPos := m.pos
+	// Linter note: it's critical that we acquire the initial cursor position
+	// here prior to altering it via SetCursor() below. As such, moving this
+	// call into the corresponding if clause does not apply here.
+	oldPos := m.pos //nolint:ifshort
+
 	blink := m.setCursor(m.pos - 1)
 	for unicode.IsSpace(m.value[m.pos]) {
 		if m.pos <= 0 {
@@ -434,7 +438,11 @@ func (m *Model) deleteWordLeft() bool {
 		}
 	}
 
-	m.value = append(m.value[:m.pos], m.value[oldPos:]...)
+	if oldPos > len(m.value) {
+		m.value = m.value[:m.pos]
+	} else {
+		m.value = append(m.value[:m.pos], m.value[oldPos:]...)
+	}
 
 	return blink
 }

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -800,6 +800,9 @@ func Paste() tea.Msg {
 }
 
 func clamp(v, low, high int) int {
+	if high < low {
+		low, high = high, low
+	}
 	return min(high, max(low, v))
 }
 

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -459,7 +459,7 @@ func (m *Model) deleteWordRight() bool {
 		return m.deleteAfterCursor()
 	}
 
-	i := m.pos
+	oldPos := m.pos
 	m.setCursor(m.pos + 1)
 	for unicode.IsSpace(m.value[m.pos]) {
 		// ignore series of whitespace after cursor
@@ -479,12 +479,12 @@ func (m *Model) deleteWordRight() bool {
 	}
 
 	if m.pos > len(m.value) {
-		m.value = m.value[:i]
+		m.value = m.value[:oldPos]
 	} else {
-		m.value = append(m.value[:i], m.value[m.pos:]...)
+		m.value = append(m.value[:oldPos], m.value[m.pos:]...)
 	}
 
-	return m.setCursor(i)
+	return m.setCursor(oldPos)
 }
 
 // wordLeft moves the cursor one word to the left. Returns whether or not the

--- a/viewport/viewport.go
+++ b/viewport/viewport.go
@@ -358,7 +358,10 @@ func (m Model) View() string {
 		extraLines = strings.Repeat("\n", max(0, m.Height-len(lines)))
 	}
 
-	return m.Style.Render(strings.Join(lines, "\n") + extraLines)
+	return m.Style.Copy().
+		UnsetWidth().
+		UnsetHeight().
+		Render(strings.Join(lines, "\n") + extraLines)
 }
 
 func clamp(v, low, high int) int {


### PR DESCRIPTION
General tidying up. The notable thing here is that we now ignore width and height set on the `Style` member in a `viewport` model since it can convict with the `Width`and `Height` attributes on the model and result in odd rendering and general confusion. So something like this will no longer result in funny rendering:

```go
const width, height = 40, 80

m := viewport.New(width, height)
m.Style = lipgloss.NewStyle().
    Width(width).
    Height(height)
```

