### PR TITLE
Remove unused BackgroundStyle in TextInput

### DIFF
--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -94,7 +94,6 @@ type Model struct {
 	// https://github.com/charmbracelet/lipgloss
 	PromptStyle      lipgloss.Style
 	TextStyle        lipgloss.Style
-	BackgroundStyle  lipgloss.Style
 	PlaceholderStyle lipgloss.Style
 	CursorStyle      lipgloss.Style
 


### PR DESCRIPTION
I noticed that it seemed like `BackgroundStyle` was unused in `TextInput` and then discovered there was already an open issue for it.

Closes #182 