### PR TITLE
Table add WithStyleFunc to customize cell styling 

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -14,11 +14,12 @@ import (
 type Model struct {
 	KeyMap KeyMap
 
-	cols   []Column
-	rows   []Row
-	cursor int
-	focus  bool
-	styles Styles
+	cols      []Column
+	rows      []Row
+	cursor    int
+	focus     bool
+	styles    Styles
+	styleFunc TableStyleFunc
 
 	viewport viewport.Model
 	start    int
@@ -185,6 +186,13 @@ func WithFocused(f bool) Option {
 func WithStyles(s Styles) Option {
 	return func(m *Model) {
 		m.styles = s
+	}
+}
+
+// WithStyleFunc sets the table style func which can determine a cell style per column, row, and selected state.
+func WithStyleFunc(f TableStyleFunc) Option {
+	return func(m *Model) {
+		m.styleFunc = f
 	}
 }
 
@@ -397,6 +405,9 @@ func (m *Model) FromValues(value, separator string) {
 	m.SetRows(rows)
 }
 
+// TableStyleFunc is a function that can be used to customize the style of a table cell based on the row and column index.
+type TableStyleFunc func(row, col int, value string) lipgloss.Style
+
 func (m Model) headersView() string {
 	var s = make([]string, 0, len(m.cols))
 	for _, col := range m.cols {
@@ -416,8 +427,15 @@ func (m *Model) renderRow(rowID int) string {
 		if m.cols[i].Width <= 0 {
 			continue
 		}
+		var cellStyle lipgloss.Style
+		if m.styleFunc != nil {
+			cellStyle = m.styleFunc(rowID, i, value)
+		} else {
+			cellStyle = m.styles.Cell
+		}
+
 		style := lipgloss.NewStyle().Width(m.cols[i].Width).MaxWidth(m.cols[i].Width).Inline(true)
-		renderedCell := m.styles.Cell.Render(style.Render(runewidth.Truncate(value, m.cols[i].Width, "…")))
+		renderedCell := cellStyle.Render(style.Render(runewidth.Truncate(value, m.cols[i].Width, "…")))
 		s = append(s, renderedCell)
 	}
 


### PR DESCRIPTION
This change ports a [customization from lipgloss's table](https://github.com/charmbracelet/lipgloss/blob/29fafad5be923707318d4557fb39e80ffc0fa6ae/table/table.go#L10) to bubbles' table. 

## Option WithStyleFunc

This option lets the user set a style selection func during table creation. 

```go
type TableStyleFunc func(row, col int, value string) lipgloss.Style
```
This func allows the user to customize the style that will appear for each row and col. 

## Example 

It is tricky to commit a demo due to the examples for bubbles being in the bubbletea repository but this diff to the table example creates the result below where the Mexican row is customized to include the flag colors of Mexico.

### Example Diff 

```diff
diff --git a/examples/table/main.go b/examples/table/main.go
index 76736f3..23443ee 100644
--- a/examples/table/main.go
+++ b/examples/table/main.go
@@ -157,13 +157,6 @@ func main() {
                {"100", "Montreal", "Canada", "4,276,526"},
        }
 
-       t := table.New(
-               table.WithColumns(columns),
-               table.WithRows(rows),
-               table.WithFocused(true),
-               table.WithHeight(7),
-       )
-
        s := table.DefaultStyles()
        s.Header = s.Header.
                BorderStyle(lipgloss.NormalBorder()).
@@ -174,7 +167,29 @@ func main() {
                Foreground(lipgloss.Color("229")).
                Background(lipgloss.Color("57")).
                Bold(false)
-       t.SetStyles(s)
+
+       t := table.New(
+               table.WithColumns(columns),
+               table.WithRows(rows),
+               table.WithFocused(true),
+               table.WithHeight(7),
+               table.WithStyles(s),
+               table.WithStyleFunc(func(row, col int, value string) lipgloss.Style {
+                       if row == 5 {
+                               if col == 1 {
+                                       return s.Cell.Copy().Background(lipgloss.Color("#006341"))
+                               } else if col == 2 {
+                                       return s.Cell.Copy().Background(lipgloss.Color("#FFFFFF"))
+                               } else if col == 3 {
+                                       return s.Cell.Copy().Background(lipgloss.Color("#C8102E"))
+                               } else {
+                                       return s.Cell
+                               }
+                       }
+
+                       return s.Cell
+               }),
+       )
```
![image](https://github.com/charmbracelet/bubbles/assets/1565/0449e5ac-168b-4174-8d9f-f9b16b73d3da)
 

## Why 

I am using the table component and wish to customize the cell look based on the column and the content of the value being displayed. It would be nice to have a struct representing the Cell data as a placeholder for this sort of thing but that would be a much bigger and breaking change.

### Cavets 

Selected styling seems to be overridden by my customization. This is what the selected Mexico row looks like:

![image](https://github.com/charmbracelet/bubbles/assets/1565/473b71fa-06ad-491a-b910-e63f2301a349)
