### PR TITLE
refactor(table): remove unused cmds variable

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -188,8 +188,6 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		return m, nil
 	}
 
-	var cmds []tea.Cmd
-
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch {
@@ -214,7 +212,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		}
 	}
 
-	return m, tea.Batch(cmds...)
+	return m, nil
 }
 
 // Focused returns the focus state of the table.


### PR DESCRIPTION
the `cmds` variable in table's Update method is unused. 
I replaced it with `nil`.