### PR TITLE
fix (textinput): do not resize based on placeholder

### DIFF
--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -714,7 +714,11 @@ func (m Model) placeholderView() string {
 	v += m.Cursor.View()
 
 	// The rest of the placeholder text
-	v += style(string(p[1:]))
+	var spaces []rune
+	for i := 0; i < m.Width-lipgloss.Width(string(p[1:m.Width])); i++ {
+		spaces = append(spaces, ' ')
+	}
+	v += style(string(append(p[1:m.Width], spaces...)))
 
 	return m.PromptStyle.Render(m.Prompt) + v
 }


### PR DESCRIPTION
This PR fixes this [issue](https://github.com/charmbracelet/bubbles/issues/358) regarding textinput resizing based on the placeholder. The original behavior is documented in the issue and has been modified to the following:

`Placeholder = ""`
![empty-placeholder](https://github.com/charmbracelet/bubbles/assets/74473367/87a26f96-2935-405a-9911-c0c9ba7a235f)

`Placeholder="123"`
![short-placeholder](https://github.com/charmbracelet/bubbles/assets/74473367/d9f63b69-62d0-4be4-bcc1-0d54bf049384)

`Placeholder = "1234567890"`
![long-placeholder](https://github.com/charmbracelet/bubbles/assets/74473367/d112a29d-416f-408a-a1f4-dc231213149c)