### PR TITLE
Fix timer Stop

### DIFF
--- a/timer/timer.go
+++ b/timer/timer.go
@@ -162,9 +162,7 @@ func (m *Model) Start() tea.Cmd {
 
 // Stop pauses the timer. Has no effect if the timer has timed out.
 func (m *Model) Stop() tea.Cmd {
-	return func() tea.Msg {
-		return m.startStop(false)
-	}
+	return m.startStop(false)
 }
 
 // Toggle stops the timer if it's running and starts it if it's stopped.


### PR DESCRIPTION
I don't know the details, but when I used Stop function on timer it doesn't stop the timer, but it worked fine if I use Toggle() function instead on a running Timer.

Looking at the code this sounds as it should be this way, but I don't know if I'm doing something wrong os this piece of code should be fixed.