### PR TITLE
feat: Add DateTimePicker in Bubbles

### DIFF
--- a/datetimepicker/datetimepicker.go
+++ b/datetimepicker/datetimepicker.go
@@ -1,0 +1,195 @@
+package datetimepicker
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// KeyMap is the key bindings for different actions within the datetimepicker.
+type KeyMap struct {
+	Increment key.Binding
+	Decrement key.Binding
+	Forward   key.Binding
+	Backward  key.Binding
+	Quit      key.Binding
+}
+
+// DefaultKeyMap is the default set of key bindings for navigating and acting
+// upon the datetimepicker.
+var DefaultKeyMap = KeyMap{
+	Increment: key.NewBinding(key.WithKeys("up")),
+	Decrement: key.NewBinding(key.WithKeys("down")),
+	Forward:   key.NewBinding(key.WithKeys("right")),
+	Backward:  key.NewBinding(key.WithKeys("left")),
+	Quit:      key.NewBinding(key.WithKeys("ctrl+c")),
+}
+
+// PositionType represents the current position (Date, Month, or Year)
+type PositionType int
+
+const (
+	Date PositionType = iota
+	Month
+	Year
+	Hour
+	Minute
+)
+
+// Model is the Bubble Tea model for the date input element.
+type Model struct {
+	Err         error
+	Prompt      string
+	Date        time.Time
+	Format      string
+	PromptStyle lipgloss.Style
+	TextStyle   lipgloss.Style
+	CursorStyle lipgloss.Style
+	Pos         PositionType
+	// KeyMap encodes the keybindings.
+	KeyMap KeyMap
+}
+
+// New creates a new model with default settings.
+func New() Model {
+	return Model{
+		Prompt:      "> ",
+		PromptStyle: lipgloss.NewStyle().Foreground(lipgloss.Color("212")),
+		TextStyle:   lipgloss.NewStyle().Foreground(lipgloss.Color("255")),
+		CursorStyle: lipgloss.NewStyle().Foreground(lipgloss.Color("212")),
+		Pos:         Date,
+		Date:        time.Now(),
+		KeyMap:      DefaultKeyMap,
+	}
+}
+
+// Update is the Bubble Tea update loop.
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+
+		switch {
+		// case to exit the program.
+		case key.Matches(msg, m.KeyMap.Quit):
+			return m, tea.Quit
+
+		case key.Matches(msg, m.KeyMap.Increment):
+			if m.Pos == Date {
+				m.Date = m.Date.AddDate(0, 0, 1) // Increase the date by 1
+			}
+			if m.Pos == Month {
+				m.Date = m.Date.AddDate(0, 1, 0) // Increase the month by 1
+			}
+			if m.Pos == Year {
+				m.Date = m.Date.AddDate(1, 0, 0) // Increase the year by 1
+			}
+			if m.Pos == Hour {
+				m.Date = m.Date.Add(time.Hour) // Increase the minute by 1
+			}
+			if m.Pos == Minute {
+				m.Date = m.Date.Add(time.Minute) // Increase the minute by 1
+			}
+
+		case key.Matches(msg, m.KeyMap.Decrement):
+			if m.Pos == Date {
+				if m.Date.Year() <= 0 && m.Date.Month() <= time.January && m.Date.Day() <= 1 {
+					// Avoid negative year
+				} else {
+					m.Date = m.Date.AddDate(0, 0, -1) // Decrease the date by 1
+				}
+			}
+			if m.Pos == Month {
+				if m.Date.Year() <= 0 && m.Date.Month() <= time.January {
+					// Avoid negative year
+				} else {
+					m.Date = m.Date.AddDate(0, -1, 0) // Decrease the month by 1
+				}
+			}
+			if m.Pos == Year {
+				if m.Date.Year() > 0 {
+					m.Date = m.Date.AddDate(-1, 0, 0) // Decrease the year by 1
+				}
+			}
+			if m.Pos == Hour {
+				m.Date = m.Date.Add(-time.Hour) // Decrease the minute by 1
+			}
+			if m.Pos == Minute {
+				m.Date = m.Date.Add(-time.Minute) // Decrease the minute by 1
+			}
+
+		case key.Matches(msg, m.KeyMap.Forward):
+			if m.Pos < Minute {
+				m.Pos++
+			}
+
+		case key.Matches(msg, m.KeyMap.Backward):
+			if m.Pos > Date {
+				m.Pos--
+			}
+		}
+	}
+
+	// Return the updated model to the Bubble Tea runtime for processing.
+	return m, nil
+}
+
+// View renders the date input in its current state.
+func (m Model) View() string {
+	// Customize styles based on the current position
+	var (
+		dayStyle    = m.TextStyle
+		monthStyle  = m.TextStyle
+		yearStyle   = m.TextStyle
+		hourStyle   = m.TextStyle
+		minuteStyle = m.TextStyle
+	)
+
+	// Apply styles
+	prompt := m.PromptStyle.Render(m.Prompt)
+
+	switch m.Pos {
+	case Date:
+		dayStyle = m.CursorStyle
+	case Month:
+		monthStyle = m.CursorStyle
+	case Year:
+		yearStyle = m.CursorStyle
+	case Hour:
+		hourStyle = m.CursorStyle
+	case Minute:
+		minuteStyle = m.CursorStyle
+	}
+
+	day := m.Date.Day()
+	month := m.Date.Month().String()
+	year := m.Date.Year()
+
+	// Format the date components
+	dayText := fmt.Sprintf("%02d", day)
+	yearText := fmt.Sprintf("%04d", year)
+	timeText := m.Date.Format("03:04 PM")
+
+	text := ""
+	text += dayStyle.Render(dayText) + " " + monthStyle.Render(month) + " " + yearStyle.Render(yearText)
+	text += " | "
+	text += hourStyle.Render(timeText[:2]) + ":" + minuteStyle.Render(timeText[3:5]) + " " + m.TextStyle.Render(timeText[6:])
+	return prompt + text
+}
+
+// SetValue sets the date value of the input.
+func (m *Model) SetValue(date time.Time) {
+	m.Date = date
+}
+
+// Value returns the formatted date value as a string.
+func (m Model) Value() string {
+	return m.Date.Format("02 January 2006 03:04 PM")
+}
+
+// bubbletea Init function
+func (m Model) Init() tea.Cmd {
+	return nil
+}

