### PR TITLE
docs(spinner): correct comment about internal ID

### DIFF
--- a/spinner/spinner.go
+++ b/spinner/spinner.go
@@ -8,8 +8,8 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-// Internal ID management for text inputs. Necessary for blink integrity when
-// multiple text inputs are involved.
+// Internal ID management. Used during animating to assure that frame messages
+// can only be received by spinner components that sent them.
 var (
 	lastID int
 	idMtx  sync.Mutex

--- a/spinner/spinner.go
+++ b/spinner/spinner.go
@@ -8,8 +8,8 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-// Internal ID management. Used during animating to assure that frame messages
-// can only be received by spinner components that sent them.
+// Internal ID management. Used during animating to ensure that frame messages
+// are received only by spinner components that sent them.
 var (
 	lastID int
 	idMtx  sync.Mutex


### PR DESCRIPTION
It appears that spinner's Internal ID comment was accidentally left the same as [textinput's comment](https://github.com/charmbracelet/bubbles/blob/e57fd292cc688c315659ae180eded043369452ac/textinput/textinput.go#L18-L19).

This new comment is taken from [progress.go](https://github.com/charmbracelet/bubbles/blob/e57fd292cc688c315659ae180eded043369452ac/progress/progress.go#L18-L19).