### PR TITLE
feat: Introduce paginator options

### DIFF
--- a/paginator/paginator.go
+++ b/paginator/paginator.go
@@ -130,9 +130,12 @@ func (m Model) OnFirstPage() bool {
 	return m.Page == 0
 }
 
+// Option is used to set options in New.
+type Option func(*Model)
+
 // New creates a new model with defaults.
-func New() Model {
-	return Model{
+func New(opts ...Option) Model {
+	m := Model{
 		Type:         Arabic,
 		Page:         0,
 		PerPage:      1,
@@ -142,12 +145,32 @@ func New() Model {
 		InactiveDot:  "○",
 		ArabicFormat: "%d/%d",
 	}
+
+	for _, opt := range opts {
+		opt(&m)
+	}
+
+	return m
 }
 
 // NewModel creates a new model with defaults.
 //
 // Deprecated: use [New] instead.
 var NewModel = New
+
+// WithTotalPages sets the total pages.
+func WithTotalPages(totalPages int) Option {
+	return func(m *Model) {
+		m.TotalPages = totalPages
+	}
+}
+
+// WithPerPage sets the total pages.
+func WithPerPage(perPage int) Option {
+	return func(m *Model) {
+		m.PerPage = perPage
+	}
+}
 
 // Update is the Tea update function which binds keystrokes to pagination.
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {

--- a/paginator/paginator_test.go
+++ b/paginator/paginator_test.go
@@ -6,6 +6,32 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
+func TestNew(t *testing.T) {
+	model := New()
+
+	if model.PerPage != 1 {
+		t.Errorf("PerPage = %d, expected %d", model.PerPage, 1)
+	}
+	if model.TotalPages != 1 {
+		t.Errorf("TotalPages = %d, expected %d", model.TotalPages, 1)
+	}
+
+	perPage := 42
+	totalPages := 42
+
+	model = New(
+		WithPerPage(perPage),
+		WithTotalPages(totalPages),
+	)
+
+	if model.PerPage != perPage {
+		t.Errorf("PerPage = %d, expected %d", model.PerPage, perPage)
+	}
+	if model.TotalPages != totalPages {
+		t.Errorf("TotalPages = %d, expected %d", model.TotalPages, totalPages)
+	}
+}
+
 func TestSetTotalPages(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
Introduce paginator options, to ease instanciation.

```go
p := paginator.New(
	paginator.WithPerPage(42),
	paginator.WithTotalPages(42),
)
```

Only these two options has been added, but other could be easily added now that the foundations has been laid :)

Note: to be honnest, i don't know if you prefer such integration, or the "chain" one like:
```go
p := paginator.New().WithPerPage(42).WithTotalPages(42)
```

I see bof of them in current charmbracelet ecosystem, just tell me :)