--- a/datetimepicker/datetimepicker_test.go
+++ b/datetimepicker/datetimepicker_test.go
@@ -1,0 +1,294 @@
+package datetimepicker
+
+import (
+	"testing"
+	"time"
+	"strings"
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestNew(t *testing.T) {
+	picker := New()
+	view := picker.View()
+
+	if picker.Pos != Date {
+		t.Errorf("Expected default position to be Date, got %v", picker.Pos)
+	}
+	if !strings.Contains(view, ">") {
+		t.Log(view)
+		t.Error("datetimepicker did not render the prompt")
+	}
+}
+
+
+func TestUpdate(t *testing.T) {
+	picker := New()
+
+	testCases := []struct {
+		name           string
+		keyMsgs        []tea.Msg
+		expectedPos    PositionType
+		expectedDate   time.Time
+		pickerType     PickerType
+		intializeDate  time.Time
+	}{
+		// Test key bindings.
+		{
+			name: "Left key press",
+			keyMsgs: []tea.Msg{
+				tea.KeyMsg{Type: tea.KeyLeft, Alt: false, Runes: []rune{}},
+			},
+			expectedPos: Date,
+			pickerType: DateTime,
+		},
+		{
+			name: "Right key press",
+			keyMsgs: []tea.Msg{
+				tea.KeyMsg{Type: tea.KeyRight, Alt: false, Runes: []rune{}},
+			},
+			expectedPos: Month,
+			pickerType: DateTime,
+		},
+		{
+			name: "Forward key press for DateOnly picker",
+			keyMsgs: []tea.Msg{
+				tea.KeyMsg{Type: tea.KeyRight, Alt: false, Runes: []rune{}},
+				tea.KeyMsg{Type: tea.KeyRight, Alt: false, Runes: []rune{}},
+				tea.KeyMsg{Type: tea.KeyRight, Alt: false, Runes: []rune{}},
+				tea.KeyMsg{Type: tea.KeyRight, Alt: false, Runes: []rune{}},
+				tea.KeyMsg{Type: tea.KeyRight, Alt: false, Runes: []rune{}},
+				tea.KeyMsg{Type: tea.KeyRight, Alt: false, Runes: []rune{}},
+			},
+			expectedPos: Year,
+			pickerType: DateOnly,
+		},
+		{
+			name: "Backward key press for TimeOnly picker",
+			keyMsgs: []tea.Msg{
+				tea.KeyMsg{Type: tea.KeyLeft, Alt: false, Runes: []rune{}},
+				tea.KeyMsg{Type: tea.KeyLeft, Alt: false, Runes: []rune{}},
+				tea.KeyMsg{Type: tea.KeyLeft, Alt: false, Runes: []rune{}},
+				tea.KeyMsg{Type: tea.KeyLeft, Alt: false, Runes: []rune{}},
+				tea.KeyMsg{Type: tea.KeyLeft, Alt: false, Runes: []rune{}},
+			},
+			expectedPos: Hour,
+			pickerType: TimeOnly,
+		},
+		// Test Increment/Decrement.
+		{
+			name: "Increment Test (Up key)",
+			keyMsgs: []tea.Msg{
+				tea.KeyMsg{Type: tea.KeyUp, Alt: false, Runes: []rune{}},
+			},
+			expectedDate: picker.Date.AddDate(0, 0, 1),
+			pickerType: DateTime,
+		},
+		{
+			name: "Decrement Test : Decrement the month by 1",
+			keyMsgs: []tea.Msg{
+				tea.KeyMsg{Type: tea.KeyRight, Alt: false, Runes: []rune{}},
+				tea.KeyMsg{Type: tea.KeyDown, Alt: false, Runes: []rune{}},
+			},
+			expectedDate: time.Date(2024, time.January, 1, 12, 0, 0, 0, time.UTC),
+			pickerType: DateTime,
+			expectedPos: Month,
+			intializeDate: time.Date(2024, time.February, 1, 12, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "Avoid negative years (by decrementing month)",
+			keyMsgs: []tea.Msg{
+				tea.KeyMsg{Type: tea.KeyRight, Alt: false, Runes: []rune{}},
+				tea.KeyMsg{Type: tea.KeyDown, Alt: false, Runes: []rune{}},
+			},
+			expectedDate: time.Date(0, time.January, 1, 23, 59, 0, 0, time.UTC),
+			pickerType: DateTime,
+			intializeDate: time.Date(0, time.January, 1, 23, 59, 0, 0, time.UTC),
+			expectedPos: Month,
+		},
+		{
+			name: "Avoid negative years (by decrementing Date)",
+			keyMsgs: []tea.Msg{
+				tea.KeyMsg{Type: tea.KeyDown, Alt: false, Runes: []rune{}},
+			},
+			expectedDate: time.Date(0, time.January, 1, 23, 59, 0, 0, time.UTC),
+			pickerType: DateTime,
+			intializeDate: time.Date(0, time.January, 1, 23, 59, 0, 0, time.UTC),
+			expectedPos: Date,
+		},
+		{
+			name: "Avoid negative years (by decrementing Year)",
+			keyMsgs: []tea.Msg{
+				tea.KeyMsg{Type: tea.KeyRight, Alt: false, Runes: []rune{}},
+				tea.KeyMsg{Type: tea.KeyRight, Alt: false, Runes: []rune{}},
+				tea.KeyMsg{Type: tea.KeyDown, Alt: false, Runes: []rune{}},
+			},
+			expectedDate: time.Date(0, time.January, 1, 23, 59, 0, 0, time.UTC),
+			pickerType: DateTime,
+			intializeDate: time.Date(0, time.January, 1, 23, 59, 0, 0, time.UTC),
+			expectedPos: Year,
+		},
+		{
+			name: "Avoid negative years (by decrementing Hour)",
+			keyMsgs: []tea.Msg{
+				tea.KeyMsg{Type: tea.KeyRight, Alt: false, Runes: []rune{}},
+				tea.KeyMsg{Type: tea.KeyRight, Alt: false, Runes: []rune{}},
+				tea.KeyMsg{Type: tea.KeyRight, Alt: false, Runes: []rune{}},
+				tea.KeyMsg{Type: tea.KeyDown, Alt: false, Runes: []rune{}},
+			},
+			expectedDate: time.Date(0, time.January, 1, 23, 59, 0, 0, time.UTC),
+			pickerType: DateTime,
+			intializeDate: time.Date(0, time.January, 1, 0, 59, 0, 0, time.UTC),
+			expectedPos: Hour,
+		},
+		{
+			name: "Avoid negative years (by decrementing Minute)",
+			keyMsgs: []tea.Msg{
+				tea.KeyMsg{Type: tea.KeyRight, Alt: false, Runes: []rune{}},
+				tea.KeyMsg{Type: tea.KeyRight, Alt: false, Runes: []rune{}},
+				tea.KeyMsg{Type: tea.KeyRight, Alt: false, Runes: []rune{}},
+				tea.KeyMsg{Type: tea.KeyRight, Alt: false, Runes: []rune{}},
+				tea.KeyMsg{Type: tea.KeyDown, Alt: false, Runes: []rune{}},
+			},
+			expectedDate: time.Date(0, time.January, 1, 23, 59, 0, 0, time.UTC),
+			pickerType: DateTime,
+			intializeDate: time.Date(0, time.January, 1, 0, 0, 0, 0, time.UTC),
+			expectedPos: Minute,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := picker
+			p.SetPickerType(tc.pickerType)
+			if !tc.intializeDate.IsZero() {
+				p.SetValue(tc.intializeDate)
+			}
+			for _, msg := range tc.keyMsgs {
+				pModel, _ := p.Update(msg)
+				p = pModel.(Model)
+			}
+
+			if p.Pos != tc.expectedPos {
+				t.Errorf("Expected position %v after %s, got %v", tc.expectedPos, tc.name, p.Pos)
+			}
+
+			if !tc.expectedDate.IsZero() && p.Date != tc.expectedDate {
+				t.Errorf("Expected date %v after %s, got %v", tc.expectedDate, tc.name, p.Date)
+			}
+		})
+	}
+}
+
+func TestSetValue(t *testing.T) {
+	picker := New()
+
+	// Set date value and check if it's correctly set.
+	newDate := time.Date(2024, time.February, 1, 12, 0, 0, 0, time.UTC)
+	picker.SetValue(newDate)
+	if !picker.Date.Equal(newDate) {
+		t.Error("Expected date value to be set to", newDate)
+	}
+}
+
+func TestSetTimeFormat(t *testing.T) {
+	picker := New()
+
+	// Set time format to 24-hour and check if it's correctly set.
+	picker.SetTimeFormat(Hour24)
+	if picker.TimeFormat != Hour24 {
+		t.Error("Expected time format to be set to 24-hour")
+	}
+
+	// Should auto handle if timeFormat is out of defined enum.
+	picker.SetTimeFormat(-1)
+	if picker.TimeFormat != Hour12 {
+		t.Error("Expected time format to be set to 12-hour")
+	}
+
+	picker.SetTimeFormat(2)
+	if picker.TimeFormat != Hour24 {
+		t.Error("Expected time format to be set to 12-hour")
+	}
+
+}
+
+func TestSetPickerType(t *testing.T) {
+	picker := New()
+
+	// Test 1: Set picker type to TimeOnly and check if it's correctly set.
+	picker.SetPickerType(TimeOnly)
+	if picker.PickerType != TimeOnly {
+		t.Error("Expected picker type to be set to TimeOnly")
+	}
+	if picker.Pos != Hour {
+		t.Error("Expected Pos to be set to Hour")
+	}
+
+	// Test 2: 
+	picker.SetPickerType(DateOnly)
+	if picker.PickerType != DateOnly {
+		t.Error("Expected picker type to be set to DateOnly")
+	}
+	if picker.Pos != Date {
+		t.Error("Expected Pos to be set to Date")
+	}
+ 
+	// Test 3: 
+	picker.SetPickerType(DateTime)
+	if picker.PickerType != DateTime {
+		t.Error("Expected picker type to be set to DateTime")
+	}
+	if picker.Pos != Date {
+		t.Error("Expected Pos to be set to Date")
+	}
+}
+
+func TestValue(t *testing.T) {
+	picker := New()
+
+	// Test value formatting for different picker types and time formats.
+	// Test 1: (DateTime pickerType).
+	inputTime := time.Date(2024, time.February, 1, 12, 0, 0, 0, time.UTC)
+	picker.SetValue(inputTime)
+
+	if err := validateValue(picker, DateTime, inputTime); err != nil {
+		t.Error(err)
+	}
+
+	// Test 2: (DateOnly pickerType).
+	picker.SetPickerType(DateOnly)
+
+	if err := validateValue(picker, DateOnly, inputTime); err != nil {
+		t.Error(err)
+	}
+
+	// Test 3: (TimeOnly pickerType).
+	picker.SetPickerType(TimeOnly)
+
+	if err := validateValue(picker, TimeOnly, inputTime); err != nil {
+		t.Error(err)
+	}
+}
+
+func validateValue(m Model, pickerType PickerType, inputTime time.Time) error {
+	expectedValue := ""
+	if pickerType == DateTime {
+		expectedValue = inputTime.Format("02 January 2006 03:04 PM")
+	} else if pickerType == DateOnly {
+		expectedValue = inputTime.Format("02 January 2006")
+	} else {
+		// TimeOnly.
+		if m.TimeFormat == Hour12 {
+			expectedValue =  inputTime.Format("03:04 PM")
+		} else { // Hour24.
+			expectedValue = inputTime.Format("15:04")
+		}
+	}
+
+	if val := m.Value(); val != expectedValue {
+		return fmt.Errorf("Expected value %s, got %s", expectedValue, val)
+	}
+	return nil
+}


### PR DESCRIPTION
# Introducing DateTimePicker in Bubbles

## Description
This pull request introduces the DateTimePicker component to the Bubbles library. The DateTimePicker now allows users to input both date and time. But in later version you can take either of it (only date or only time) as a input by disabling either of it. Additionally, the current implementation supports a 12-hour time frame, with plans to extend support to a 24-hour format in future releases.

<img width="276" alt="image" src="https://github.com/charmbracelet/bubbles/assets/155895067/b09d10f9-a5fb-4345-b505-ac8711f0fbe8">

## Demo:

https://github.com/charmbracelet/bubbles/assets/155895067/e4fde9e1-adc2-4946-8d4e-8d4e888f06ee


## To-Do:

- [x] Extend support for 24-hour time frame.
- [x]  Enable and disable time or date