### PR TITLE
fix(textinput): set cursor on initial value

### DIFF
--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -205,7 +205,7 @@ func (m *Model) SetValue(s string) {
 	} else {
 		m.value = runes
 	}
-	if (m.pos == 0 && len(m.value) == 0) || m.pos > len(m.value) {
+	if m.pos == 0 || m.pos > len(m.value) {
 		m.setCursor(len(m.value))
 	}
 	m.handleOverflow()


### PR DESCRIPTION
This reverts the code back to the logic from 4ce16e8 which fixed the issue of the cursor not being moved when an initial value was set with SetValue.

The fix regressed in 16053f4.