### PR TITLE
Add support for colors in table cells

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -2,6 +2,7 @@ package table
 
 import (
 	"strings"
+	"unicode"
 
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/viewport"
@@ -392,8 +393,18 @@ func (m Model) headersView() string {
 func (m *Model) renderRow(rowID int) string {
 	var s = make([]string, 0, len(m.cols))
 	for i, value := range m.rows[rowID] {
+		printableValue := strings.Map(func(r rune) rune {
+			if unicode.IsGraphic(r) {
+				return r
+			}
+			return -1
+		}, value)
 		style := lipgloss.NewStyle().Width(m.cols[i].Width).MaxWidth(m.cols[i].Width).Inline(true)
-		renderedCell := m.styles.Cell.Render(style.Render(runewidth.Truncate(value, m.cols[i].Width, "…")))
+		renderedCell := m.styles.Cell.Render(
+			style.Render(
+				strings.Replace(value, printableValue, runewidth.Truncate(printableValue, m.cols[i].Width, "…"), 0),
+			),
+		)
 		s = append(s, renderedCell)
 	}
 

--- a/table/table.go
+++ b/table/table.go
@@ -414,22 +414,6 @@ func (m *Model) renderRow(rowID int) string {
 	return row
 }
 
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-
-	return b
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-
-	return b
-}
-
 func clamp(v, low, high int) int {
 	return min(max(v, low), high)
 }

--- a/table/table.go
+++ b/table/table.go
@@ -400,20 +400,17 @@ func (m *Model) renderRow(rowID int) string {
 			return -1
 		}, value)
 		style := lipgloss.NewStyle().Width(m.cols[i].Width).MaxWidth(m.cols[i].Width).Inline(true)
-		renderedCell := m.styles.Cell.Render(
-			style.Render(
-				strings.Replace(value, printableValue, runewidth.Truncate(printableValue, m.cols[i].Width, "…"), 0),
-			),
-		)
-		s = append(s, renderedCell)
+		renderedCell := m.styles.Cell.Render(style.Render(strings.Replace(value, printableValue, runewidth.Truncate(printableValue, m.cols[i].Width, "…"), 1)))
+		if rowID == m.cursor {
+			renderedCell = strings.ReplaceAll(renderedCell, "\033[0m", "")
+			s = append(s, m.styles.Selected.Render(renderedCell))
+		} else {
+			s = append(s, renderedCell)
+		}
+
 	}
 
 	row := lipgloss.JoinHorizontal(lipgloss.Left, s...)
-
-	if rowID == m.cursor {
-		return m.styles.Selected.Render(row)
-	}
-
 	return row
 }
 


### PR DESCRIPTION
With this PR I want to address the following:
- Invisible characters cause incorrect calculation of cell width, making the table component to incorrectly print ellipsis when it shouldn't.
- When highlighting a row, if a cell had colors in it, the reset character would break the highlighting. I am removing the reset character and then highlighting each cell individually instead of the whole row, so that the highlight reset character serves as the reset character for the previously set color.
- While I was at it, I removed the `min` and `max` methods, since GoLang introduces them since v1.21