### PR TITLE
New spinner with option

### DIFF
--- a/spinner/spinner.go
+++ b/spinner/spinner.go
@@ -198,41 +198,14 @@ func Tick() tea.Msg {
 //
 type Option func(*Model)
 
-// WithSpinner sets the spinner
+// WithSpinner is an option to set the spinner.
 func WithSpinner(spinner Spinner) Option {
 	return func(m *Model) {
 		m.Spinner = spinner
 	}
 }
 
-// WithLine sets a Line spinner
-func WithLine() Option { return WithSpinner(Line) }
-
-// WithDot sets a Dot spinner
-func WithDot() Option { return WithSpinner(Dot) }
-
-// WithMiniDot sets a MiniDot spinner
-func WithMiniDot() Option { return WithSpinner(MiniDot) }
-
-// WithJump sets a Jump spinner
-func WithJump() Option { return WithSpinner(Jump) }
-
-// WithPulse sets a Pulse spinner
-func WithPulse() Option { return WithSpinner(Pulse) }
-
-// WithPoints sets a Points spinner
-func WithPoints() Option { return WithSpinner(Points) }
-
-// WithGlobe sets a Globe spinner
-func WithGlobe() Option { return WithSpinner(Globe) }
-
-// WithMoon sets a Moon spinner
-func WithMoon() Option { return WithSpinner(Moon) }
-
-// WithMonkey sets a Monkey spinner
-func WithMonkey() Option { return WithSpinner(Monkey) }
-
-// WithStyle sets the Model style
+// WithStyle is an option to set the spinner style.
 func WithStyle(style lipgloss.Style) Option {
 	return func(m *Model) {
 		m.Style = style

--- a/spinner/spinner.go
+++ b/spinner/spinner.go
@@ -231,3 +231,10 @@ func WithMoon() Option { return WithSpinner(Moon) }
 
 // WithMonkey sets a Monkey spinner
 func WithMonkey() Option { return WithSpinner(Monkey) }
+
+// WithStyle sets the Model style
+func WithStyle(style lipgloss.Style) Option {
+	return func(m *Model) {
+		m.Style = style
+	}
+}

--- a/spinner/spinner.go
+++ b/spinner/spinner.go
@@ -185,3 +185,16 @@ func (m Model) tick(id, tag int) tea.Cmd {
 func Tick() tea.Msg {
 	return TickMsg{Time: time.Now()}
 }
+
+// Option is used to set options in New. For example:
+//
+//    spinner := New(WithSpinner(Dot))
+//
+type Option func(*Model)
+
+// WithSpinner sets the spinner
+func WithSpinner(spinner Spinner) Option {
+	return func(m *Model) {
+		m.Spinner = spinner
+	}
+}

--- a/spinner/spinner.go
+++ b/spinner/spinner.go
@@ -204,3 +204,30 @@ func WithSpinner(spinner Spinner) Option {
 		m.Spinner = spinner
 	}
 }
+
+// WithLine sets a Line spinner
+func WithLine() Option { return WithSpinner(Line) }
+
+// WithDot sets a Dot spinner
+func WithDot() Option { return WithSpinner(Dot) }
+
+// WithMiniDot sets a MiniDot spinner
+func WithMiniDot() Option { return WithSpinner(MiniDot) }
+
+// WithJump sets a Jump spinner
+func WithJump() Option { return WithSpinner(Jump) }
+
+// WithPulse sets a Pulse spinner
+func WithPulse() Option { return WithSpinner(Pulse) }
+
+// WithPoints sets a Points spinner
+func WithPoints() Option { return WithSpinner(Points) }
+
+// WithGlobe sets a Globe spinner
+func WithGlobe() Option { return WithSpinner(Globe) }
+
+// WithMoon sets a Moon spinner
+func WithMoon() Option { return WithSpinner(Moon) }
+
+// WithMonkey sets a Monkey spinner
+func WithMonkey() Option { return WithSpinner(Monkey) }

--- a/spinner/spinner.go
+++ b/spinner/spinner.go
@@ -93,11 +93,17 @@ func (m Model) ID() int {
 }
 
 // New returns a model with default values.
-func New() Model {
-	return Model{
+func New(opts ...Option) Model {
+	m := Model{
 		Spinner: Line,
 		id:      nextID(),
 	}
+
+	for _, opt := range opts {
+		opt(&m)
+	}
+
+	return m
 }
 
 // NewModel returns a model with default values.

--- a/spinner/spinner_test.go
+++ b/spinner/spinner_test.go
@@ -1,0 +1,29 @@
+package spinner_test
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/bubbles/spinner"
+)
+
+func TestSpinnerNew(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		s := spinner.New()
+
+		exp, got := spinner.Line, s.Spinner
+
+		if exp.FPS != got.FPS {
+			t.Errorf("expecting %d FPS, got %d", exp.FPS, got.FPS)
+		}
+
+		if e, g := len(exp.Frames), len(got.Frames); e != g {
+			t.Fatalf("expecting %d frames, got %d", e, g)
+		}
+
+		for i, e := range exp.Frames {
+			if g := got.Frames[i]; e != g {
+				t.Errorf("expecting frame index %d with value %q, got %q", i, e, g)
+			}
+		}
+	})
+}

--- a/spinner/spinner_test.go
+++ b/spinner/spinner_test.go
@@ -7,10 +7,8 @@ import (
 )
 
 func TestSpinnerNew(t *testing.T) {
-	t.Run("default", func(t *testing.T) {
-		s := spinner.New()
-
-		exp, got := spinner.Line, s.Spinner
+	assertEqualSpinner := func(t *testing.T, exp, got spinner.Spinner) {
+		t.Helper()
 
 		if exp.FPS != got.FPS {
 			t.Errorf("expecting %d FPS, got %d", exp.FPS, got.FPS)
@@ -25,5 +23,16 @@ func TestSpinnerNew(t *testing.T) {
 				t.Errorf("expecting frame index %d with value %q, got %q", i, e, g)
 			}
 		}
+	}
+	t.Run("default", func(t *testing.T) {
+		s := spinner.New()
+
+		assertEqualSpinner(t, spinner.Line, s.Spinner)
+	})
+
+	t.Run("with spinner", func(t *testing.T) {
+		s := spinner.New(spinner.WithSpinner(spinner.Dot))
+
+		assertEqualSpinner(t, spinner.Dot, s.Spinner)
 	})
 }

--- a/spinner/spinner_test.go
+++ b/spinner/spinner_test.go
@@ -41,26 +41,21 @@ func TestSpinnerNew(t *testing.T) {
 		assertEqualSpinner(t, customSpinner, s.Spinner)
 	})
 
-	tests := map[string]struct {
-		option func() spinner.Option
-		exp    spinner.Spinner
-	}{
-		"WithLine":    {spinner.WithLine, spinner.Line},
-		"WithDot":     {spinner.WithDot, spinner.Dot},
-		"WithMiniDot": {spinner.WithMiniDot, spinner.MiniDot},
-		"WithJump":    {spinner.WithJump, spinner.Jump},
-		"WithPulse":   {spinner.WithPulse, spinner.Pulse},
-		"WithPoints":  {spinner.WithPoints, spinner.Points},
-		"WithGlobe":   {spinner.WithGlobe, spinner.Globe},
-		"WithMoon":    {spinner.WithMoon, spinner.Moon},
-		"WithMonkey":  {spinner.WithMonkey, spinner.Monkey},
+	tests := map[string]spinner.Spinner{
+		"Line":    spinner.Line,
+		"Dot":     spinner.Dot,
+		"MiniDot": spinner.MiniDot,
+		"Jump":    spinner.Jump,
+		"Pulse":   spinner.Pulse,
+		"Points":  spinner.Points,
+		"Globe":   spinner.Globe,
+		"Moon":    spinner.Moon,
+		"Monkey":  spinner.Monkey,
 	}
 
-	for name, tt := range tests {
+	for name, s := range tests {
 		t.Run(name, func(t *testing.T) {
-			s := spinner.New(tt.option())
-
-			assertEqualSpinner(t, tt.exp, s.Spinner)
+			assertEqualSpinner(t, spinner.New(spinner.WithSpinner(s)).Spinner, s)
 		})
 	}
 }

--- a/spinner/spinner_test.go
+++ b/spinner/spinner_test.go
@@ -30,10 +30,15 @@ func TestSpinnerNew(t *testing.T) {
 		assertEqualSpinner(t, spinner.Line, s.Spinner)
 	})
 
-	t.Run("with spinner", func(t *testing.T) {
-		s := spinner.New(spinner.WithSpinner(spinner.Dot))
+	t.Run("WithSpinner", func(t *testing.T) {
+		customSpinner := spinner.Spinner{
+			Frames: []string{"a", "b", "c", "d"},
+			FPS:    16,
+		}
 
-		assertEqualSpinner(t, spinner.Dot, s.Spinner)
+		s := spinner.New(spinner.WithSpinner(customSpinner))
+
+		assertEqualSpinner(t, customSpinner, s.Spinner)
 	})
 
 	tests := map[string]struct {

--- a/spinner/spinner_test.go
+++ b/spinner/spinner_test.go
@@ -35,4 +35,27 @@ func TestSpinnerNew(t *testing.T) {
 
 		assertEqualSpinner(t, spinner.Dot, s.Spinner)
 	})
+
+	tests := map[string]struct {
+		option func() spinner.Option
+		exp    spinner.Spinner
+	}{
+		"WithLine":    {spinner.WithLine, spinner.Line},
+		"WithDot":     {spinner.WithDot, spinner.Dot},
+		"WithMiniDot": {spinner.WithMiniDot, spinner.MiniDot},
+		"WithJump":    {spinner.WithJump, spinner.Jump},
+		"WithPulse":   {spinner.WithPulse, spinner.Pulse},
+		"WithPoints":  {spinner.WithPoints, spinner.Points},
+		"WithGlobe":   {spinner.WithGlobe, spinner.Globe},
+		"WithMoon":    {spinner.WithMoon, spinner.Moon},
+		"WithMonkey":  {spinner.WithMonkey, spinner.Monkey},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			s := spinner.New(tt.option())
+
+			assertEqualSpinner(t, tt.exp, s.Spinner)
+		})
+	}
 }


### PR DESCRIPTION
This PR introduces a `spinner.Option` type that allows passing configuration options when creating new spinners using `spinner.New`. This doesn't break existing code as it uses variadic arguments, so any existing code as the following should continue to work:

```go
s := spinner.New()
s.spinner = spinner.Dot
```

This code now can be written as:

```go
s := spinner.New(spinner.WithSpinner(spinner.Dot))
```

In order not to be overly verbose, a `With` function was defined for each of the pre-existing spinners, so one can have for instance:

```go
s := spinner.New(spinner.withPulse())
```

Last but not least it also adds a `WithStyle(lipgloss.Style)` option function.

This is mostly syntactic sugar, but helps when you have a custom model and want to create it:

```go
func New() MyModel {
    return MyModel{
        spinner: spinner.New(spinner.WithDot(), spinner.WithStyle(myStyle)),
    }
}
```

Without these functions the call above has to be written as:

```go
func New() MyModel {
    m := MyModel{
        spinner: spinner.New(),
    }
    m.spinner.Spinner = spinner.Dot
    m.spinner.Style = myStyle

    return m
}
```