### PR TITLE
Fixing progress.Percent() source value

### DIFF
--- a/progress/progress.go
+++ b/progress/progress.go
@@ -237,7 +237,7 @@ func (m *Model) SetSpringOptions(frequency, damping float64) {
 //
 // If you're rendering with ViewAs you won't need this.
 func (m Model) Percent() float64 {
-	return m.targetPercent
+	return m.percentShown
 }
 
 // SetPercent sets the percentage state of the model as well as a command


### PR DESCRIPTION
`.Percent()` should return the _current_ value shown on the percent bar not the _intended_ destination based on the doc string.

I was recently confused in trying to display different strings based on the current value of the progress bar. The math however never changes because this function is always returning `100.0`. I took a look at the source and I believe this is a mistake. 