### PR TITLE
[New Component] Crop Viewport with ANSI SGR support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 * [treilik/bubblelister](https://github.com/treilik/bubblelister): An alternate
   list that is scrollable without pagination and has the ability to contain
   other bubbles as list items.
+* [ogios/cropviewport](https://github.com/ogios/cropviewport): Crops view from
+  string given position and size. ANSI SGR supported.
 
 If you’ve built a Bubble you think should be listed here, please create a Pull
 Request. Please note that for a project to be included, it must meet the


### PR DESCRIPTION
Basicly it's a `viewport` without `wrap`, And it's able to move view with some basic vim keys.

repo and exampels:
[ogios/cropviewport](https://github.com/ogios/cropviewport)
[ogios/cropviewport/examples](https://github.com/ogios/cropviewport/blob/master/examples/README.md)

It separate input into `ANSITableList` and `raw string`, and renders them given position and size.

one example of code view:

![code](https://github.com/ogios/clipviewport/assets/96933655/9a5aa10d-40e4-4eb1-a59e-7e6f8600fbae)