### PR TITLE
fix(table): substract headers Y size from the total table size

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -296,8 +296,8 @@ func (m *Model) SetWidth(w int) {
 
 // SetHeight sets the height of the viewport of the table.
 func (m *Model) SetHeight(h int) {
-	_, y := m.styles.Header.GetFrameSize()
-	m.viewport.Height = h - y
+	headerHeight := lipgloss.Height(m.headersView()) // Since headers are truncated, it is always 1
+	m.viewport.Height = h - headerHeight - m.styles.Header.GetVerticalFrameSize()
 	m.UpdateViewport()
 }
 

--- a/table/table.go
+++ b/table/table.go
@@ -150,7 +150,7 @@ func WithRows(rows []Row) Option {
 // WithHeight sets the height of the table.
 func WithHeight(h int) Option {
 	return func(m *Model) {
-		m.viewport.Height = h
+		m.viewport.Height = h - lipgloss.Height(m.headersView())
 	}
 }
 
@@ -296,8 +296,7 @@ func (m *Model) SetWidth(w int) {
 
 // SetHeight sets the height of the viewport of the table.
 func (m *Model) SetHeight(h int) {
-	headerHeight := lipgloss.Height(m.headersView()) // Since headers are truncated, it is always 1
-	m.viewport.Height = h - headerHeight
+	m.viewport.Height = h - lipgloss.Height(m.headersView())
 	m.UpdateViewport()
 }
 

--- a/table/table.go
+++ b/table/table.go
@@ -296,7 +296,8 @@ func (m *Model) SetWidth(w int) {
 
 // SetHeight sets the height of the viewport of the table.
 func (m *Model) SetHeight(h int) {
-	m.viewport.Height = h
+	_, y := m.styles.Header.GetFrameSize()
+	m.viewport.Height = h - y
 	m.UpdateViewport()
 }
 

--- a/table/table.go
+++ b/table/table.go
@@ -297,7 +297,7 @@ func (m *Model) SetWidth(w int) {
 // SetHeight sets the height of the viewport of the table.
 func (m *Model) SetHeight(h int) {
 	headerHeight := lipgloss.Height(m.headersView()) // Since headers are truncated, it is always 1
-	m.viewport.Height = h - headerHeight - m.styles.Header.GetVerticalFrameSize()
+	m.viewport.Height = h - headerHeight
 	m.UpdateViewport()
 }
 


### PR DESCRIPTION
I spotted a bug while creating a table and viewport side by side. Even though they have set the exact height value, both have different sizes. While debugging, it came out that we only passed it down to the nested viewport component by setting table height, but the render method looks like this.

```
// View renders the component.
func (m Model) View() string {
	return m.headersView() + "\n" + m.viewport.View()
}
```

So, the total height of the table is the sum of the viewport's height and the headers' height. I have simply subtracted headings Y size from the viewport height, and it looks like this fixed the issue.