### PR TITLE
chore: Miscellaneous minor fixes

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -183,18 +183,18 @@ type Model struct {
 func New(items []Item, delegate ItemDelegate, width, height int) Model {
 	styles := DefaultStyles()
 
-	sp := spinner.NewModel()
+	sp := spinner.New()
 	sp.Spinner = spinner.Line
 	sp.Style = styles.Spinner
 
-	filterInput := textinput.NewModel()
+	filterInput := textinput.New()
 	filterInput.Prompt = "Filter: "
 	filterInput.PromptStyle = styles.FilterPrompt
 	filterInput.CursorStyle = styles.FilterCursor
 	filterInput.CharLimit = 64
 	filterInput.Focus()
 
-	p := paginator.NewModel()
+	p := paginator.New()
 	p.Type = paginator.Dots
 	p.ActiveDot = styles.ActivePaginationDot.String()
 	p.InactiveDot = styles.InactivePaginationDot.String()
@@ -221,7 +221,7 @@ func New(items []Item, delegate ItemDelegate, width, height int) Model {
 		items:     items,
 		Paginator: p,
 		spinner:   sp,
-		Help:      help.NewModel(),
+		Help:      help.New(),
 	}
 
 	m.updatePagination()

--- a/list/list.go
+++ b/list/list.go
@@ -526,7 +526,7 @@ func (m Model) FilterValue() string {
 // SettingFilter returns whether or not the user is currently editing the
 // filter value. It's purely a convenience method for the following:
 //
-//     m.FilterState() == Filtering
+//	m.FilterState() == Filtering
 //
 // It's included here because it's a common thing to check for when
 // implementing this component.
@@ -537,8 +537,7 @@ func (m Model) SettingFilter() bool {
 // IsFiltered returns whether or not the list is currently filtered.
 // It's purely a convenience method for the following:
 //
-//	 m.FilterState() == FilterApplied
-//
+//	m.FilterState() == FilterApplied
 func (m Model) IsFiltered() bool {
 	return m.filterState == FilterApplied
 }

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -37,13 +37,12 @@ const (
 	defaultDamping   = 1.0
 )
 
-// Option is used to set options in NewModel. For example:
+// Option is used to set options in New. For example:
 //
-//     progress := NewModel(
-//	       WithRamp("#ff0000", "#0000ff"),
-//	       WithoutPercentage(),
-//     )
-//
+//	    progress := New(
+//		       WithRamp("#ff0000", "#0000ff"),
+//		       WithoutPercentage(),
+//	    )
 type Option func(*Model)
 
 // WithDefaultGradient sets a gradient fill with default colors.

--- a/spinner/spinner.go
+++ b/spinner/spinner.go
@@ -208,8 +208,7 @@ func Tick() tea.Msg {
 
 // Option is used to set options in New. For example:
 //
-//    spinner := New(WithSpinner(Dot))
-//
+//	spinner := New(WithSpinner(Dot))
 type Option func(*Model)
 
 // WithSpinner is an option to set the spinner.

--- a/spinner/spinner.go
+++ b/spinner/spinner.go
@@ -85,7 +85,7 @@ var (
 	}
 )
 
-// Model contains the state for the spinner. Use NewModel to create new models
+// Model contains the state for the spinner. Use New to create new models
 // rather than using Model as a struct literal.
 type Model struct {
 	// Spinner settings to use. See type Spinner.

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -169,7 +169,7 @@ func (m Model) Focused() bool {
 }
 
 // Focus sets the focus state on the model. When the model is in focus it can
-// receive keyboard input and the cursor will be hidden.
+// receive keyboard input and the cursor will be shown.
 func (m *Model) Focus() tea.Cmd {
 	m.focus = true
 	return m.Cursor.Focus()


### PR DESCRIPTION
* Remove internal use of deprecated `NewModel` functions.
* Fix description of `textinput.Model.Focus`.
* Format comments with `go fmt`.