### PR TITLE
fix: No items found. -> No items.

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -1174,7 +1174,7 @@ func (m Model) populatedView() string {
 		if m.filterState == Filtering {
 			return ""
 		}
-		return m.Styles.NoItems.Render("No " + m.itemNamePlural + " found.")
+		return m.Styles.NoItems.Render("No " + m.itemNamePlural + ".")
 	}
 
 	if len(items) > 0 {


### PR DESCRIPTION
Change list wording to read `No items.` as opposed to `No items found.`