### PR TITLE
Unbound keys should not be enabled

### DIFF
--- a/key/key.go
+++ b/key/key.go
@@ -106,7 +106,7 @@ func (b Binding) Help() Help {
 // keybindings won't be activated and won't show up in help. Keybindings are
 // enabled by default.
 func (b Binding) Enabled() bool {
-	return !b.disabled
+	return !b.disabled || b.keys == nil
 }
 
 // SetEnabled enables or disables the keybinding.


### PR DESCRIPTION
[Unbind()](https://pkg.go.dev/github.com/charmbracelet/bubbles@v0.13.0/key#Binding.Unbind)'ed keys are not usable anymore, so it should not be counted as Enabled. For example, unbound keys should not show up in help.
