### PR TITLE
key: optimize `Matches`

### DIFF
--- a/key/key_test.go
+++ b/key/key_test.go
@@ -2,6 +2,8 @@ package key
 
 import (
 	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 func TestBinding_Enabled(t *testing.T) {
@@ -23,4 +25,20 @@ func TestBinding_Enabled(t *testing.T) {
 	if binding.Enabled() {
 		t.Errorf("expected key not to be Enabled")
 	}
+}
+
+func BenchmarkMatches(b *testing.B) {
+	msg1 := tea.KeyMsg(tea.Key{Type: tea.KeyRunes, Runes: []rune("c"), Alt: true})
+	msg2 := tea.KeyMsg(tea.Key{Type: tea.KeyEnter})
+	kb := NewBinding(WithKeys("alt+c"))
+	b.Run("success", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = Matches(msg1, kb)
+		}
+	})
+	b.Run("fail", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = Matches(msg2, kb)
+		}
+	})
 }


### PR DESCRIPTION
Fixes #475.
```
name                old time/op    new time/op    delta
Matches/success-32    66.9ns ± 1%    15.7ns ± 0%   -76.47%  (p=0.016 n=5+4)
Matches/fail-32       27.9ns ± 0%    12.4ns ± 2%   -55.70%  (p=0.016 n=4+5)

name                old alloc/op   new alloc/op   delta
Matches/success-32     5.00B ± 0%     0.00B       -100.00%  (p=0.008 n=5+5)
Matches/fail-32        0.00B          0.00B           ~     (all equal)

name                old allocs/op  new allocs/op  delta
Matches/success-32      1.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
Matches/fail-32         0.00           0.00           ~     (all equal)
```

cc @meowgorithm @muesli 