### PR TITLE
Fix list pagination functions

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -532,12 +532,12 @@ func (m *Model) CursorDown() {
 }
 
 // PrevPage moves to the previous page, if available.
-func (m Model) PrevPage() {
+func (m *Model) PrevPage() {
 	m.Paginator.PrevPage()
 }
 
 // NextPage moves to the next page, if available.
-func (m Model) NextPage() {
+func (m *Model) NextPage() {
 	m.Paginator.NextPage()
 }
 


### PR DESCRIPTION
1. Set receivers for list.NextPage and list.PrevPage to pointers

# Why?
The Next and Prev list functions should advance or move back the page, but with the receivers not being pointers, it causes these methods to be no-ops
