### PR TITLE
Fix textinput.CurrentSuggestion() panic

### DIFF
--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -830,7 +830,16 @@ func (m *Model) AvailableSuggestions() []string {
 
 // CurrentSuggestion returns the currently selected suggestion.
 func (m *Model) CurrentSuggestion() string {
-	return string(m.matchedSuggestions[m.currentSuggestionIndex])
+	if len(m.matchedSuggestions) < 1 {
+		return ""
+	}
+
+	s := m.matchedSuggestions[m.currentSuggestionIndex]
+	if s == nil {
+		return ""
+	}
+
+	return string(s)
 }
 
 // canAcceptSuggestion returns whether there is an acceptable suggestion to

--- a/textinput/textinput_test.go
+++ b/textinput/textinput_test.go
@@ -1,0 +1,32 @@
+package textinput
+
+import (
+	"testing"
+)
+
+func Test_CurrentSuggestion(t *testing.T) {
+	textinput := New()
+	textinput.ShowSuggestions = true
+
+	suggestion := textinput.CurrentSuggestion()
+	expected := ""
+	if suggestion != expected {
+		t.Fatalf("Error: expected no current suggestion but was %s", suggestion)
+	}
+
+	textinput.SetSuggestions([]string{"test1", "test2", "test3"})
+	suggestion = textinput.CurrentSuggestion()
+	expected = ""
+	if suggestion != expected {
+		t.Fatalf("Error: expected no current suggestion but was %s", suggestion)
+	}
+
+	textinput.SetValue("test")
+	textinput.updateSuggestions()
+	textinput.nextSuggestion()
+	suggestion = textinput.CurrentSuggestion()
+	expected = "test2"
+	if suggestion != expected {
+		t.Fatalf("Error: expected first suggestion but was %s", suggestion)
+	}
+}


### PR DESCRIPTION
When suggestions are not yet set CurrentSuggestion() will panic. This change fixes that with a guard and returns an empty string when there is no current suggestion.

I added a test to ensure the fix works.