### PR TITLE
Add SetFilterText and SetFilterState

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -10,16 +10,17 @@ import (
 	"strings"
 	"time"
 
-	"github.com/charmbracelet/bubbles/help"
-	"github.com/charmbracelet/bubbles/key"
-	"github.com/charmbracelet/bubbles/paginator"
-	"github.com/charmbracelet/bubbles/spinner"
-	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/reflow/ansi"
 	"github.com/muesli/reflow/truncate"
 	"github.com/sahilm/fuzzy"
+
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/paginator"
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/textinput"
 )
 
 // Item is an item that appears in the list.
@@ -277,7 +278,7 @@ func (m *Model) SetFilterText(filter string) {
 func (m *Model) SetFilterState(state FilterState) {
 	m.Paginator.Page = 0
 	m.cursor = 0
-	m.filterState = Filtering
+	m.filterState = state
 	m.FilterInput.CursorEnd()
 	m.FilterInput.Focus()
 	m.updateKeybindings()

--- a/list/list.go
+++ b/list/list.go
@@ -261,7 +261,7 @@ func (m *Model) SetShowTitle(v bool) {
 func (m *Model) SetFilterText(filter string) {
 	m.filterState = Filtering
 	m.FilterInput.SetValue(filter)
-	cmd := tea.Cmd(filterItems(*m))
+	cmd := filterItems(*m)
 	msg := cmd()
 	fmm, _ := msg.(FilterMatchesMsg)
 	m.filteredItems = filteredItems(fmm)


### PR DESCRIPTION
Currently, there's no way to allow a developer to prefill a list filter reliably. A workaround of using Program.Send works, but is limiting.

This PR introduces two new functions, SetFilterText and SetFilterState which fix this issue and allow for finer control over the list's initial filter state.

Willing to make whatever style changes etc. are required.