### PR TITLE
fix(table): table scrolls before selected reaches top/bottom

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -343,9 +343,9 @@ func (m *Model) MoveDown(n int) {
 	m.UpdateViewport()
 
 	switch {
-	case m.end == len(m.rows):
+	case m.end == len(m.rows) && m.viewport.YOffset > 0:
 		m.viewport.SetYOffset(clamp(m.viewport.YOffset-n, 1, m.viewport.Height))
-	case m.cursor > (m.end-m.start)/2:
+	case m.cursor > (m.end-m.start)/2 && m.viewport.YOffset > 0:
 		m.viewport.SetYOffset(clamp(m.viewport.YOffset-n, 1, m.cursor))
 	case m.viewport.YOffset > 1:
 	case m.cursor > m.viewport.YOffset+m.viewport.Height-1:

--- a/table/table.go
+++ b/table/table.go
@@ -329,7 +329,7 @@ func (m *Model) MoveUp(n int) {
 	case m.start == 0:
 		m.viewport.SetYOffset(clamp(m.viewport.YOffset, 0, m.cursor))
 	case m.start < m.viewport.Height:
-		m.viewport.SetYOffset(clamp(m.viewport.YOffset+n, 0, m.cursor))
+		m.viewport.YOffset = (clamp(clamp(m.viewport.YOffset+1, 0, m.cursor), 0, m.viewport.Height))
 	case m.viewport.YOffset >= 1:
 		m.viewport.YOffset = clamp(m.viewport.YOffset+n, 1, m.viewport.Height)
 	}

--- a/table/table.go
+++ b/table/table.go
@@ -329,7 +329,7 @@ func (m *Model) MoveUp(n int) {
 	case m.start == 0:
 		m.viewport.SetYOffset(clamp(m.viewport.YOffset, 0, m.cursor))
 	case m.start < m.viewport.Height:
-		m.viewport.YOffset = (clamp(clamp(m.viewport.YOffset+1, 0, m.cursor), 0, m.viewport.Height))
+		m.viewport.YOffset = (clamp(clamp(m.viewport.YOffset+n, 0, m.cursor), 0, m.viewport.Height))
 	case m.viewport.YOffset >= 1:
 		m.viewport.YOffset = clamp(m.viewport.YOffset+n, 1, m.viewport.Height)
 	}


### PR DESCRIPTION
The previous version of the code used the SetYOffset function of the table's viewport, which caused the viewport to scroll up before the selected reached the top.

Fix: #428 