### PR TITLE
feat(key): add support for Help callback

### DIFF
--- a/help/help.go
+++ b/help/help.go
@@ -121,7 +121,7 @@ func (m Model) ShortHelpView(bindings []key.Binding) string {
 	var separator = m.Styles.ShortSeparator.Inline(true).Render(m.ShortSeparator)
 
 	for i, kb := range bindings {
-		if !kb.Enabled() {
+		if !kb.Enabled() || !kb.HelpAvailable() {
 			continue
 		}
 
@@ -188,7 +188,7 @@ func (m Model) FullHelpView(groups [][]key.Binding) string {
 
 		// Separate keys and descriptions into different slices
 		for _, kb := range group {
-			if !kb.Enabled() {
+			if !kb.Enabled() || !kb.HelpAvailable() {
 				continue
 			}
 			keys = append(keys, kb.Help().Key)

--- a/key/key_test.go
+++ b/key/key_test.go
@@ -1,26 +1,160 @@
 package key
 
 import (
+	"math/bits"
 	"testing"
 )
 
+type optConfig uint
+
+const (
+	optWithKeys = optConfig(1) << iota
+	optWithHelp
+	optWithDisabled
+)
+const optNone = optConfig(0)
+
+type bindingTest struct {
+	desc string
+	bin  Binding
+	ok   bool
+}
+
+func (o *optConfig) next() optConfig {
+	c := optConfig(1) << bits.TrailingZeros(uint(*o))
+	*o &^= c // clear optConfig at LSB
+	return c
+}
+
+func makeBinding(o ...optConfig) Binding {
+	opt := []BindingOpt{}
+	for _, c := range o {
+		for c > 0 {
+			switch c.next() {
+			case optWithKeys:
+				opt = append(opt, WithKeys("k", "up"))
+			case optWithHelp:
+				opt = append(opt, WithHelp("↑/k", "move up"))
+			case optWithDisabled:
+				opt = append(opt, WithDisabled())
+			}
+		}
+	}
+	return NewBinding(opt...)
+}
+
 func TestBinding_Enabled(t *testing.T) {
-	binding := NewBinding(
-		WithKeys("k", "up"),
-		WithHelp("↑/k", "move up"),
-	)
-	if !binding.Enabled() {
-		t.Errorf("expected key to be Enabled")
+	for _, tc := range []bindingTest{
+		{
+			desc: "WithKeys",
+			bin: makeBinding(optWithKeys),
+			ok: true,
+		},
+		{
+			desc: "WithKeys, WithHelp",
+			bin: makeBinding(optWithKeys | optWithHelp),
+			ok: true,
+		},
+		{
+			desc: "WithHelp",
+			bin: makeBinding(optWithHelp),
+			ok: true,
+		},
+		{
+			desc: "",
+			bin: makeBinding(),
+			ok: true,
+		},
+		{
+			desc: "WithDisabled, WithKeys",
+			bin: makeBinding(optWithDisabled | optWithKeys),
+			ok: false,
+		},
+		{
+			desc: "WithDisabled, WithKeys, WithHelp",
+			bin: makeBinding(optWithDisabled | optWithKeys | optWithHelp),
+			ok: false,
+		},
+		{
+			desc: "WithDisabled, WithHelp",
+			bin: makeBinding(optWithDisabled | optWithHelp),
+			ok: false,
+		},
+		{
+			desc: "WithDisabled",
+			bin: makeBinding(optWithDisabled),
+			ok: false,
+		},
+	} {
+		if tc.bin.Enabled() != tc.ok {
+			t.Errorf("bin.Enabled(%s) != %t", tc.desc, tc.ok)
+		}
+		tc.bin.SetEnabled(!tc.ok)
+		if tc.bin.Enabled() == tc.ok {
+			t.Errorf("bin.Enabled(%s) != %t", tc.desc, !tc.ok)
+		}
+		tc.bin.SetEnabled(true)
+		tc.bin.Unbind()
+		if tc.bin.Enabled() {
+			t.Errorf("bin.Enabled(%s) != %t", tc.desc, false)
+		}
 	}
+}
 
-	binding.SetEnabled(false)
-	if binding.Enabled() {
-		t.Errorf("expected key not to be Enabled")
-	}
-
-	binding.SetEnabled(true)
-	binding.Unbind()
-	if binding.Enabled() {
-		t.Errorf("expected key not to be Enabled")
+func TestBinding_HelpAvailable(t *testing.T) {
+	for _, tc := range []bindingTest{
+		{
+			desc: "WithKeys",
+			bin: makeBinding(optWithKeys),
+			ok: false,
+		},
+		{
+			desc: "WithKeys, WithHelp",
+			bin: makeBinding(optWithKeys | optWithHelp),
+			ok: true,
+		},
+		{
+			desc: "WithHelp",
+			bin: makeBinding(optWithHelp),
+			ok: true,
+		},
+		{
+			desc: "",
+			bin: makeBinding(),
+			ok: false,
+		},
+		{
+			desc: "WithDisabled, WithKeys",
+			bin: makeBinding(optWithDisabled | optWithKeys),
+			ok: false,
+		},
+		{
+			desc: "WithDisabled, WithKeys, WithHelp",
+			bin: makeBinding(optWithDisabled | optWithKeys | optWithHelp),
+			ok: true,
+		},
+		{
+			desc: "WithDisabled, WithHelp",
+			bin: makeBinding(optWithDisabled | optWithHelp),
+			ok: true,
+		},
+		{
+			desc: "WithDisabled",
+			bin: makeBinding(optWithDisabled),
+			ok: false,
+		},
+	} {
+		if tc.bin.HelpAvailable() != tc.ok {
+			t.Errorf("bin.HelpAvailable(%s) != %t", tc.desc, tc.ok)
+		}
+		tc.bin.SetEnabled(false)
+		if tc.bin.HelpAvailable() != tc.ok {
+			t.Errorf("bin.HelpAvailable(%s) != %t", tc.desc, tc.ok)
+		}
+		tc.bin.SetEnabled(true)
+		tc.bin.Unbind()
+		if tc.bin.HelpAvailable() {
+			t.Errorf("bin.HelpAvailable(%s) != %t", tc.desc, false)
+		}
 	}
 }


### PR DESCRIPTION
This adds support for user-defined help information on `key.Binding` via callback function. Adding a callback enables more flexibility with displaying help information such as:

- combined multi-key descriptions:
    `←↑↓→ • move cursor`
- instead of:
    `← left • ↑ up • ↓ down • → right`

The existing API is not changed, and all existing code should continue working as it did prior this change.