### PR TITLE
Add Blink method to textinput to return blink state

### DIFF
--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -203,6 +203,11 @@ func (m Model) Cursor() int {
 	return m.pos
 }
 
+// Blink returns whether or not to draw the cursor.
+func (m Model) Blink() bool {
+	return m.blink
+}
+
 // SetCursor moves the cursor to the given position. If the position is
 // out of bounds the cursor will be moved to the start or end accordingly.
 func (m *Model) SetCursor(pos int) {


### PR DESCRIPTION
As discussed on Slack earlier, this PR adds a `Blink()` method that returns the text input's blink state. This is useful if you want to render something more complex than the existing `View()` method can handle. For context, I'm implementing an input with multiple types of placeholders, each with different styles. I thought about adding something to the text input itself to handle this case, but it would add a lot of complexity for a rather niche use case. With the `blink` property exposed, users can implement their own `View()` method.