### PR TITLE
feat(viewport): add content style for controlling colors within viewport

### DIFF
--- a/viewport/viewport.go
+++ b/viewport/viewport.go
@@ -42,6 +42,10 @@ type Model struct {
 	// useful for setting borders, margins and padding.
 	Style lipgloss.Style
 
+	// Style applies a lipgloss style to the content in the viewport.
+	// Can be be helpful for controlling the background and foreground colors.
+	ContentStyle lipgloss.Style
+
 	// HighPerformanceRendering bypasses the normal Bubble Tea renderer to
 	// provide higher performance rendering. Most of the time the normal Bubble
 	// Tea rendering methods will suffice, but if you're passing content with
@@ -372,7 +376,7 @@ func (m Model) View() string {
 	}
 	contentWidth := w - m.Style.GetHorizontalFrameSize()
 	contentHeight := h - m.Style.GetVerticalFrameSize()
-	contents := lipgloss.NewStyle().
+	contents := m.ContentStyle.Copy().
 		Height(contentHeight).    // pad to height.
 		MaxHeight(contentHeight). // truncate height if taller.
 		MaxWidth(contentWidth).   // truncate width.

--- a/viewport/viewport.go
+++ b/viewport/viewport.go
@@ -43,7 +43,7 @@ type Model struct {
 	Style lipgloss.Style
 
 	// Style applies a lipgloss style to the content in the viewport.
-	// Can be be helpful for controlling the background and foreground colors.
+	// Can be helpful for controlling the background and foreground colors.
 	ContentStyle lipgloss.Style
 
 	// HighPerformanceRendering bypasses the normal Bubble Tea renderer to


### PR DESCRIPTION
There's a weird issue when attempting to change the colors within the viewport when the using [reflow/wrap](https://github.com/muesli/reflow).

Here's a code example:
```golang
var c1 = lipgloss.Color("111")
var c2 = lipgloss.Color("123")
var c3 = lipgloss.Color("239")

func main() {
	const name = "somebody"
	const msg = "a nice message about some things."

	const limit = 20

	nameStyle := lipgloss.NewStyle().Foreground(c1).Background(c3)
	msgStyle := lipgloss.NewStyle().Foreground(c2).Background(c3)
	wrapped := wrap.String(nameStyle.Render(name+": ")+msgStyle.Render(msg), limit)

	vp := viewport.New(20, 5)

	vpStyle := lipgloss.NewStyle().Foreground(c2).Background(c3)
	vp.Style = vpStyle

	vp.SetContent(wrapped)

	fmt.Println(vp.View())
}
```

which results in:
![pr-screen-cap](https://github.com/charmbracelet/bubbles/assets/21091975/ed13a0b8-bf06-48c7-b142-84f100fcbcc3)

However, with this PR and changing the code above like so:
```diff
-	vp.Style = vpStyle
+	vp.ContentStyle = vpStyl
```

the result is: 
![fixed](https://github.com/charmbracelet/bubbles/assets/21091975/ef20cd5e-2995-4819-a8c7-2eeae6da00d1)

I struggled to find a way to get this result without changing `viewport.go`.