### PR TITLE
fix: deprecate `CursorStyle` in favour of `Cursor.Style`

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -191,7 +191,7 @@ func New(items []Item, delegate ItemDelegate, width, height int) Model {
 	filterInput := textinput.New()
 	filterInput.Prompt = "Filter: "
 	filterInput.PromptStyle = styles.FilterPrompt
-	filterInput.CursorStyle = styles.FilterCursor
+	filterInput.Cursor.Style = styles.FilterCursor
 	filterInput.CharLimit = 64
 	filterInput.Focus()
 

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -95,7 +95,9 @@ type Model struct {
 	PromptStyle      lipgloss.Style
 	TextStyle        lipgloss.Style
 	PlaceholderStyle lipgloss.Style
-	CursorStyle      lipgloss.Style
+
+	// Deprecated: use Cursor.Style instead.
+	CursorStyle lipgloss.Style
 
 	// CharLimit is the maximum amount of characters this input element will
 	// accept. If 0 or less, there's no limit.


### PR DESCRIPTION
Deprecates `CursorStyle` in favour of `Cursor.Style`.