### PR TITLE
fix: add bounds checking to the selectedrow func

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -266,10 +266,10 @@ func (m *Model) UpdateViewport() {
 // SelectedRow returns the selected row.
 // You can cast it to your own implementation.
 func (m Model) SelectedRow() Row {
-	// Check if the cursor is within bounds else return  nil
-	if !(m.cursor >= 0 && m.cursor < len(m.rows)) {
+	if m.cursor < 0 || m.cursor >= len(m.rows) {
 		return nil
 	}
+
 	return m.rows[m.cursor]
 }
 

--- a/table/table.go
+++ b/table/table.go
@@ -267,10 +267,10 @@ func (m *Model) UpdateViewport() {
 // You can cast it to your own implementation.
 func (m Model) SelectedRow() Row {
 	// Check if the cursor is within bounds else return  nil
-	if m.cursor < len(m.rows) && m.cursor >= 0 {
-		return m.rows[m.cursor]
+	if !(m.cursor >= 0 && m.cursor < len(m.rows)) {
+		return nil
 	}
-	return nil
+	return m.rows[m.cursor]
 }
 
 // Rows returns the current rows.

--- a/table/table.go
+++ b/table/table.go
@@ -269,9 +269,8 @@ func (m Model) SelectedRow() Row {
 	// Check if the cursor is within bounds else return  nil
 	if m.cursor < len(m.rows) && m.cursor >= 0 {
 		return m.rows[m.cursor]
-	} else {
-		return nil
 	}
+	return nil
 }
 
 // Rows returns the current rows.

--- a/table/table.go
+++ b/table/table.go
@@ -266,7 +266,12 @@ func (m *Model) UpdateViewport() {
 // SelectedRow returns the selected row.
 // You can cast it to your own implementation.
 func (m Model) SelectedRow() Row {
-	return m.rows[m.cursor]
+	// Check if the cursor is within bounds else return  nil
+	if m.cursor < len(m.rows) && m.cursor >= 0 {
+		return m.rows[m.cursor]
+	} else {
+		return nil
+	}
 }
 
 // Rows returns the current rows.


### PR DESCRIPTION
### Fixes: charmbracelet/gum#304

### Changes:
 * This adds bounds checking to the function returning the row under the cursor. By adding the check, it avoids that the program crashes when calling the function and the cursor is out of bounds.

### Still an issue:
 * The cursor can still become out of bounds values, which is a problem in itself.