### PR TITLE
fix(viewport): pad width to contentWidth

### DIFF
--- a/viewport/viewport.go
+++ b/viewport/viewport.go
@@ -373,9 +373,10 @@ func (m Model) View() string {
 	contentWidth := w - m.Style.GetHorizontalFrameSize()
 	contentHeight := h - m.Style.GetVerticalFrameSize()
 	contents := lipgloss.NewStyle().
+		Width(contentWidth).      // pad to width.
 		Height(contentHeight).    // pad to height.
 		MaxHeight(contentHeight). // truncate height if taller.
-		MaxWidth(contentWidth).   // truncate width.
+		MaxWidth(contentWidth).   // truncate width if wider.
 		Render(strings.Join(m.visibleLines(), "\n"))
 	return m.Style.Copy().
 		UnsetWidth().UnsetHeight(). // Style size already applied in contents.


### PR DESCRIPTION
I have an application that uses the viewport, and I added borders to the viewport. I noticed the width is not set to what can be set through `.Width()`, as I'm loading variable width content, which shrinks and grows depending on what it currently renders.

My initial workaround was to force the style from the viewport to set a fixed width. However, that didn't work. Then, I added spaces to the last line of the content to match the viewport's width, which worked, but I believe the end-user code shouldn't be handling this case.

So, with this PR, I'm padding the width of the viewport content to what has been specified in its `width`. Please look at the screenshots from a minimal application reproducing the issue.

Before:
![Screenshot from 2023-06-15 10-18-06](https://github.com/charmbracelet/bubbles/assets/27286/6073b261-153d-4d1c-bbc0-d4c3127ff6f4)

After:
![Screenshot from 2023-06-15 10-12-56](https://github.com/charmbracelet/bubbles/assets/27286/bcd1241f-9856-4106-8bf3-8c9736e9caf1)

And this is the code that reproduces the issue:

```golang
package main

// An example program demonstrating the pager component from the Bubbles
// component library.

import (
	"fmt"
	"os"

	"github.com/charmbracelet/bubbles/viewport"
	tea "github.com/charmbracelet/bubbletea"
	"github.com/charmbracelet/lipgloss"
)

type model struct {
	ready    bool
	viewport viewport.Model
}

func (m model) Init() tea.Cmd {
	return nil
}

func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
	switch msg := msg.(type) {
	case tea.KeyMsg:
		if msg.String() == "ctrl+c" {
			return m, tea.Quit
		}

	case tea.WindowSizeMsg:
		if !m.ready {
			m.viewport = viewport.New(msg.Width, msg.Height)
			m.viewport.Style = lipgloss.NewStyle().BorderStyle(lipgloss.NormalBorder()).BorderForeground(lipgloss.Color("4")).Padding(0, 1)
			m.viewport.SetContent("testing")
			m.ready = true
		} else {
			m.viewport.Width = msg.Width
			m.viewport.Height = msg.Height
		}
	}

	var cmd tea.Cmd
	m.viewport, cmd = m.viewport.Update(msg)

	return m, cmd
}

func (m model) View() string {
	if !m.ready {
		return "\n  Initializing..."
	}
	return m.viewport.View()
}

func main() {
	p := tea.NewProgram(
		new(model),
		tea.WithAltScreen(),
	)

	if _, err := p.Run(); err != nil {
		fmt.Println("could not run program:", err)
		os.Exit(1)
	}
}
```