### PR TITLE
fix: progress spring defaults should't override WithStringOptions

### DIFF
--- a/progress/progress.go
+++ b/progress/progress.go
@@ -187,13 +187,15 @@ func New(opts ...Option) Model {
 		PercentFormat:  " %3.0f%%",
 		colorProfile:   termenv.ColorProfile(),
 	}
-	if !m.springCustomized {
-		m.SetSpringOptions(defaultFrequency, defaultDamping)
-	}
 
 	for _, opt := range opts {
 		opt(&m)
 	}
+
+	if !m.springCustomized {
+		m.SetSpringOptions(defaultFrequency, defaultDamping)
+	}
+
 	return m
 }
 


### PR DESCRIPTION
In progress component constructor, default spring option must be handled *after*  applying options :)

Indeed, the `springCustomized` variable is set by the option `WithSpringOptions`.