### PR TITLE
[Needs Review] Fix: textinput cursor for UTF-8 characters

### DIFF
--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -647,12 +647,14 @@ func (m Model) placeholderView() string {
 		style = m.PlaceholderStyle.Inline(true).Render
 	)
 
+	q := []rune(p)
+
 	m.Cursor.TextStyle = m.PlaceholderStyle
-	m.Cursor.SetChar(p[:1])
+	m.Cursor.SetChar(string(q[:1]))
 	v += m.Cursor.View()
 
 	// The rest of the placeholder text
-	v += style(p[1:])
+	v += style(string(q[1:]))
 
 	return m.PromptStyle.Render(m.Prompt) + v
 }


### PR DESCRIPTION
The current method for highlighting the first character of the placeholder corrupts multi-codepoint characters. This is easily fixed with the `rune` type, but would require many changes to be consistent.

I've applied a hacky fix below, but I'm pretty sure this isn't the best way to do this. Any advice?

This is the bug responsible for charmbracelet/gum#240.