### PR TITLE
Consistently return TextArea pointer

### DIFF
--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -227,7 +227,7 @@ type Model struct {
 }
 
 // New creates a new model with default settings.
-func New() Model {
+func New() *Model {
 	vp := viewport.New(0, 0)
 	vp.KeyMap = viewport.KeyMap{}
 	cur := cursor.New()
@@ -259,7 +259,7 @@ func New() Model {
 	m.SetHeight(defaultHeight)
 	m.SetWidth(defaultWidth)
 
-	return m
+	return &m
 }
 
 // DefaultStyles returns the default styles for focused and blurred states for
@@ -396,7 +396,7 @@ func (m *Model) insertRunesFromUserInput(runes []rune) {
 }
 
 // Value returns the value of the text input.
-func (m Model) Value() string {
+func (m *Model) Value() string {
 	if m.value == nil {
 		return ""
 	}
@@ -426,7 +426,7 @@ func (m *Model) LineCount() int {
 }
 
 // Line returns the line position.
-func (m Model) Line() int {
+func (m *Model) Line() int {
 	return m.row
 }
 
@@ -518,7 +518,7 @@ func (m *Model) CursorEnd() {
 }
 
 // Focused returns the focus state on the model.
-func (m Model) Focused() bool {
+func (m *Model) Focused() bool {
 	return m.focus
 }
 
@@ -767,7 +767,7 @@ func (m *Model) capitalizeRight() {
 
 // LineInfo returns the number of characters from the start of the
 // (soft-wrapped) line and the (soft-wrapped) line width.
-func (m Model) LineInfo() LineInfo {
+func (m *Model) LineInfo() LineInfo {
 	grid := wrap(m.value[m.row], m.width)
 
 	// Find out which line we are currently on. This can be determined by the
@@ -820,7 +820,7 @@ func (m *Model) repositionView() {
 }
 
 // Width returns the width of the textarea.
-func (m Model) Width() int {
+func (m *Model) Width() int {
 	return m.width
 }
 
@@ -885,7 +885,7 @@ func (m *Model) SetPromptFunc(promptWidth int, fn func(lineIdx int) string) {
 }
 
 // Height returns the current height of the textarea.
-func (m Model) Height() int {
+func (m *Model) Height() int {
 	return m.height
 }
 
@@ -901,7 +901,7 @@ func (m *Model) SetHeight(h int) {
 }
 
 // Update is the Bubble Tea update loop.
-func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
+func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 	if !m.focus {
 		m.Cursor.Blur()
 		return m, nil
@@ -1032,7 +1032,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 }
 
 // View renders the text area in its current state.
-func (m Model) View() string {
+func (m *Model) View() string {
 	if m.Value() == "" && m.row == 0 && m.col == 0 && m.Placeholder != "" {
 		return m.placeholderView()
 	}
@@ -1123,7 +1123,7 @@ func (m Model) View() string {
 	return m.style.Base.Render(m.viewport.View())
 }
 
-func (m Model) getPromptString(displayLine int) (prompt string) {
+func (m *Model) getPromptString(displayLine int) (prompt string) {
 	prompt = m.Prompt
 	if m.promptFunc == nil {
 		return prompt
@@ -1137,7 +1137,7 @@ func (m Model) getPromptString(displayLine int) (prompt string) {
 }
 
 // placeholderView returns the prompt and placeholder view, if any.
-func (m Model) placeholderView() string {
+func (m *Model) placeholderView() string {
 	var (
 		s     strings.Builder
 		p     = rw.Truncate(m.Placeholder, m.width, "...")
@@ -1183,7 +1183,7 @@ func Blink() tea.Msg {
 
 // cursorLineNumber returns the line number that the cursor is on.
 // This accounts for soft wrapped lines.
-func (m Model) cursorLineNumber() int {
+func (m *Model) cursorLineNumber() int {
 	line := 0
 	for i := 0; i < m.row; i++ {
 		// Calculate the number of lines that the current line will be split

--- a/textarea/textarea_test.go
+++ b/textarea/textarea_test.go
@@ -428,7 +428,7 @@ func TestRendersEndOfLineBuffer(t *testing.T) {
 	}
 }
 
-func newTextArea() Model {
+func newTextArea() *Model {
 	textarea := New()
 
 	textarea.Prompt = "> "


### PR DESCRIPTION
This PR changes the textarea model to return pointers instead of net-new instances, and updates method definitions to reference a pointer (which in practice, here, is mostly a semantic).

Currently, if you pass a message to a textarea Model, you get returned a model that may differ from the original model. This means that you have to reassign any textarea instances you maintain with the returned model.

This caused some strange issues in an tea program where I instantiated a model (e.g. `textarea.New()`) and then passed its pointer to two different locations, one handling view rendering (layouts), and another handling updates. The net result was that each update would cause the view to drift. 

Returning a pointer here gives a little bit more flexibility and still functions the same way.