### PR TITLE
feat(progress): make full/empty fill characters configurable

### DIFF
--- a/progress/progress.go
+++ b/progress/progress.go
@@ -79,6 +79,14 @@ func WithSolidFill(color string) Option {
 	}
 }
 
+// WithCustomFillCharacters sets the characters used to construct the full and empty components of the progress bar.
+func WithCustomFillCharacters(full rune, empty rune) Option {
+	return func(m *Model) {
+		m.Full = full
+		m.Empty = empty
+	}
+}
+
 // WithoutPercentage hides the numeric percentage.
 func WithoutPercentage() Option {
 	return func(m *Model) {

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -79,8 +79,8 @@ func WithSolidFill(color string) Option {
 	}
 }
 
-// WithCustomFillCharacters sets the characters used to construct the full and empty components of the progress bar.
-func WithCustomFillCharacters(full rune, empty rune) Option {
+// WithFillCharacters sets the characters used to construct the full and empty components of the progress bar.
+func WithFillCharacters(full rune, empty rune) Option {
 	return func(m *Model) {
 		m.Full = full
 		m.Empty = empty


### PR DESCRIPTION
This is a simple change adding a function, WithCustomFillCharacters, to configure the characters the progress bar is made from. The function takes two runes as parameters for setting m.Full and m.Empty, respectively.

In other words, this adds the option to create a progress bar using any desired characters to represent the full and empty portions of the bar.

This is my first contribution to a larger public project, so please let me know if I went about creating this pull request correctly.