### PR TITLE
fix(viewport): properly truncate to size

### DIFF
--- a/viewport/viewport.go
+++ b/viewport/viewport.go
@@ -349,10 +349,11 @@ func (m Model) View() string {
 		// position anything below this view properly.
 		return strings.Repeat("\n", max(0, m.Height-1))
 	}
-
+	contentWidth := m.Width - m.Style.GetHorizontalFrameSize()
+	contentHeight := m.Height - m.Style.GetVerticalFrameSize()
 	return m.Style.Copy().
-		Width(m.Width - m.Style.GetHorizontalFrameSize()).
-		Height(m.Height - m.Style.GetVerticalFrameSize()).
+		UnsetWidth().MaxWidth(contentWidth).            // truncate long lines.
+		Height(contentHeight).MaxHeight(contentHeight). // pad to height then truncate.
 		Render(strings.Join(m.visibleLines(), "\n"))
 }
 


### PR DESCRIPTION
Fixes #227 

- logical content is wider than display width (long lines).
  In this case, we truncate.
- logical content is smaller than display height (fewer lines
  than visible).
  In this case, we pad with empty lines up to the specified height.
- logical content is higher than display height (more lines than
  visible).
  In this case, we truncate.

- style specifies a width wider than the display width.
  In this case, we ignore the style width and
  fit in the display width.
- style specifies a height higher than the display height.
  Same as width, we ignore the style and fit in the display height.
- style specifies a narrower width or smaller height than the display.
  In this case we obey the style.

cc @meowgorithm 