### PR TITLE
Fix division by zero in viewport scrollpercentage calculation

### DIFF
--- a/viewport/viewport.go
+++ b/viewport/viewport.go
@@ -92,7 +92,7 @@ func (m Model) ScrollPercent() float64 {
 	}
 	y := float64(m.YOffset)
 	h := float64(m.Height)
-	t := float64(len(m.lines) - 1)
+	t := float64(len(m.lines))
 	v := y / (t - h)
 	return math.Max(0.0, math.Min(1.0, v))
 }


### PR DESCRIPTION
In the current implementation one gets a division by zero in case `len(m.lines) == m.Height + 1`, which in turn makes the function return `NaN`.
Removing the `-1` does avoid this error and still yields sensible results.