### PR TITLE
feat(table): expose `start` and `end` fields via getter methods

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -321,6 +321,16 @@ func (m *Model) SetCursor(n int) {
 	m.UpdateViewport()
 }
 
+// Start returns the index of the first rendered row.
+func (m *Model) Start() int {
+	return m.start
+}
+
+// End returns the index of the last rendered row.
+func (m *Model) End() int {
+	return m.end
+}
+
 // MoveUp moves the selection up by any number of rows.
 // It can not go above the first row.
 func (m *Model) MoveUp(n int) {


### PR DESCRIPTION
This PR exposes the `start` and the `end` fields from the table model struct.

Not having setters is fine because that would break the inner logic, but handling
mouse clicks on rows is a bit inconvenient because the mouse events contain the 
relative position but to select the actual row under the (mouse)cursor, the absolute
row index is needed. With exporting these - mainly the start - it should be as easy
as `table.Start() + mouseMsg.Y`.