### PR TITLE
feat(table): add option for wraping cells

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -8,6 +8,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/mattn/go-runewidth"
+	"github.com/muesli/reflow/wordwrap"
 )
 
 // Model defines a state for the table widget.
@@ -403,7 +404,7 @@ func (m *Model) renderRow(rowID int) string {
 		style := lipgloss.NewStyle().Width(m.cols[i].Width).MaxWidth(m.cols[i].Width).Inline(true)
 		cellValue := runewidth.Truncate(value, m.cols[i].Width, "…")
 		if m.cellsWrap {
-			cellValue = runewidth.Wrap(value, m.cols[i].Width)
+			cellValue = wordwrap.String(value, m.cols[i].Width)
 			style = style.Copy().Inline(false)
 		}
 


### PR DESCRIPTION
The current implementation of the `table.renderRow` function allows only for truncating cell content, resulting in something like this: "test123 ...". 

<img width="693" alt="image" src="https://github.com/charmbracelet/bubbles/assets/23465248/ae32ac7d-cf30-4c76-adec-40d12ad0188a">




My project requires full content visibility, so I need a way to handle it. My first idea was to write a custom `table` component, but I guess it may be useful to make it optional for everyone
<img width="697" alt="image" src="https://github.com/charmbracelet/bubbles/assets/23465248/997786f7-5a59-4139-8d0f-ef25ad9f3732">

I couldn't find any contribution guide, so I hope everything is ok.
