### PR TITLE
Feature: Multi-line Text Input

### DIFF
--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -451,7 +451,6 @@ func (m *Model) canHandleMoreInput(length int) bool {
 // not the cursor blink should be reset.
 func (m *Model) deleteBeforeCursor() bool {
 	m.value[m.row] = m.value[m.row][m.col:]
-	m.offset = 0
 	return m.setCursor(0)
 }
 
@@ -665,6 +664,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	}
 
 	var resetBlink bool
+	var cmds []tea.Cmd
 
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
@@ -918,15 +918,17 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		m.Err = msg
 	}
 
-	vp, vpcmd := m.Viewport.Update(msg)
+	vp, cmd := m.Viewport.Update(msg)
 	m.Viewport = &vp
+	cmds = append(cmds, cmd)
 
 	m.handleOverflow()
 
 	if resetBlink {
-		return m, tea.Batch(m.blinkCmd(), vpcmd)
+		m.blink = false
+		cmds = append(cmds, m.blinkCmd())
 	}
-	return m, vpcmd
+	return m, tea.Batch(cmds...)
 }
 
 // View renders the textinput in its current state.

--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -158,11 +158,6 @@ type Model struct {
 	// Cursor row.
 	row int
 
-	// Used to emulate a viewport when width is set and the content is
-	// overflowing.
-	offset      int
-	offsetRight int
-
 	// Used to manage cursor blink
 	blinkCtx *blinkCtx
 

--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -1,4 +1,4 @@
-package textinput
+package textarea
 
 import (
 	"context"
@@ -8,6 +8,7 @@ import (
 	"unicode"
 
 	"github.com/atotto/clipboard"
+	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	rw "github.com/mattn/go-runewidth"
@@ -111,8 +112,9 @@ type Model struct {
 	BackgroundStyle  lipgloss.Style
 	PlaceholderStyle lipgloss.Style
 	CursorStyle      lipgloss.Style
+	CursorLineStyle  lipgloss.Style
 
-	// CharLimit is the maximum amount of characters this input element will
+	// CharLimit is the maximum number of characters this input element will
 	// accept. If 0 or less, there's no limit.
 	CharLimit int
 
@@ -121,6 +123,15 @@ type Model struct {
 	// viewport. If 0 or less this setting is ignored.
 	Width int
 
+	// LineLimit is the maximum number of lines this input element will accept.
+	// If 0 or less, there's no limit.
+	LineLimit int
+
+	// Height is the maximum number of lines that can be displayed at once.
+	// It essentially treats the text field like a vertically scrolling viewport
+	// if there are more lines that permitted height.
+	Height int
+
 	// The ID of this Model as it relates to other textinput Models.
 	id int
 
@@ -128,7 +139,7 @@ type Model struct {
 	blinkTag int
 
 	// Underlying text value.
-	value []rune
+	value [][]rune
 
 	// focus indicates whether user input focus should be on this input
 	// component. When false, ignore keyboard input and hide the cursor.
@@ -137,8 +148,11 @@ type Model struct {
 	// Cursor blink state.
 	blink bool
 
-	// Cursor position.
-	pos int
+	// Cursor column.
+	col int
+
+	// Cursor row.
+	row int
 
 	// Used to emulate a viewport when width is set and the content is
 	// overflowing.
@@ -150,27 +164,39 @@ type Model struct {
 
 	// cursorMode determines the behavior of the cursor
 	cursorMode CursorMode
+
+	// Viewport is the vertically-scrollable Viewport of the multi-line text
+	// input.
+	Viewport *viewport.Model
 }
 
 // NewModel creates a new model with default settings.
 func New() Model {
+	vp := viewport.New(0, 0)
+	vp.KeyMap = viewport.KeyMap{}
+
 	return Model{
-		Prompt:           "> ",
+		Prompt:           "│ ",
 		BlinkSpeed:       defaultBlinkSpeed,
 		EchoCharacter:    '*',
 		CharLimit:        0,
 		PlaceholderStyle: lipgloss.NewStyle().Foreground(lipgloss.Color("240")),
+		LineLimit:        1,
+		Height:           1,
 
 		id:         nextID(),
 		value:      nil,
 		focus:      false,
 		blink:      true,
-		pos:        0,
+		col:        0,
+		row:        0,
 		cursorMode: CursorBlink,
 
 		blinkCtx: &blinkCtx{
 			ctx: context.Background(),
 		},
+
+		Viewport: &vp,
 	}
 }
 
@@ -183,24 +209,43 @@ var NewModel = New
 func (m *Model) SetValue(s string) {
 	runes := []rune(s)
 	if m.CharLimit > 0 && len(runes) > m.CharLimit {
-		m.value = runes[:m.CharLimit]
+		m.value[m.row] = runes[:m.CharLimit]
 	} else {
-		m.value = runes
+		m.value[m.row] = runes
 	}
-	if m.pos == 0 || m.pos > len(m.value) {
-		m.setCursor(len(m.value))
+	if m.col == 0 || m.col > len(m.value[m.row]) {
+		m.setCursor(len(m.value[m.row]))
 	}
 	m.handleOverflow()
 }
 
 // Value returns the value of the text input.
 func (m Model) Value() string {
-	return string(m.value)
+	var v string
+	for _, l := range m.value {
+		v += string(l)
+		v += "\n"
+	}
+	return strings.TrimSpace(v)
 }
 
-// Cursor returns the cursor position.
+// Length returns the number of characters currently in the text input.
+func (m *Model) Length() int {
+	var l int
+	for _, row := range m.value {
+		l += rw.StringWidth(string(row))
+	}
+	return l
+}
+
+// Cursor returns the cursor row.
 func (m Model) Cursor() int {
-	return m.pos
+	return m.col
+}
+
+// Cursor returns the line position.
+func (m Model) Line() int {
+	return m.row
 }
 
 // Blink returns whether or not to draw the cursor.
@@ -210,15 +255,15 @@ func (m Model) Blink() bool {
 
 // SetCursor moves the cursor to the given position. If the position is
 // out of bounds the cursor will be moved to the start or end accordingly.
-func (m *Model) SetCursor(pos int) {
-	m.setCursor(pos)
+func (m *Model) SetCursor(col int) {
+	m.setCursor(col)
 }
 
 // setCursor moves the cursor to the given position and returns whether or not
 // the cursor blink should be reset. If the position is out of bounds the
 // cursor will be moved to the start or end accordingly.
-func (m *Model) setCursor(pos int) bool {
-	m.pos = clamp(pos, 0, len(m.value))
+func (m *Model) setCursor(col int) bool {
+	m.col = clamp(col, 0, len(m.value[m.row]))
 	m.handleOverflow()
 
 	// Show the cursor unless it's been explicitly hidden
@@ -265,7 +310,7 @@ func (m *Model) SetCursorMode(mode CursorMode) tea.Cmd {
 // cursorEnd moves the cursor to the end of the input field and returns whether
 // the cursor should blink should reset.
 func (m *Model) cursorEnd() bool {
-	return m.setCursor(len(m.value))
+	return m.setCursor(len(m.value[m.row]))
 }
 
 // Focused returns the focus state on the model.
@@ -295,7 +340,10 @@ func (m *Model) Blur() {
 // Reset sets the input to its default state with no input. Returns whether
 // or not the cursor blink should reset.
 func (m *Model) Reset() bool {
-	m.value = nil
+	m.value = make([][]rune, m.LineLimit)
+	m.col = 0
+	m.row = 0
+	m.Viewport.GotoTop()
 	return m.setCursor(0)
 }
 
@@ -306,7 +354,7 @@ func (m *Model) handlePaste(v string) bool {
 
 	var availSpace int
 	if m.CharLimit > 0 {
-		availSpace = m.CharLimit - len(m.value)
+		availSpace = m.CharLimit - m.Length()
 	}
 
 	// If the char limit's been reached cancel
@@ -321,15 +369,15 @@ func (m *Model) handlePaste(v string) bool {
 	}
 
 	// Stuff before and after the cursor
-	head := m.value[:m.pos]
-	tailSrc := m.value[m.pos:]
+	head := m.value[m.row][:m.col]
+	tailSrc := m.value[m.row][m.col:]
 	tail := make([]rune, len(tailSrc))
 	copy(tail, tailSrc)
 
 	// Insert pasted runes
 	for _, r := range paste {
 		head = append(head, r)
-		m.pos++
+		m.col++
 		if m.CharLimit > 0 {
 			availSpace--
 			if availSpace <= 0 {
@@ -338,62 +386,65 @@ func (m *Model) handlePaste(v string) bool {
 		}
 	}
 
-	// Put it all back together
-	m.value = append(head, tail...)
-
 	// Reset blink state if necessary and run overflow checks
-	return m.setCursor(m.pos)
+	m.handleColumnBoundaries()
+	resetBlink := m.setCursor(m.col + len(paste))
+	return resetBlink
 }
 
-// If a max width is defined, perform some logic to treat the visible area
-// as a horizontally scrolling viewport.
+// If input is multi-line, the input can scroll vertically,
+// otherwise, scroll horizontally.
 func (m *Model) handleOverflow() {
-	if m.Width <= 0 || rw.StringWidth(string(m.value)) <= m.Width {
-		m.offset = 0
-		m.offsetRight = len(m.value)
-		return
-	}
-
-	// Correct right offset if we've deleted characters
-	m.offsetRight = min(m.offsetRight, len(m.value))
-
-	if m.pos < m.offset {
-		m.offset = m.pos
-
-		w := 0
-		i := 0
-		runes := m.value[m.offset:]
-
-		for i < len(runes) && w <= m.Width {
-			w += rw.RuneWidth(runes[i])
-			if w <= m.Width+1 {
-				i++
-			}
+	for i := 0; i < len(m.value)-1; i++ {
+		l := m.value[i]
+		if rw.StringWidth(string(l)) < m.Width {
+			// The line is less than the maximum width, so let's move on to the
+			// next line.
+			continue
 		}
 
-		m.offsetRight = m.offset + i
-	} else if m.pos >= m.offsetRight {
-		m.offsetRight = m.pos
-
+		// The line is too long, so let's wrap it
+		// Before we do this, we need to find the character that will act as
+		// the break point. Since we may have multi-width characters this will
+		// not always align with the m.value[row][width-1]
 		w := 0
-		runes := m.value[:m.offsetRight]
-		i := len(runes) - 1
-
-		for i > 0 && w < m.Width {
-			w += rw.RuneWidth(runes[i])
-			if w <= m.Width {
-				i--
+		for j := 0; j < len(l); j++ {
+			w += rw.RuneWidth(l[j])
+			if w >= m.Width {
+				overflow := l[j:]
+				m.value[i] = l[:j]
+				m.value[i+1] = concat(overflow, m.value[i+1])
+				break
 			}
 		}
-
-		m.offset = m.offsetRight - (len(runes) - 1 - i)
 	}
+}
+
+// canHandleMoreInput returns whether or not the input can handle `length` more
+// characters of input being added.
+func (m *Model) canHandleMoreInput(length int) bool {
+	if m.CharLimit >= 0 && m.Length() >= m.CharLimit {
+		return false
+	}
+
+	// Depending on where we are in the multi-line input, we may not be able to insert
+	// more characters as they may overflow the input area when wrapping, i.e. may go over the LineLimit.
+	// In this case, let's just make sure we can handle the input.
+
+	// We'll need to count the number of characters remaining and the characters we've already inserted
+	// starting from the cursor.
+	spaceRemaining := ((m.LineLimit - m.row) * (m.Width - 1)) + 1
+	spaceUsed := 0
+	for i := m.row; i < m.LineLimit; i++ {
+		spaceUsed += rw.StringWidth(string(m.value[i]))
+	}
+	return spaceUsed+length < spaceRemaining
 }
 
 // deleteBeforeCursor deletes all text before the cursor. Returns whether or
 // not the cursor blink should be reset.
 func (m *Model) deleteBeforeCursor() bool {
-	m.value = m.value[m.pos:]
+	m.value[m.row] = m.value[m.row][m.col:]
 	m.offset = 0
 	return m.setCursor(0)
 }
@@ -402,14 +453,14 @@ func (m *Model) deleteBeforeCursor() bool {
 // the cursor blink should be reset. If input is masked delete everything after
 // the cursor so as not to reveal word breaks in the masked input.
 func (m *Model) deleteAfterCursor() bool {
-	m.value = m.value[:m.pos]
-	return m.setCursor(len(m.value))
+	m.value[m.row] = m.value[m.row][:m.col]
+	return m.setCursor(len(m.value[m.row]))
 }
 
 // deleteWordLeft deletes the word left to the cursor. Returns whether or not
 // the cursor blink should be reset.
 func (m *Model) deleteWordLeft() bool {
-	if m.pos == 0 || len(m.value) == 0 {
+	if m.col == 0 || len(m.value[m.row]) == 0 {
 		return false
 	}
 
@@ -420,33 +471,33 @@ func (m *Model) deleteWordLeft() bool {
 	// Linter note: it's critical that we acquire the initial cursor position
 	// here prior to altering it via SetCursor() below. As such, moving this
 	// call into the corresponding if clause does not apply here.
-	oldPos := m.pos //nolint:ifshort
+	oldCol := m.col //nolint:ifshort
 
-	blink := m.setCursor(m.pos - 1)
-	for unicode.IsSpace(m.value[m.pos]) {
-		if m.pos <= 0 {
+	blink := m.setCursor(m.col - 1)
+	for unicode.IsSpace(m.value[m.row][m.col]) {
+		if m.col <= 0 {
 			break
 		}
 		// ignore series of whitespace before cursor
-		blink = m.setCursor(m.pos - 1)
+		blink = m.setCursor(m.col - 1)
 	}
 
-	for m.pos > 0 {
-		if !unicode.IsSpace(m.value[m.pos]) {
-			blink = m.setCursor(m.pos - 1)
+	for m.col > 0 {
+		if !unicode.IsSpace(m.value[m.row][m.col]) {
+			blink = m.setCursor(m.col - 1)
 		} else {
-			if m.pos > 0 {
+			if m.col > 0 {
 				// keep the previous space
-				blink = m.setCursor(m.pos + 1)
+				blink = m.setCursor(m.col + 1)
 			}
 			break
 		}
 	}
 
-	if oldPos > len(m.value) {
-		m.value = m.value[:m.pos]
+	if oldCol > len(m.value[m.row]) {
+		m.value[m.row] = m.value[m.row][:m.col]
 	} else {
-		m.value = append(m.value[:m.pos], m.value[oldPos:]...)
+		m.value[m.row] = append(m.value[m.row][:m.col], m.value[m.row][oldCol:]...)
 	}
 
 	return blink
@@ -456,7 +507,7 @@ func (m *Model) deleteWordLeft() bool {
 // the cursor blink should be reset. If input is masked delete everything after
 // the cursor so as not to reveal word breaks in the masked input.
 func (m *Model) deleteWordRight() bool {
-	if m.pos >= len(m.value) || len(m.value) == 0 {
+	if m.col >= len(m.value[m.row]) || len(m.value[m.row]) == 0 {
 		return false
 	}
 
@@ -464,39 +515,39 @@ func (m *Model) deleteWordRight() bool {
 		return m.deleteAfterCursor()
 	}
 
-	oldPos := m.pos
-	m.setCursor(m.pos + 1)
-	for unicode.IsSpace(m.value[m.pos]) {
+	oldCol := m.col
+	m.setCursor(m.col + 1)
+	for unicode.IsSpace(m.value[m.row][m.col]) {
 		// ignore series of whitespace after cursor
-		m.setCursor(m.pos + 1)
+		m.setCursor(m.col + 1)
 
-		if m.pos >= len(m.value) {
+		if m.col >= len(m.value[m.row]) {
 			break
 		}
 	}
 
-	for m.pos < len(m.value) {
-		if !unicode.IsSpace(m.value[m.pos]) {
-			m.setCursor(m.pos + 1)
+	for m.col < len(m.value[m.row]) {
+		if !unicode.IsSpace(m.value[m.row][m.col]) {
+			m.setCursor(m.col + 1)
 		} else {
 			break
 		}
 	}
 
-	if m.pos > len(m.value) {
-		m.value = m.value[:oldPos]
+	if m.col > len(m.value[m.row]) {
+		m.value[m.row] = m.value[m.row][:oldCol]
 	} else {
-		m.value = append(m.value[:oldPos], m.value[m.pos:]...)
+		m.value[m.row] = append(m.value[m.row][:oldCol], m.value[m.row][m.col:]...)
 	}
 
-	return m.setCursor(oldPos)
+	return m.setCursor(oldCol)
 }
 
 // wordLeft moves the cursor one word to the left. Returns whether or not the
 // cursor blink should be reset. If input is masked, move input to the start
 // so as not to reveal word breaks in the masked input.
 func (m *Model) wordLeft() bool {
-	if m.pos == 0 || len(m.value) == 0 {
+	if m.col == 0 || len(m.value[m.row]) == 0 {
 		return false
 	}
 
@@ -505,10 +556,10 @@ func (m *Model) wordLeft() bool {
 	}
 
 	blink := false
-	i := m.pos - 1
+	i := m.col - 1
 	for i >= 0 {
-		if unicode.IsSpace(m.value[i]) {
-			blink = m.setCursor(m.pos - 1)
+		if unicode.IsSpace(m.value[m.row][min(i, len(m.value[m.row])-1)]) {
+			blink = m.setCursor(m.col - 1)
 			i--
 		} else {
 			break
@@ -516,8 +567,8 @@ func (m *Model) wordLeft() bool {
 	}
 
 	for i >= 0 {
-		if !unicode.IsSpace(m.value[i]) {
-			blink = m.setCursor(m.pos - 1)
+		if !unicode.IsSpace(m.value[m.row][min(i, len(m.value[m.row])-1)]) {
+			blink = m.setCursor(m.col - 1)
 			i--
 		} else {
 			break
@@ -531,7 +582,7 @@ func (m *Model) wordLeft() bool {
 // cursor blink should be reset. If the input is masked, move input to the end
 // so as not to reveal word breaks in the masked input.
 func (m *Model) wordRight() bool {
-	if m.pos >= len(m.value) || len(m.value) == 0 {
+	if m.col >= len(m.value[m.row]) || len(m.value[m.row]) == 0 {
 		return false
 	}
 
@@ -540,19 +591,19 @@ func (m *Model) wordRight() bool {
 	}
 
 	blink := false
-	i := m.pos
-	for i < len(m.value) {
-		if unicode.IsSpace(m.value[i]) {
-			blink = m.setCursor(m.pos + 1)
+	i := m.col
+	for i < len(m.value[m.row]) {
+		if unicode.IsSpace(m.value[m.row][i]) {
+			blink = m.setCursor(m.col + 1)
 			i++
 		} else {
 			break
 		}
 	}
 
-	for i < len(m.value) {
-		if !unicode.IsSpace(m.value[i]) {
-			blink = m.setCursor(m.pos + 1)
+	for i < len(m.value[m.row]) {
+		if !unicode.IsSpace(m.value[m.row][i]) {
+			blink = m.setCursor(m.col + 1)
 			i++
 		} else {
 			break
@@ -560,6 +611,20 @@ func (m *Model) wordRight() bool {
 	}
 
 	return blink
+}
+
+func (m *Model) lineDown() {
+	if m.row < m.LineLimit-1 {
+		m.row++
+	}
+	m.Viewport.SetYOffset(m.row - m.Height/2)
+}
+
+func (m *Model) lineUp() {
+	if m.row > 0 {
+		m.row--
+	}
+	m.Viewport.SetYOffset(m.row - m.Height/2)
 }
 
 func (m Model) echoTransform(v string) string {
@@ -581,54 +646,151 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		return m, nil
 	}
 
+	if m.value == nil {
+		m.value = make([][]rune, m.LineLimit)
+		m.Viewport.Height = m.Height
+		m.Viewport.Width = m.Width
+	}
+
 	var resetBlink bool
 
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.Type {
 		case tea.KeyBackspace: // delete character before cursor
+			m.handleColumnBoundaries()
+
 			if msg.Alt {
 				resetBlink = m.deleteWordLeft()
 			} else {
-				if len(m.value) > 0 {
-					m.value = append(m.value[:max(0, m.pos-1)], m.value[m.pos:]...)
-					if m.pos > 0 {
-						resetBlink = m.setCursor(m.pos - 1)
+				// In a multi-line input, if the cursor is at the start of a
+				// line, and backspace is pressed move the cursor to the end of
+				// the previous line and bring the previous line up.
+				if m.col == 0 && m.row > 0 {
+					rowIsEmpty := len(m.value[m.row]) == 0
+
+					m.lineUp()
+					m.cursorEnd()
+
+					// If the current line is full we won't have space to shift
+					// all the other lines up, so simply do nothing.
+					if !rowIsEmpty && len(m.value[m.row]) >= m.Width {
+						break
+					}
+
+					m.value[m.row] = append(m.value[m.row], m.value[m.row+1]...)
+
+					// Shift all the lines up by one.
+					for i := m.row + 1; i < m.LineLimit-1; i++ {
+						m.value[i] = m.value[i+1]
+					}
+					// Clear the last line
+					m.value[m.LineLimit-1] = nil
+					break
+				}
+
+				if len(m.value[m.row]) > 0 {
+					m.value[m.row] = append(m.value[m.row][:max(0, m.col-1)], m.value[m.row][m.col:]...)
+					if m.col > 0 {
+						resetBlink = m.setCursor(m.col - 1)
 					}
 				}
 			}
+
+		case tea.KeyUp:
+			resetBlink = true
+			m.lineUp()
+		case tea.KeyDown:
+			resetBlink = true
+			m.lineDown()
+		case tea.KeyEnter:
+			m.handleColumnBoundaries()
+
+			lastRow := m.row
+			m.lineDown()
+			currentRow := m.row
+
+			// On a multi-line input, we will need to shift the lines after the
+			// cursor line down by one since a new line was inserted.
+			if m.LineLimit <= 1 {
+				break
+			}
+
+			// First, let's ensure that there is enough space to insert a new line.
+			// We can do this by ensuring that the last line is empty.
+			if len(m.value[m.LineLimit-1]) > 0 {
+				break
+			}
+
+			// Shift all rows after the current row down by one.
+			for i := m.LineLimit - 1; i > currentRow; i-- {
+				m.value[i] = make([]rune, len(m.value[i-1]))
+				copy(m.value[i], m.value[i-1])
+			}
+
+			// Split the current line into two lines.
+			s1, s2 := m.value[lastRow][:m.col], m.value[lastRow][m.col:]
+			m.value[lastRow], m.value[currentRow] = make([]rune, len(s1)), make([]rune, len(s2))
+			copy(m.value[lastRow], s1)
+			copy(m.value[currentRow], s2)
+
+			// Reset column only if we've actually changed rows
+			if lastRow != currentRow {
+				m.col = 0
+			}
+
 		case tea.KeyLeft, tea.KeyCtrlB:
 			if msg.Alt { // alt+left arrow, back one word
 				resetBlink = m.wordLeft()
 				break
 			}
-			if m.pos > 0 { // left arrow, ^F, back one character
-				resetBlink = m.setCursor(m.pos - 1)
+			if m.col == 0 && m.row != 0 {
+				m.lineUp()
+				m.cursorEnd()
+				m.col++
+			}
+			if m.col > 0 { // left arrow, ^F, back one character
+				resetBlink = m.setCursor(m.col - 1)
 			}
 		case tea.KeyRight, tea.KeyCtrlF:
 			if msg.Alt { // alt+right arrow, forward one word
 				resetBlink = m.wordRight()
 				break
 			}
-			if m.pos < len(m.value) { // right arrow, ^F, forward one character
-				resetBlink = m.setCursor(m.pos + 1)
+			if m.col >= len(m.value[m.row]) && m.row != m.LineLimit-1 {
+				m.lineDown()
+				m.cursorStart()
+				m.col--
+			}
+			if m.col < len(m.value[m.row]) { // right arrow, ^F, forward one character
+				resetBlink = m.setCursor(m.col + 1)
 			}
 		case tea.KeyCtrlW: // ^W, delete word left of cursor
+			m.handleColumnBoundaries()
 			resetBlink = m.deleteWordLeft()
 		case tea.KeyHome, tea.KeyCtrlA: // ^A, go to beginning
 			resetBlink = m.cursorStart()
 		case tea.KeyDelete, tea.KeyCtrlD: // ^D, delete char under cursor
-			if len(m.value) > 0 && m.pos < len(m.value) {
-				m.value = append(m.value[:m.pos], m.value[m.pos+1:]...)
+			m.handleColumnBoundaries()
+			if len(m.value[m.row]) > 0 && m.col < len(m.value[m.row]) {
+				m.value[m.row] = append(m.value[m.row][:m.col], m.value[m.row][m.col+1:]...)
 			}
 		case tea.KeyCtrlE, tea.KeyEnd: // ^E, go to end
 			resetBlink = m.cursorEnd()
 		case tea.KeyCtrlK: // ^K, kill text after cursor
+			m.handleColumnBoundaries()
 			resetBlink = m.deleteAfterCursor()
 		case tea.KeyCtrlU: // ^U, kill text before cursor
+			m.handleColumnBoundaries()
 			resetBlink = m.deleteBeforeCursor()
 		case tea.KeyCtrlV: // ^V paste
 			return m, Paste
+		case tea.KeyCtrlN: // ^N next line
+			m.lineDown()
+			resetBlink = true
+		case tea.KeyCtrlP: // ^P previous line
+			m.lineUp()
+			resetBlink = true
 		case tea.KeyRunes, tea.KeySpace: // input regular characters
 			if msg.Alt && len(msg.Runes) == 1 {
 				if msg.Runes[0] == 'd' { // alt+d, delete word right of cursor
@@ -645,10 +807,45 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 				}
 			}
 
+			m.handleColumnBoundaries()
+
+			// We can't allow the user to input if we are already at the maximum width and height.
+			lw := rw.StringWidth(string(m.value[m.row]))
+			msgw := rw.StringWidth(string(msg.Runes))
+			if m.row >= m.LineLimit-1 && lw+msgw >= m.Width {
+				break
+			}
+
+			// If the cursor is at the end of the line let's move the cursor to
+			// the next line
+			if rw.StringWidth(string(m.value[m.row][:m.col])) >= m.Width-1 {
+				m.lineDown()
+				m.cursorStart()
+			}
+
+			if len(msg.Runes) > 1 {
+				// We are possibly pasting in multiple characters. If this
+				// paste contains a new line it can break the input, so strip
+				// newlines away.
+				for i, r := range msg.Runes {
+					if r == '\n' || r == '\r' {
+						msg.Runes[i] = ' '
+					}
+				}
+			}
+
 			// Input a regular character
-			if m.CharLimit <= 0 || len(m.value) < m.CharLimit {
-				m.value = append(m.value[:m.pos], append(msg.Runes, m.value[m.pos:]...)...)
-				resetBlink = m.setCursor(m.pos + len(msg.Runes))
+			if m.canHandleMoreInput(msgw) {
+				m.value[m.row] = append(m.value[m.row][:m.col], append(msg.Runes, m.value[m.row][m.col:]...)...)
+				resetBlink = m.setCursor(m.col + msgw)
+
+				if m.col > m.Width && m.row <= m.LineLimit-1 {
+					newLines := m.col / m.Width
+					m.row += newLines
+					m.col = (m.col % m.Width) + newLines
+					// Re-center the viewport
+					m.Viewport.SetYOffset(m.row - m.Height/2)
+				}
 			}
 		}
 
@@ -693,47 +890,60 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		m.Err = msg
 	}
 
-	var cmd tea.Cmd
-	if resetBlink {
-		cmd = m.blinkCmd()
-	}
+	vp, vpCmd := m.Viewport.Update(msg)
+	m.Viewport = &vp
 
 	m.handleOverflow()
-	return m, cmd
+
+	if resetBlink {
+		return m, tea.Batch(vpCmd, m.blinkCmd())
+	}
+
+	return m, vpCmd
 }
 
 // View renders the textinput in its current state.
 func (m Model) View() string {
 	// Placeholder text
-	if len(m.value) == 0 && m.Placeholder != "" {
+	if m.Value() == "" && m.row == 0 && m.Placeholder != "" {
 		return m.placeholderView()
 	}
 
-	styleText := m.TextStyle.Inline(true).Render
+	var (
+		str             string
+		styleText       = m.TextStyle.Inline(true).Render
+		styleCursorLine = m.CursorLineStyle.Render
+	)
 
-	value := m.value[m.offset:m.offsetRight]
-	pos := max(0, m.pos-m.offset)
-	v := styleText(m.echoTransform(string(value[:pos])))
+	// Display the value for all it's height
+	for i := 0; i < m.LineLimit; i++ {
+		var v string
+		value := m.value[i]
 
-	if pos < len(value) {
-		v += m.cursorView(m.echoTransform(string(value[pos]))) // cursor and text under it
-		v += styleText(m.echoTransform(string(value[pos+1:]))) // text after cursor
-	} else {
-		v += m.cursorView(" ")
-	}
+		// We're at the cursor line now, so display the cursor
+		if i == m.row {
+			col := min(max(0, m.col), len(value))
+			v = styleCursorLine(m.echoTransform(string(value[:col])))
+			padding := m.Width - rw.StringWidth(string(value))
+			if m.col < len(value) {
+				v += styleCursorLine(m.cursorView(m.echoTransform(string(value[m.col])))) // cursor and text under it
+				v += styleCursorLine(m.echoTransform(string(value[m.col+1:])))            // text after cursor
+			} else {
+				v += styleCursorLine(m.cursorView(" "))
+				padding--
+			}
 
-	// If a max width and background color were set fill the empty spaces with
-	// the background color.
-	valWidth := rw.StringWidth(string(value))
-	if m.Width > 0 && valWidth <= m.Width {
-		padding := max(0, m.Width-valWidth)
-		if valWidth+padding <= m.Width && pos < len(value) {
-			padding++
+			// Add padding to fill out the rest of the background
+			v += styleCursorLine(strings.Repeat(" ", padding))
+		} else {
+			v = styleText(m.echoTransform(string(value)))
 		}
-		v += styleText(strings.Repeat(" ", padding))
+
+		str += m.PromptStyle.Render(m.Prompt) + v + "\n"
 	}
 
-	return m.PromptStyle.Render(m.Prompt) + v
+	m.Viewport.SetContent(str)
+	return m.Viewport.View()
 }
 
 // placeholderView returns the prompt and placeholder view, if any.
@@ -754,7 +964,14 @@ func (m Model) placeholderView() string {
 	// The rest of the placeholder text
 	v += style(p[1:])
 
-	return m.PromptStyle.Render(m.Prompt) + v
+	// The rest of the new lines
+	v += strings.Repeat("\n"+m.PromptStyle.Render(m.Prompt), m.LineLimit)
+	v = strings.TrimSuffix(v, "\n"+m.PromptStyle.Render(m.Prompt))
+
+	prompt := m.PromptStyle.Render(m.Prompt)
+
+	m.Viewport.SetContent(prompt + v)
+	return m.Viewport.View()
 }
 
 // cursorView styles the cursor.
@@ -790,6 +1007,18 @@ func (m *Model) blinkCmd() tea.Cmd {
 	}
 }
 
+func (m *Model) handleColumnBoundaries() {
+	// While the user is traversing a multi-line input, the cursor may be past
+	// the end of the line. This is not an issue until the user makes a change,
+	// in which case we will want to adjust the cursor so that it is within the
+	// bounds of the line.
+	//
+	// We don't want to adjust the cursor if the user is only moving the cursor
+	// as it may be disorienting if the user goes from a long line to a short
+	// line and then back to a long line, otherwise.
+	m.col = clamp(m.col, 0, len(m.value[m.row]))
+}
+
 // Blink is a command used to initialize cursor blinking.
 func Blink() tea.Msg {
 	return initialBlinkMsg{}
@@ -823,4 +1052,9 @@ func max(a, b int) int {
 		return a
 	}
 	return b
+}
+
+func concat(first []rune, second []rune) []rune {
+	n := len(first)
+	return append(first[:n:n], second...)
 }

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -174,7 +174,7 @@ func New() Model {
 		PlaceholderStyle: lipgloss.NewStyle().Foreground(lipgloss.Color("240")),
 
 		id:         nextID(),
-		value:      make([][]rune, 100),
+		value:      nil,
 		focus:      false,
 		blink:      true,
 		col:        0,
@@ -674,6 +674,10 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	if !m.focus {
 		m.blink = true
 		return m, nil
+	}
+
+	if m.value == nil {
+		m.value = make([][]rune, max(m.LineLimit, m.Height)+1)
 	}
 
 	var resetBlink bool

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -691,8 +691,16 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 				// line, and backspace is pressed move the cursor to the end of
 				// the previous line and bring the previous line up.
 				if m.col == 0 && m.row > 0 {
+					rowIsEmpty := len(m.value[m.row]) == 0
+
 					m.lineUp()
 					m.cursorEnd()
+
+					// If the current line is full we won't have space to shift
+					// all the other lines up, so simply do nothing.
+					if !rowIsEmpty && len(m.value[m.row]) >= m.Width {
+						break
+					}
 
 					m.value[m.row] = append(m.value[m.row], m.value[m.row+1]...)
 
@@ -718,7 +726,6 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			resetBlink = true
 			m.lineDown()
 		case tea.KeyEnter:
-			resetBlink = true
 			lastRow := m.row
 			m.lineDown()
 			currentRow := m.row

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -491,7 +491,7 @@ func (m *Model) canHandleMoreInput(length int) bool {
 
 	// We'll need to count the number of characters remaining and the characters we've already inserted
 	// starting from the cursor.
-	spaceRemaining := ((m.LineLimit - m.row) * m.Width)
+	spaceRemaining := ((m.LineLimit - m.row) * (m.Width - 1)) + 1
 	spaceUsed := 0
 	for i := m.row; i < m.LineLimit; i++ {
 		spaceUsed += rw.StringWidth(string(m.value[i]))
@@ -874,7 +874,8 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 				break
 			}
 
-			// If the cursor is at the end of the line let's move the cursor to the next line
+			// If the cursor is at the end of the line let's move the cursor to
+			// the next line
 			if m.isMultiLineInput() && rw.StringWidth(string(m.value[m.row][:m.col])) >= m.Width-1 {
 				m.lineDown()
 				m.cursorStart()

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -647,13 +647,13 @@ func (m *Model) wordRight() bool {
 
 func (m *Model) lineDown() {
 	if m.row < m.LineLimit-1 {
-		m.row += 1
+		m.row++
 	}
 }
 
 func (m *Model) lineUp() {
 	if m.row > 0 {
-		m.row -= 1
+		m.row--
 	}
 }
 

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -339,7 +339,10 @@ func (m *Model) Blur() {
 // Reset sets the input to its default state with no input. Returns whether
 // or not the cursor blink should reset.
 func (m *Model) Reset() bool {
-	m.value = nil
+	m.value = make([][]rune, m.LineLimit)
+	m.col = 0
+	m.row = 0
+	m.Viewport.GotoTop()
 	return m.setCursor(0)
 }
 

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -690,7 +690,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 	if m.value == nil {
 		m.value = make([][]rune, m.LineLimit)
-		m.Viewport.Height = m.Height + 1
+		m.Viewport.Height = m.Height
 		m.Viewport.Width = m.Width
 	}
 
@@ -721,9 +721,11 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 					m.value[m.row] = append(m.value[m.row], m.value[m.row+1]...)
 
 					// Shift all the lines up by one.
-					for i := m.row + 1; i < m.LineLimit; i++ {
+					for i := m.row + 1; i < m.LineLimit-1; i++ {
 						m.value[i] = m.value[i+1]
 					}
+					// Clear the last line
+					m.value[m.LineLimit-1] = nil
 					break
 				}
 

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -112,7 +112,7 @@ type Model struct {
 	PlaceholderStyle lipgloss.Style
 	CursorStyle      lipgloss.Style
 
-	// CharLimit is the maximum amount of characters this input element will
+	// CharLimit is the maximum number of characters this input element will
 	// accept. If 0 or less, there's no limit.
 	CharLimit int
 
@@ -120,6 +120,15 @@ type Model struct {
 	// It essentially treats the text field like a horizontally scrolling
 	// viewport. If 0 or less this setting is ignored.
 	Width int
+
+	// LineLimit is the maximum number of lines this input element will accept.
+	// If 0 or less, there's no limit.
+	LineLimit int
+
+	// Height is the maximum number of lines that can be displayed at once.
+	// It essentially treats the text field like a vertically scrolling viewport
+	// if there are more lines that permitted height.
+	Height int
 
 	// The ID of this Model as it relates to other textinput Models.
 	id int

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -424,6 +424,7 @@ func (m *Model) handleHorizontalOverflow() {
 }
 
 func (m *Model) handleVerticalOverflow() {
+
 }
 
 // deleteBeforeCursor deletes all text before the cursor. Returns whether or
@@ -663,7 +664,9 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			m.lineDown()
 		case tea.KeyEnter:
 			resetBlink = true
-			m.col = 0
+			if m.row != m.LineLimit-1 {
+				m.col = 0
+			}
 			m.lineDown()
 		case tea.KeyLeft, tea.KeyCtrlB:
 			if msg.Alt { // alt+left arrow, back one word

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -664,10 +664,14 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			m.lineDown()
 		case tea.KeyEnter:
 			resetBlink = true
-			if m.row != m.LineLimit-1 {
+			lastRow := m.row
+			m.lineDown()
+			currentRow := m.row
+
+			// Reset column only if we've actually changed rows
+			if lastRow != currentRow {
 				m.col = 0
 			}
-			m.lineDown()
 		case tea.KeyLeft, tea.KeyCtrlB:
 			if msg.Alt { // alt+left arrow, back one word
 				resetBlink = m.wordLeft()

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -476,7 +476,7 @@ func (m *Model) canHandleMoreInput() bool {
 // deleteBeforeCursor deletes all text before the cursor. Returns whether or
 // not the cursor blink should be reset.
 func (m *Model) deleteBeforeCursor() bool {
-	m.value = m.value[m.col:]
+	m.value[m.row] = m.value[m.row][m.col:]
 	m.offset = 0
 	return m.setCursor(0)
 }
@@ -485,7 +485,7 @@ func (m *Model) deleteBeforeCursor() bool {
 // the cursor blink should be reset. If input is masked delete everything after
 // the cursor so as not to reveal word breaks in the masked input.
 func (m *Model) deleteAfterCursor() bool {
-	m.value = m.value[:m.col]
+	m.value[m.row] = m.value[m.row][:m.col]
 	return m.setCursor(len(m.value[m.row]))
 }
 

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -472,8 +472,8 @@ func (m *Model) handleVerticalOverflow() {
 	}
 }
 
-// canHandleMoreInput returns whether or not the input can handle n more
-// characters of input.
+// canHandleMoreInput returns whether or not the input can handle `length` more
+// characters of input being added.
 func (m *Model) canHandleMoreInput(length int) bool {
 	// Single line input
 	if m.isSingleLineInput() {
@@ -491,12 +491,12 @@ func (m *Model) canHandleMoreInput(length int) bool {
 
 	// We'll need to count the number of characters remaining and the characters we've already inserted
 	// starting from the cursor.
-	totalSpaceRemaining := ((m.LineLimit - m.row) * m.Width)
+	spaceRemaining := ((m.LineLimit - m.row) * m.Width)
 	spaceUsed := 0
 	for i := m.row; i < m.LineLimit; i++ {
 		spaceUsed += rw.StringWidth(string(m.value[i]))
 	}
-	return spaceUsed < (totalSpaceRemaining - length)
+	return spaceUsed+length < spaceRemaining
 }
 
 // deleteBeforeCursor deletes all text before the cursor. Returns whether or
@@ -896,7 +896,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 				m.value[m.row] = append(m.value[m.row][:m.col], append(msg.Runes, m.value[m.row][m.col:]...)...)
 				resetBlink = m.setCursor(m.col + msgw)
 
-				if m.isMultiLineInput() && m.col > m.Width {
+				if m.isMultiLineInput() && m.col > m.Width && m.row <= m.LineLimit-1 {
 					newLines := m.col / m.Width
 					m.row += newLines
 					m.col = (m.col % m.Width) + newLines

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -441,9 +441,10 @@ func (m *Model) handleVerticalOverflow() {
 		}
 	}
 
-	if m.col >= m.Width && m.row != m.LineLimit-1 {
+	if m.col > m.Width && m.row != m.LineLimit-1 {
 		m.lineDown()
 		m.cursorStart()
+		m.col++
 	}
 }
 
@@ -691,7 +692,8 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 				// the previous line and bring the previous line up.
 				if m.col == 0 {
 					m.lineUp()
-					m.col = len(m.value[m.row])
+					m.cursorEnd()
+					break
 				}
 
 				if len(m.value[m.row]) > 0 {
@@ -725,10 +727,18 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			if m.col > 0 { // left arrow, ^F, back one character
 				resetBlink = m.setCursor(m.col - 1)
 			}
+			if m.col == 0 {
+				m.lineUp()
+				m.cursorEnd()
+			}
 		case tea.KeyRight, tea.KeyCtrlF:
 			if msg.Alt { // alt+right arrow, forward one word
 				resetBlink = m.wordRight()
 				break
+			}
+			if m.col >= len(m.value[m.row]) {
+				m.lineDown()
+				m.cursorStart()
 			}
 			if m.col < len(m.value[m.row]) { // right arrow, ^F, forward one character
 				resetBlink = m.setCursor(m.col + 1)

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -727,7 +727,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			if m.col > 0 { // left arrow, ^F, back one character
 				resetBlink = m.setCursor(m.col - 1)
 			}
-			if m.col == 0 {
+			if m.Height > 1 && m.col == 0 && m.row != 0 {
 				m.lineUp()
 				m.cursorEnd()
 			}
@@ -736,7 +736,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 				resetBlink = m.wordRight()
 				break
 			}
-			if m.col >= len(m.value[m.row]) {
+			if m.Height > 1 && m.col >= len(m.value[m.row]) && m.row != m.LineLimit-1 {
 				m.lineDown()
 				m.cursorStart()
 			}


### PR DESCRIPTION
Fixes #63 

<img width="777" alt="multiline-textinput" src="https://user-images.githubusercontent.com/42545625/171744365-cf058356-6322-4526-9321-03ad633bcb92.png">

Allows the `textinput` bubble to be used as a multi-line text input by specifying `Height` and `LineLimit` as properties on the bubble model.

### API Changes

* Adds `Height` property which specifies the display height of the multi-line text input.
* Adds `LineLimit` property which specifies the maximum number of lines the text input can handle.

> Note: in the current state of the `Height` and `LineLimit` should be equal (there is no vertical scrolling currently)

### Internal Logic Changes
* `value` is now a 2D array of runes (`[][]rune`) to account for multi-line input.
* `pos` is now `row` and `col` to account for multi-line input.
* `View` is now separated into `singleLineView` and `multilineView`
