### PR TITLE
Feat(list): enable filtering programmatically

### DIFF
--- a/list/list_test.go
+++ b/list/list_test.go
@@ -72,3 +72,13 @@ func TestCustomStatusBarItemName(t *testing.T) {
 		t.Fatalf("Error: expected view to contain %s", expected)
 	}
 }
+
+func TestSetFilterValue(t *testing.T) {
+	list := New([]Item{item("foo")}, itemDelegate{}, 10, 10)
+	list.SetFilterValue("hello")
+
+	expected := "hello"
+	if !strings.EqualFold(list.FilterValue(), expected) {
+		t.Fatalf("Error: expected filter value to be %s", expected)
+	}
+}


### PR DESCRIPTION
Hey! This PR aims to address #85. The names for the method I've added are coming from #129. 

- set filter value programmatically
- enable filtering programmatically. Apply filter if needed

https://user-images.githubusercontent.com/5574267/183026053-8169a28c-b862-467b-bdf6-d538769148df.mov


Below is the code used in the video. I tried to keep it as simple as possible
```go
package main

import (
	"github.com/charmbracelet/bubbles/list"
	tea "github.com/charmbracelet/bubbletea"
)

type item struct {
	title string
}

func (i item) Title() string       { return i.title }
func (i item) Description() string { return i.title }
func (i item) FilterValue() string { return i.title }

type Model struct {
	list list.Model
}

func New() Model {
	items := []list.Item{
		item{title: "red"},
		item{title: "blue"},
		item{title: "orange"},
		item{title: "purple"},
		item{title: "green"},
		item{title: "magenta"},
	}
	l := list.New(items, list.NewDefaultDelegate(), 100, 100)

	// uncomment to set default filter value
	// l.SetFilterValue("purple")

	return Model{
		list: l,
	}
}

func (m Model) Init() tea.Cmd {
	// used to enable filtering programmatically
	return list.EnableLiveFiltering
}

func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
	var (
		cmd  tea.Cmd
		cmds []tea.Cmd
	)

	switch msg := msg.(type) {
	case tea.WindowSizeMsg:
		m.list.SetSize(msg.Width, msg.Height)
	}

	m.list, cmd = m.list.Update(msg)
	cmds = append(cmds, cmd)

	return m, tea.Batch(cmds...)
}

func (m Model) View() string {
	return m.list.View()
}

```

I did not implement a way to disable the filter programmatically as I believe this can already be done using `ResetFilter`.

I've also tested my implementation with a custom input by setting `l.SetShowFilter(false)`.
