### PR TITLE
Add AppendContent

### DIFF
--- a/viewport/viewport.go
+++ b/viewport/viewport.go
@@ -100,8 +100,14 @@ func (m Model) ScrollPercent() float64 {
 // SetContent set the pager's text content. For high performance rendering the
 // Sync command should also be called.
 func (m *Model) SetContent(s string) {
+	m.lines = nil
+	m.AppendContent(s)
+}
+
+// AppendContent append a string to the pager's text content. For high performance rendering the Sync command should also be called.
+func (m *Model) AppendContent(s string) {
 	s = strings.ReplaceAll(s, "\r\n", "\n") // normalize line endings
-	m.lines = strings.Split(s, "\n")
+	m.lines = append(m.lines, strings.Split(s, "\n")...)
 
 	if m.YOffset > len(m.lines)-1 {
 		m.GotoBottom()

--- a/viewport/viewport.go
+++ b/viewport/viewport.go
@@ -243,7 +243,7 @@ func Sync(m Model) tea.Cmd {
 }
 
 // ViewDown is a high performance command that moves the viewport up by a given
-// numer of lines. Use Model.ViewDown to get the lines that should be rendered.
+// number of lines. Use Model.ViewDown to get the lines that should be rendered.
 // For example:
 //
 //     lines := model.ViewDown(1)
@@ -350,7 +350,7 @@ func (m Model) updateAsModel(msg tea.Msg) (Model, tea.Cmd) {
 func (m Model) View() string {
 	if m.HighPerformanceRendering {
 		// Just send newlines since we're going to be rendering the actual
-		// content seprately. We still need to send something that equals the
+		// content separately. We still need to send something that equals the
 		// height of this view so that the Bubble Tea standard renderer can
 		// position anything below this view properly.
 		return strings.Repeat("\n", m.Height-1)


### PR DESCRIPTION
I wanted the ability to append content to the viewport without maintaining content externally and resetting the content every time the content changed.

What I ended up doing was taking the SetContent logic and changing it up so that we don't replace the internal model string slice, but instead append to it. This implies having the string split up into lines  first and then appended to the model. This method still respects YOffset and moves to the bottom if the offset is greater than the number of lines.

SetContent now functions by setting m.lines to nil, and then calling AppendContent.