### PR TITLE
chore: apply appropriate GoDoc syntax to deprecated items

### DIFF
--- a/help/help.go
+++ b/help/help.go
@@ -92,7 +92,7 @@ func New() Model {
 
 // NewModel creates a new help view with some useful defaults.
 //
-// Deprecated. Use New instead.
+// Deprecated: use [New] instead.
 var NewModel = New
 
 // Update helps satisfy the Bubble Tea Model interface. It's a no-op.

--- a/list/list.go
+++ b/list/list.go
@@ -231,7 +231,7 @@ func New(items []Item, delegate ItemDelegate, width, height int) Model {
 
 // NewModel returns a new model with sensible defaults.
 //
-// Deprecated. Use New instead.
+// Deprecated: use [New] instead.
 var NewModel = New
 
 // SetFilteringEnabled enables or disables filtering. Note that this is different

--- a/paginator/paginator.go
+++ b/paginator/paginator.go
@@ -53,15 +53,15 @@ type Model struct {
 	// KeyMap encodes the keybindings recognized by the widget.
 	KeyMap KeyMap
 
-	// Deprecated: customize KeyMap instead.
+	// Deprecated: customize [KeyMap] instead.
 	UsePgUpPgDownKeys bool
-	// Deprecated: customize KeyMap instead.
+	// Deprecated: customize [KeyMap] instead.
 	UseLeftRightKeys bool
-	// Deprecated: customize KeyMap instead.
+	// Deprecated: customize [KeyMap] instead.
 	UseUpDownKeys bool
-	// Deprecated: customize KeyMap instead.
+	// Deprecated: customize [KeyMap] instead.
 	UseHLKeys bool
-	// Deprecated: customize KeyMap instead.
+	// Deprecated: customize [KeyMap] instead.
 	UseJKKeys bool
 }
 
@@ -141,7 +141,7 @@ func New() Model {
 
 // NewModel creates a new model with defaults.
 //
-// Deprecated. Use New instead.
+// Deprecated: use [New] instead.
 var NewModel = New
 
 // Update is the Tea update function which binds keystrokes to pagination.

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -191,7 +191,7 @@ func New(opts ...Option) Model {
 
 // NewModel returns a model with default values.
 //
-// Deprecated. Use New instead.
+// Deprecated: use [New] instead.
 var NewModel = New
 
 // Init exists satisfy the tea.Model interface.

--- a/spinner/spinner.go
+++ b/spinner/spinner.go
@@ -124,7 +124,7 @@ func New(opts ...Option) Model {
 
 // NewModel returns a model with default values.
 //
-// Deprecated. Use New instead.
+// Deprecated: use [New] instead.
 var NewModel = New
 
 // TickMsg indicates that the timer has ticked and we should render a frame.
@@ -201,7 +201,7 @@ func (m Model) tick(id, tag int) tea.Cmd {
 // Tick is the command used to advance the spinner one frame. Use this command
 // to effectively start the spinner.
 //
-// This method is deprecated. Use Model.Tick instead.
+// Deprecated: Use [Model.Tick] instead.
 func Tick() tea.Msg {
 	return TickMsg{Time: time.Now()}
 }

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -84,8 +84,7 @@ type Model struct {
 	EchoCharacter rune
 	Cursor        cursor.Model
 
-	// Deprecated: use cursor.BlinkSpeed instead.
-	// This is unused and will be removed in the future.
+	// Deprecated: use [cursor.BlinkSpeed] instead.
 	BlinkSpeed time.Duration
 
 	// Styles. These will be applied as inline styles.
@@ -150,7 +149,7 @@ func New() Model {
 
 // NewModel creates a new model with default settings.
 //
-// Deprecated. Use New instead.
+// Deprecated: Use [New] instead.
 var NewModel = New
 
 // SetValue sets the value of the text input.


### PR DESCRIPTION
Just a little GoDoc housekeeping with regard to deprecate items.