### PR TITLE
fix(textarea): fix data corruption after multi-line input

### DIFF
--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -321,7 +321,11 @@ func (m *Model) insertRunesFromUserInput(runes []rune) {
 	lstart := 0
 	for i := 0; i < len(runes); i++ {
 		if runes[i] == '\n' {
-			lines = append(lines, runes[lstart:i])
+			// Queue a line to become a new row in the text area below.
+			// Beware to clamp the max capacity of the slice, to ensure no
+			// data from different rows get overwritten when later edits
+			// will modify this line.
+			lines = append(lines, runes[lstart:i:i])
 			lstart = i + 1
 		}
 	}


### PR DESCRIPTION
Found using the unit test suite at https://github.com/knz/bubbline

Previously, when inserting multiple lines of input at once, the underlying Go data array was incorrectly shared in memory across multiple rows of the textarea. This was causing input corruption, where a user trying to modify one line would see their text added on the next line as well.

This patch fixes it.

cc @maaslalani 