### PR TITLE
fix: CharLimit <= 0 should be ignored

### DIFF
--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -797,7 +797,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		case key.Matches(msg, m.KeyMap.WordBackward):
 			m.wordLeft()
 		default:
-			if rw.StringWidth(m.Value()) >= m.CharLimit {
+			if m.CharLimit > 0 && rw.StringWidth(m.Value()) >= m.CharLimit {
 				break
 			}
 


### PR DESCRIPTION
`CharLimit` documentation states:

```
	// CharLimit is the maximum number of characters this input element will
	// accept. If 0 or less, there's no limit.
```

However, when `CharLimit` is `0` it does not allow any input.