### PR TITLE
fix(textarea): Fix end of buffer character

### DIFF
--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -1138,10 +1138,7 @@ func (m Model) View() string {
 		s.WriteString(prompt)
 		displayLine++
 
-		if m.ShowLineNumbers {
-			lineNumber := m.style.EndOfBuffer.Render(string(m.EndOfBufferCharacter))
-			s.WriteString(lineNumber)
-		}
+		s.WriteString(m.style.EndOfBuffer.Render(string(m.EndOfBufferCharacter)))
 		s.WriteRune('\n')
 	}
 

--- a/textarea/textarea_test.go
+++ b/textarea/textarea_test.go
@@ -478,11 +478,11 @@ func TestView(t *testing.T) {
 			},
 			expected: heredoc.Doc(`
 				> the first line
-				>
-				>
-				>
-				>
-				>
+				> ~
+				> ~
+				> ~
+				> ~
+				> ~
 			`),
 		},
 		{
@@ -497,9 +497,9 @@ func TestView(t *testing.T) {
 				> the first line
 				> the second line
 				> the third line
-				>
-				>
-				>
+				> ~
+				> ~
+				> ~
 			`),
 		},
 		{
@@ -547,11 +547,11 @@ func TestView(t *testing.T) {
 			},
 			expected: heredoc.Doc(`
 				> the first line
-				>
-				>
-				>
-				>
-				>
+				> *
+				> *
+				> *
+				> *
+				> *
 			`),
 		},
 		{
@@ -567,9 +567,9 @@ func TestView(t *testing.T) {
 				> the first line
 				> the second line
 				> the third line
-				>
-				>
-				>
+				> *
+				> *
+				> *
 			`),
 		},
 		{


### PR DESCRIPTION
The end of buffer character was not being rendered when line numbers were not enabled.

When the new test tables unit tests were created this issue was identified however to limit the scope of those changes to just creating unit tests, this regression was maintained.

This change fixes this issue and updates the tests to the intended result.