### PR TITLE
Added code to make table widths dynamic and flexible as per the viewport size

### DIFF
--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -611,7 +611,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.Type {
-		case tea.KeyBackspace: // delete character before cursor
+		case tea.KeyBackspace, tea.KeyCtrlH: // delete character before cursor
 			m.Err = nil
 
 			if msg.Alt {


### PR DESCRIPTION
**WIP**
Added code to make table widths dynamic and flexible as per the viewport size

In my example code below, you can see I also set some of the row content to be a different color. This has led to the 'selected' highlight style 'not working'.

Ideally I think it would be better to optionally assign a row a specific style which has its own on selected style. 

I also think my dynamic sizing code is very 'meh'.  
I look for really large columns which would want more space... 
Then go through columns and seeing if we can pinch space off smaller columns to give extra to the bigger demanding columns. 
Seems to work pretty good, theres some magic numbers in there to help width border widths etc. 

https://user-images.githubusercontent.com/87901949/180672319-026e18ba-5a3c-4a0e-b8ad-5c5562615187.mov


