### PR TITLE
Add note to viewport that width/height are a no-op

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ indenting and text wrapping.
 
 ### Note:
 
-The bubble no longer applies a specific height or width setting because of possible rendering issues. (See https://github.com/charmbracelet/bubbles/commit/7ecce3fb97420ba2a44e3453c9291a98d5894d9d)
+The bubble no longer applies a specific height or width setting because of possible rendering issues. (See [the commit in question](https://github.com/charmbracelet/bubbles/commit/7ecce3fb97420ba2a44e3453c9291a98d5894d9d))
 
 ## List
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ indenting and text wrapping.
 
 [reflow]: https://github.com/muesli/reflow
 
+### Note:
+
+The bubble no longer applies a specific height or width setting because of possible rendering issues. (See 7ecce3fb97420ba2a44e3453c9291a98d5894d9d)
 
 ## List
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ indenting and text wrapping.
 
 ### Note:
 
-The bubble no longer applies a specific height or width setting because of possible rendering issues. (See 7ecce3fb97420ba2a44e3453c9291a98d5894d9d)
+The bubble no longer applies a specific height or width setting because of possible rendering issues. (See https://github.com/charmbracelet/bubbles/commit/7ecce3fb97420ba2a44e3453c9291a98d5894d9d)
 
 ## List
 


### PR DESCRIPTION
Because I just spent a few hours debugging why I was not able to set the width of the viewport I propose a note in the documentation to prevent similar confusion in the future. :woozy_face: