### PR TITLE
fix: Bug: SetMode method in cursor library does not handle invalid mode values correctly

### DIFF
--- a/cursor/cursor.go
+++ b/cursor/cursor.go
@@ -138,6 +138,14 @@ func (m Model) Mode() Mode {
 //
 // For available cursor modes, see type CursorMode.
 func (m *Model) SetMode(mode Mode) tea.Cmd {
+	// Adjust the mode value if it's less than 0.
+	if mode < CursorBlink {
+		mode = CursorBlink
+	}
+	// Adjust the mode value if it's greater than 2.
+	if mode > CursorHide {
+		mode = CursorHide
+	}
 	m.mode = mode
 	m.Blink = m.mode == CursorHide || !m.focus
 	if mode == CursorBlink {

--- a/cursor/cursor.go
+++ b/cursor/cursor.go
@@ -138,13 +138,9 @@ func (m Model) Mode() Mode {
 //
 // For available cursor modes, see type CursorMode.
 func (m *Model) SetMode(mode Mode) tea.Cmd {
-	// Adjust the mode value if it's less than 0.
-	if mode < CursorBlink {
-		mode = CursorBlink
-	}
-	// Adjust the mode value if it's greater than 2.
-	if mode > CursorHide {
-		mode = CursorHide
+	// Adjust the mode value if it's value is out of range
+	if mode < CursorBlink || mode > CursorHide {
+		return nil
 	}
 	m.mode = mode
 	m.Blink = m.mode == CursorHide || !m.focus


### PR DESCRIPTION
## Description:
The SetMode method in the cursor library does not handle invalid (out of range values of `Mode` type) mode values correctly. When an invalid mode value is provided, the method should adjust it to a valid value (CursorBlink to CursorHide) or return an error to indicate the issue. However, the current implementation does not enforce this behavior, potentially leading to unexpected results.

## Steps to Reproduce:

- Instantiate a cursor model.
- Call the SetMode method with an invalid mode value (e.g., less than CursorBlink or greater than CursorHide). `cursor.SetMode(-1)`
- Verify the behavior of the method.

## Expected Behavior:

If an invalid mode value is provided, the SetMode method should either adjust it to a valid value within the range (CursorBlink to CursorHide) or return an error to indicate the issue.

## Actual Behavior:

The SetMode method does not handle invalid mode values correctly. It does not adjust the provided mode value or return an error, potentially leading to unexpected behavior.

## Proposed Solution:
Adjust the SetMode method to validate the provided mode value and adjust it to a valid value within the range (CursorBlink to CursorHide). 
(another solution could be throwing error if input values are out range)