### PR TITLE
Table: Make UpdateViewport() have constant runtime, not depending on …

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -242,7 +242,13 @@ func (m Model) View() string {
 // columns and rows.
 func (m *Model) UpdateViewport() {
 	renderedRows := make([]string, 0, len(m.rows))
-	for i := range m.rows {
+
+	// Render only rows from: m.cursor-m.viewport.Height to: m.cursor+m.viewport.Height
+	// Constant runtime, independent of number of rows in a table.
+	// Limits the numer of renderedRows to a maximum of 2*m.viewport.Height
+	start := clamp(m.cursor-m.viewport.Height, 0, len(m.rows))
+	end := clamp(m.cursor+m.viewport.Height, m.cursor, len(m.rows))
+	for i := start; i < end; i++ {
 		renderedRows = append(renderedRows, m.renderRow(i))
 	}
 

--- a/table/table.go
+++ b/table/table.go
@@ -21,11 +21,8 @@ type Model struct {
 	styles Styles
 
 	viewport viewport.Model
-	renderedLines
-}
-
-type renderedLines struct {
-	start, end int
+	start    int
+	end      int
 }
 
 // Row represents one line in the table.
@@ -252,12 +249,12 @@ func (m *Model) UpdateViewport() {
 	// Constant runtime, independent of number of rows in a table.
 	// Limits the numer of renderedRows to a maximum of 2*m.viewport.Height
 	if m.cursor >= 0 {
-		m.renderedLines.start = clamp(m.cursor-m.viewport.Height, 0, m.cursor)
+		m.start = clamp(m.cursor-m.viewport.Height, 0, m.cursor)
 	} else {
-		m.renderedLines.start = 0
+		m.start = 0
 	}
-	m.renderedLines.end = clamp(m.cursor+m.viewport.Height, m.cursor, len(m.rows))
-	for i := m.renderedLines.start; i < m.renderedLines.end; i++ {
+	m.end = clamp(m.cursor+m.viewport.Height, m.cursor, len(m.rows))
+	for i := m.start; i < m.end; i++ {
 		renderedRows = append(renderedRows, m.renderRow(i))
 	}
 
@@ -316,9 +313,9 @@ func (m *Model) SetCursor(n int) {
 func (m *Model) MoveUp(n int) {
 	m.cursor = clamp(m.cursor-n, 0, len(m.rows)-1)
 	switch {
-	case m.renderedLines.start == 0:
+	case m.start == 0:
 		m.viewport.SetYOffset(clamp(m.viewport.YOffset, 0, m.cursor))
-	case m.renderedLines.start < m.viewport.Height:
+	case m.start < m.viewport.Height:
 		m.viewport.SetYOffset(clamp(m.viewport.YOffset+n, 0, m.cursor))
 	case m.viewport.YOffset >= 1:
 		m.viewport.YOffset = clamp(m.viewport.YOffset+n, 1, m.viewport.Height)
@@ -334,9 +331,9 @@ func (m *Model) MoveDown(n int) {
 	m.UpdateViewport()
 
 	switch {
-	case m.renderedLines.end == len(m.rows):
+	case m.end == len(m.rows):
 		m.viewport.SetYOffset(clamp(m.viewport.YOffset-n, 1, m.viewport.Height))
-	case m.cursor > (m.renderedLines.end-m.renderedLines.start)/2:
+	case m.cursor > (m.end-m.start)/2:
 		m.viewport.SetYOffset(clamp(m.viewport.YOffset-n, 1, m.cursor))
 	case m.viewport.YOffset > 1:
 	case m.cursor > m.viewport.YOffset+m.viewport.Height-1:


### PR DESCRIPTION
…number of rows in a table.

Related issue: https://github.com/charmbracelet/bubbles/issues/276

Since there was no feedback on the issue, i tried the following approach to solve the problem of table becoming pretty much useless for a large number of rows.

Instead of rendering the whole table, i limited the rendering to only rows from: m.cursor-m.viewport.Height to: m.cursor+m.viewport.Height. This approach gives the constant runtime (see below) making table act snappy and responsive independent on the number of rows in it.

Results, timed by measuring time to execute a MoveDown(1):
```
		// DOWN
		case key.Matches(msg, keybindings.DefaultKeyMap.Down):
			t := time.Now()
			m.Log.Printf("Update: Move down\n")
			activeTable.MoveDown(1)
			m.Log.Printf("Update: Move down finished in: %.3f sec\n", time.Since(t).Seconds())
```

```
Rows: 36932


SC: 14:34:19.346611 update.go:396: Update: Move down
debug 2022/11/04 14:34:19 rows: 36932 start: 0 end: 51 cursor: 1 height: 50 range: 51
SC: 14:34:19.351719 update.go:398: Update: Move down finished in: 0.005 sec

SC: 14:34:19.507794 update.go:396: Update: Move down
debug 2022/11/04 14:34:19 rows: 36932 start: 0 end: 52 cursor: 2 height: 50 range: 52
SC: 14:34:19.511653 update.go:398: Update: Move down finished in: 0.004 sec

SC: 14:34:19.675428 update.go:396: Update: Move down
debug 2022/11/04 14:34:19 rows: 36932 start: 0 end: 53 cursor: 3 height: 50 range: 53
SC: 14:34:19.679369 update.go:398: Update: Move down finished in: 0.004 sec


Rows: 12

SC: 14:34:31.174864 update.go:396: Update: Move down
debug 2022/11/04 14:34:31 rows: 12 start: 0 end: 12 cursor: 1 height: 50 range: 12
SC: 14:34:31.176839 update.go:398: Update: Move down finished in: 0.002 sec

SC: 14:34:31.344683 update.go:396: Update: Move down
debug 2022/11/04 14:34:31 rows: 12 start: 0 end: 12 cursor: 2 height: 50 range: 12
SC: 14:34:31.345428 update.go:398: Update: Move down finished in: 0.001 sec

SC: 14:34:31.514059 update.go:396: Update: Move down
debug 2022/11/04 14:34:31 rows: 12 start: 0 end: 12 cursor: 3 height: 50 range: 12
SC: 14:34:31.514577 update.go:398: Update: Move down finished in: 0.001 sec
```
This code works fine in my app , although i'm not sure if it might have any adverse effect in some other table code-paths?
Can't see any for now. If you spot anything, let me know! :smiley_cat: 


