### PR TITLE
fix(textinput): slicing outside cap

### DIFF
--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -17,8 +17,10 @@ import (
 )
 
 // Internal messages for clipboard operations.
-type pasteMsg string
-type pasteErrMsg struct{ error }
+type (
+	pasteMsg    string
+	pasteErrMsg struct{ error }
+)
 
 // EchoMode sets the input behavior of the text input field.
 type EchoMode int

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -698,9 +698,11 @@ func (m Model) View() string {
 func (m Model) placeholderView() string {
 	var (
 		v     string
-		p     = []rune(m.Placeholder)
 		style = m.PlaceholderStyle.Inline(true).Render
 	)
+
+	p := make([]rune, m.Width+1)
+	copy(p, []rune(m.Placeholder))
 
 	m.Cursor.TextStyle = m.PlaceholderStyle
 	m.Cursor.SetChar(string(p[:1]))

--- a/textinput/textinput_test.go
+++ b/textinput/textinput_test.go
@@ -30,3 +30,10 @@ func Test_CurrentSuggestion(t *testing.T) {
 		t.Fatalf("Error: expected first suggestion but was %s", suggestion)
 	}
 }
+
+func Test_SlicingOutsideCap(t *testing.T) {
+	textinput := New()
+	textinput.Placeholder = "作業ディレクトリを指定してください"
+	textinput.Width = 32
+	textinput.View()
+}


### PR DESCRIPTION
Fixes: #531
Fixes: https://github.com/charmbracelet/gum/issues/591

### Changes
 - Manually assigned `p` with the size of the `Width + 1` because when you use `var()` to assign, the cap defaults to 32 and thus it is possible to get out of bounds errors.