### PR TITLE
fix(textarea): support pastes that end with a newline character

### DIFF
--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -325,7 +325,7 @@ func (m *Model) insertRunesFromUserInput(runes []rune) {
 			lstart = i + 1
 		}
 	}
-	if lstart < len(runes) {
+	if lstart <= len(runes) {
 		// The last line did not end with a newline character.
 		// Take it now.
 		lines = append(lines, runes[lstart:])


### PR DESCRIPTION
My previous fix did not properly handle a multi-rune input that *ends* with a newline character. In that case, the final newline was removed.

I found this using the test suite I built for textarea in bubbline at https://github.com/knz/bubbline/tree/main/editline/internal/textarea/testdata.

cc @maaslalani @muesli 