### PR TITLE
fix(textarea/textinput): Reset blink only when CusrorBlink

### DIFF
--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -1020,7 +1020,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 	newRow, newCol := m.cursorLineNumber(), m.col
 	m.Cursor, cmd = m.Cursor.Update(msg)
-	if newRow != oldRow || newCol != oldCol {
+	if (newRow != oldRow || newCol != oldCol) && m.Cursor.Mode() == cursor.CursorBlink {
 		m.Cursor.Blink = false
 		cmd = m.Cursor.BlinkCmd()
 	}

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -595,7 +595,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	m.Cursor, cmd = m.Cursor.Update(msg)
 	cmds = append(cmds, cmd)
 
-	if oldPos != m.pos {
+	if oldPos != m.pos && m.Cursor.Mode() == cursor.CursorBlink {
 		m.Cursor.Blink = false
 		cmds = append(cmds, m.Cursor.BlinkCmd())
 	}


### PR DESCRIPTION
Fixed the issue where cursor showing up when moved despite `cursor.Mode == CursorHide`.