### PR TITLE
Bugfix/render off by one

### DIFF
--- a/filepicker/filepicker.go
+++ b/filepicker/filepicker.go
@@ -138,7 +138,7 @@ type Model struct {
 	DirAllowed  bool
 	FileAllowed bool
 
-	FileSelcted   string
+	FileSelected  string
 	selected      int
 	selectedStack stack
 

--- a/filepicker/filepicker.go
+++ b/filepicker/filepicker.go
@@ -57,7 +57,7 @@ type errorMsg struct {
 type readDirMsg []os.DirEntry
 
 const (
-	marginBottom  = 6
+	marginBottom  = 5
 	fileSizeWidth = 8
 	paddingLeft   = 2
 )
@@ -227,12 +227,12 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case readDirMsg:
 		m.files = msg
-		m.max = m.Height
+		m.max = m.Height - 1
 	case tea.WindowSizeMsg:
 		if m.AutoHeight {
 			m.Height = msg.Height - marginBottom
 		}
-		m.max = m.Height
+		m.max = m.Height - 1
 	case tea.KeyMsg:
 		switch {
 		case key.Matches(msg, m.KeyMap.GoToTop):

--- a/filepicker/filepicker.go
+++ b/filepicker/filepicker.go
@@ -56,9 +56,11 @@ type errorMsg struct {
 
 type readDirMsg []os.DirEntry
 
-const marginBottom = 5
-const fileSizeWidth = 8
-const paddingLeft = 2
+const (
+	marginBottom  = 6
+	fileSizeWidth = 8
+	paddingLeft   = 2
+)
 
 // KeyMap defines key bindings for each user action.
 type KeyMap struct {
@@ -380,7 +382,7 @@ func (m Model) View() string {
 			continue
 		}
 
-		var style = m.Styles.File
+		style := m.Styles.File
 		if f.IsDir() {
 			style = m.Styles.Directory
 		} else if isSymlink {


### PR DESCRIPTION
Bug: The top folder re-renders when going into a subfolder. It happens when the subfolder contains a larger number of files than can be rendered on one screen.

![file-picker](https://user-images.githubusercontent.com/96494390/235218751-7dce9afc-a84f-46a3-bfe6-b2cbf4a3258e.gif)

Fix:
![file-picker-fixed](https://user-images.githubusercontent.com/96494390/235218828-519ed001-7aea-4da4-b171-035d6b4ab485.gif)

cc: @maaslalani @bashbunni 