### PR TITLE
list: fix to not show up quit in help while filtering

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -602,7 +602,7 @@ func (m *Model) updateKeybindings() {
 		m.KeyMap.ClearFilter.SetEnabled(false)
 		m.KeyMap.CancelWhileFiltering.SetEnabled(true)
 		m.KeyMap.AcceptWhileFiltering.SetEnabled(m.FilterInput.Value() != "")
-		m.KeyMap.Quit.SetEnabled(true)
+		m.KeyMap.Quit.SetEnabled(false)
 		m.KeyMap.ShowFullHelp.SetEnabled(false)
 		m.KeyMap.CloseFullHelp.SetEnabled(false)
 


### PR DESCRIPTION
It’s correct that can't `quit` by pressing q when filtering, so it seems better to not show `q` in the help while filtering.