### PR TITLE
perf(list): reduce allocations in `filterItems`

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -1218,11 +1218,11 @@ func filterItems(m Model) tea.Cmd {
 			return FilterMatchesMsg(m.itemsAsFilterItems()) // return nothing
 		}
 
-		targets := []string{}
 		items := m.items
+		targets := make([]string, len(items))
 
-		for _, t := range items {
-			targets = append(targets, t.FilterValue())
+		for i, t := range items {
+			targets[i] = t.FilterValue()
 		}
 
 		filterMatches := []filteredItem{}


### PR DESCRIPTION
As the number of items in `targets` is known, use `make` with the expected size instead of appending, which requires more allocations as the `targets` slice grows.