### PR TITLE
fix: textarea paste

### DIFF
--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -494,6 +494,10 @@ func (m *Model) handlePaste(v string) {
 		}
 	}
 
+	// Put it all back together
+	value := append(head, tail...)
+	m.SetValue(string(value))
+
 	// Reset blink state if necessary and run overflow checks
 	m.SetCursor(m.col + len(paste))
 }


### PR DESCRIPTION
while trying to put together a program using this bubble, i discovered that the paste function seems to be incomplete (at least, compared to the ``textinput`` paste function), in that it doesn't apply changes to ``textarea.value``.

i just copied the associated code from ``textinput`` to actually apply the changes, it's nothing special.