### PR TITLE
textarea: fix the pre-allocation of value

### DIFF
--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -193,7 +193,7 @@ func New() Model {
 		Cursor:               cur,
 		KeyMap:               DefaultKeyMap,
 
-		value:            make([][]rune, minHeight, maxWidth),
+		value:            make([][]rune, minHeight, maxHeight),
 		focus:            false,
 		col:              0,
 		row:              0,
@@ -409,7 +409,7 @@ func (m *Model) Blur() {
 
 // Reset sets the input to its default state with no input.
 func (m *Model) Reset() {
-	m.value = make([][]rune, minHeight, maxWidth)
+	m.value = make([][]rune, minHeight, maxHeight)
 	m.col = 0
 	m.row = 0
 	m.viewport.GotoTop()


### PR DESCRIPTION
The maximum slice size of m.value is the max number of rows,
which is the max height.

cc @maaslalani 