### PR TITLE
Changed Update method return type for progress bar

### DIFF
--- a/progress/progress.go
+++ b/progress/progress.go
@@ -203,7 +203,7 @@ func (m Model) Init() tea.Cmd {
 // SetPercent to create the command you'll need to trigger the animation.
 //
 // If you're rendering with ViewAs you won't need this.
-func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case FrameMsg:
 		if msg.id != m.id || msg.tag != m.tag {


### PR DESCRIPTION
The progress bar code returns a generic tea.Model instead of the specific model in progress.go. This works but it means that you end up having to do a type assertion like this:

```go
	var cmd tea.Cmd
	var cmds []tea.Cmd
	var newModel tea.Model

	newModel, cmd = m.ProgressBar.Update(msg)
	cmds = append(cmds, cmd)

	if newModel, ok := newModel.(progress.Model); ok {
		m.ProgressBar = newModel
	}
```

If it used the correct Model struct you could instead do this:

```go
	var cmd tea.Cmd
	var cmds []tea.Cmd

	m.ProgressBar, cmd = m.ProgressBar.Update(msg)
	cmds = append(cmds, cmd)
```

This PR changes the return type.