### PR TITLE
chore: filepicker edits

### DIFF
--- a/filepicker/filepicker.go
+++ b/filepicker/filepicker.go
@@ -46,7 +46,7 @@ func New() Model {
 		minStack:         newStack(),
 		maxStack:         newStack(),
 		KeyMap:           DefaultKeyMap,
-		Styles:           DefaultStyles,
+		Styles:           DefaultStyles(),
 	}
 }
 
@@ -107,18 +107,26 @@ type Styles struct {
 }
 
 // DefaultStyles defines the default styling for the file picker.
-var DefaultStyles = Styles{
-	DisabledCursor:   lipgloss.NewStyle().Foreground(lipgloss.Color("247")),
-	Cursor:           lipgloss.NewStyle().Foreground(lipgloss.Color("212")),
-	Symlink:          lipgloss.NewStyle().Foreground(lipgloss.Color("36")),
-	Directory:        lipgloss.NewStyle().Foreground(lipgloss.Color("99")),
-	File:             lipgloss.NewStyle(),
-	DisabledFile:     lipgloss.NewStyle().Foreground(lipgloss.Color("243")),
-	DisabledSelected: lipgloss.NewStyle().Foreground(lipgloss.Color("247")),
-	Permission:       lipgloss.NewStyle().Foreground(lipgloss.Color("244")),
-	Selected:         lipgloss.NewStyle().Foreground(lipgloss.Color("212")).Bold(true),
-	FileSize:         lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Width(fileSizeWidth).Align(lipgloss.Right),
-	EmptyDirectory:   lipgloss.NewStyle().Foreground(lipgloss.Color("240")).PaddingLeft(paddingLeft).SetString("Bummer. No Files Found."),
+func DefaultStyles() Styles {
+	return DefaultStylesWithRenderer(lipgloss.DefaultRenderer())
+}
+
+// DefaultStylesWithRenderer defines the default styling for the file picker,
+// with a given Lip Gloss renderer.
+func DefaultStylesWithRenderer(r *lipgloss.Renderer) Styles {
+	return Styles{
+		DisabledCursor:   r.NewStyle().Foreground(lipgloss.Color("247")),
+		Cursor:           r.NewStyle().Foreground(lipgloss.Color("212")),
+		Symlink:          r.NewStyle().Foreground(lipgloss.Color("36")),
+		Directory:        r.NewStyle().Foreground(lipgloss.Color("99")),
+		File:             r.NewStyle(),
+		DisabledFile:     r.NewStyle().Foreground(lipgloss.Color("243")),
+		DisabledSelected: r.NewStyle().Foreground(lipgloss.Color("247")),
+		Permission:       r.NewStyle().Foreground(lipgloss.Color("244")),
+		Selected:         r.NewStyle().Foreground(lipgloss.Color("212")).Bold(true),
+		FileSize:         r.NewStyle().Foreground(lipgloss.Color("240")).Width(fileSizeWidth).Align(lipgloss.Right),
+		EmptyDirectory:   r.NewStyle().Foreground(lipgloss.Color("240")).PaddingLeft(paddingLeft).SetString("Bummer. No Files Found."),
+	}
 }
 
 // Model represents a file picker.

--- a/filepicker/filepicker.go
+++ b/filepicker/filepicker.go
@@ -45,7 +45,7 @@ func New() Model {
 		selectedStack:    newStack(),
 		minStack:         newStack(),
 		maxStack:         newStack(),
-		KeyMap:           DefaultKeyMap,
+		KeyMap:           DefaultKeyMap(),
 		Styles:           DefaultStyles(),
 	}
 }
@@ -79,16 +79,18 @@ type KeyMap struct {
 }
 
 // DefaultKeyMap defines the default keybindings.
-var DefaultKeyMap = KeyMap{
-	GoToTop:  key.NewBinding(key.WithKeys("g"), key.WithHelp("g", "first")),
-	GoToLast: key.NewBinding(key.WithKeys("G"), key.WithHelp("G", "last")),
-	Down:     key.NewBinding(key.WithKeys("j", "down", "ctrl+n"), key.WithHelp("j", "down")),
-	Up:       key.NewBinding(key.WithKeys("k", "up", "ctrl+p"), key.WithHelp("k", "up")),
-	PageUp:   key.NewBinding(key.WithKeys("K", "pgup"), key.WithHelp("pgup", "page up")),
-	PageDown: key.NewBinding(key.WithKeys("J", "pgdown"), key.WithHelp("pgdown", "page down")),
-	Back:     key.NewBinding(key.WithKeys("h", "backspace", "left", "esc"), key.WithHelp("h", "back")),
-	Open:     key.NewBinding(key.WithKeys("l", "right", "enter"), key.WithHelp("l", "open")),
-	Select:   key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
+func DefaultKeyMap() KeyMap {
+	return KeyMap{
+		GoToTop:  key.NewBinding(key.WithKeys("g"), key.WithHelp("g", "first")),
+		GoToLast: key.NewBinding(key.WithKeys("G"), key.WithHelp("G", "last")),
+		Down:     key.NewBinding(key.WithKeys("j", "down", "ctrl+n"), key.WithHelp("j", "down")),
+		Up:       key.NewBinding(key.WithKeys("k", "up", "ctrl+p"), key.WithHelp("k", "up")),
+		PageUp:   key.NewBinding(key.WithKeys("K", "pgup"), key.WithHelp("pgup", "page up")),
+		PageDown: key.NewBinding(key.WithKeys("J", "pgdown"), key.WithHelp("pgdown", "page down")),
+		Back:     key.NewBinding(key.WithKeys("h", "backspace", "left", "esc"), key.WithHelp("h", "back")),
+		Open:     key.NewBinding(key.WithKeys("l", "right", "enter"), key.WithHelp("l", "open")),
+		Select:   key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "select")),
+	}
 }
 
 // Styles defines the possible customizations for styles in the file picker.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/bubbletea v0.24.1
 	github.com/charmbracelet/harmonica v0.2.0
-	github.com/charmbracelet/lipgloss v0.6.0
+	github.com/charmbracelet/lipgloss v0.7.1
 	github.com/dustin/go-humanize v1.0.1
 	github.com/lucasb-eyer/go-colorful v1.2.0
 	github.com/mattn/go-runewidth v0.0.14

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/charmbracelet/harmonica v0.2.0 h1:8NxJWRWg/bzKqqEaaeFNipOu77YR5t8aSwG
 github.com/charmbracelet/harmonica v0.2.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
 github.com/charmbracelet/lipgloss v0.6.0 h1:1StyZB9vBSOyuZxQUcUwGr17JmojPNm87inij9N3wJY=
 github.com/charmbracelet/lipgloss v0.6.0/go.mod h1:tHh2wr34xcHjC2HCXIlGSG1jaDF0S0atAUvBMP6Ppuk=
+github.com/charmbracelet/lipgloss v0.7.1 h1:17WMwi7N1b1rVWOjMT+rCh7sQkvDU75B2hbZpc5Kc1E=
+github.com/charmbracelet/lipgloss v0.7.1/go.mod h1:yG0k3giv8Qj8edTCbbg6AlQ5e8KNWpFujkNawKNhE2c=
 github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 h1:q2hJAaP1k2wIvVRd/hEHD7lacgqrCPS+k8g1MndzfWY=
 github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=


### PR DESCRIPTION
Minor `filepicker` adjustments based on learnings elsewhere in Bubbles:

* Instances only respond to their own directory queries
* Optionally create styles against a custom Lip Gloss renderer
* Make default styles immutable