### PR TITLE
feat: make progress use lipgloss styles

### DIFF
--- a/progress/progress_test.go
+++ b/progress/progress_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/termenv"
 )
 
@@ -11,7 +12,55 @@ const (
 	AnsiReset = "\x1b[0m"
 )
 
+func TestSolid(t *testing.T) {
+	r := lipgloss.DefaultRenderer()
+	r.SetColorProfile(termenv.TrueColor)
+
+	tests := []struct {
+		name     string
+		width    int
+		expected string
+	}{
+		{
+			name:     "width 3",
+			width:    3,
+			expected: `[38;2;117;113;249m█[0m[38;2;117;113;249m█[0m[38;2;96;96;96m░[0m`,
+		},
+		{
+			name:     "width 5",
+			width:    5,
+			expected: `[38;2;117;113;249m█[0m[38;2;117;113;249m█[0m[38;2;117;113;249m█[0m[38;2;96;96;96m░[0m[38;2;96;96;96m░[0m`,
+		},
+		{
+			name:     "width 50",
+			width:    50,
+			expected: `[38;2;117;113;249m█[0m[38;2;117;113;249m█[0m[38;2;117;113;249m█[0m[38;2;117;113;249m█[0m[38;2;117;113;249m█[0m[38;2;117;113;249m█[0m[38;2;117;113;249m█[0m[38;2;117;113;249m█[0m[38;2;117;113;249m█[0m[38;2;117;113;249m█[0m[38;2;117;113;249m█[0m[38;2;117;113;249m█[0m[38;2;117;113;249m█[0m[38;2;117;113;249m█[0m[38;2;117;113;249m█[0m[38;2;117;113;249m█[0m[38;2;117;113;249m█[0m[38;2;117;113;249m█[0m[38;2;117;113;249m█[0m[38;2;117;113;249m█[0m[38;2;117;113;249m█[0m[38;2;117;113;249m█[0m[38;2;117;113;249m█[0m[38;2;117;113;249m█[0m[38;2;117;113;249m█[0m[38;2;96;96;96m░[0m[38;2;96;96;96m░[0m[38;2;96;96;96m░[0m[38;2;96;96;96m░[0m[38;2;96;96;96m░[0m[38;2;96;96;96m░[0m[38;2;96;96;96m░[0m[38;2;96;96;96m░[0m[38;2;96;96;96m░[0m[38;2;96;96;96m░[0m[38;2;96;96;96m░[0m[38;2;96;96;96m░[0m[38;2;96;96;96m░[0m[38;2;96;96;96m░[0m[38;2;96;96;96m░[0m[38;2;96;96;96m░[0m[38;2;96;96;96m░[0m[38;2;96;96;96m░[0m[38;2;96;96;96m░[0m[38;2;96;96;96m░[0m[38;2;96;96;96m░[0m[38;2;96;96;96m░[0m[38;2;96;96;96m░[0m[38;2;96;96;96m░[0m[38;2;96;96;96m░[0m`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			p := New(
+				WithFillStyles(
+					r.NewStyle().Foreground(lipgloss.Color("#7571F9")),
+					r.NewStyle().Foreground(lipgloss.Color("#606060")),
+				),
+				WithoutPercentage(),
+			)
+			p.Width = test.width
+			res := p.ViewAs(0.5)
+
+			if res != test.expected {
+				t.Errorf("expected view %q, instead got %q", test.expected, res)
+			}
+		})
+	}
+}
+
 func TestGradient(t *testing.T) {
+
+	r := lipgloss.DefaultRenderer()
+	r.SetColorProfile(termenv.TrueColor)
 
 	colA := "#FF0000"
 	colB := "#00FF00"
@@ -21,7 +70,11 @@ func TestGradient(t *testing.T) {
 
 	for _, scale := range []bool{false, true} {
 		opts := []Option{
-			WithColorProfile(termenv.TrueColor), WithoutPercentage(),
+			WithFillStyles(
+				r.NewStyle().Foreground(lipgloss.Color("#7571F9")),
+				r.NewStyle().Foreground(lipgloss.Color("#606060")),
+			),
+			WithoutPercentage(),
 		}
 		if scale {
 			descr = "progress bar with scaled gradient"
@@ -36,17 +89,17 @@ func TestGradient(t *testing.T) {
 
 			// build the expected colors by colorizing an empty string and then cutting off the following reset sequence
 			sb := strings.Builder{}
-			sb.WriteString(termenv.String("").Foreground(p.color(colA)).String())
+			sb.WriteString(r.NewStyle().Foreground(lipgloss.Color(colA)).Render(""))
 			expFirst := strings.Split(sb.String(), AnsiReset)[0]
 			sb.Reset()
-			sb.WriteString(termenv.String("").Foreground(p.color(colB)).String())
+			sb.WriteString(r.NewStyle().Foreground(lipgloss.Color(colB)).Render(""))
 			expLast := strings.Split(sb.String(), AnsiReset)[0]
 
 			for _, width := range []int{3, 5, 50} {
 				p.Width = width
 				res := p.ViewAs(1.0)
 
-				// extract colors from the progrss bar by splitting at p.Full+AnsiReset, leaving us with just the color sequences
+				// extract colors from the progress bar by splitting at p.Full+AnsiReset, leaving us with just the color sequences
 				colors := strings.Split(res, string(p.Full)+AnsiReset)
 
 				// discard the last color, because it is empty (no new color comes after the last char of the bar)


### PR DESCRIPTION
Progress component is not cleanly usable in a lipgloss style driven project, because of its dependencies on termenv colors and color profile. Indeed, Both of them are not directly exposed by lipgloss styles..

Btw, i've managed to make it use lipgloss styles in a backward compatible way \o/

- new `FullStyle` and `EmtpyStyle` variables are introduced, having the default foreground color of `FullColor` and `EmptyColor`
- `FullColor` and `EmptyColor` are deprecated, make their default values to empty string. This way, if they are defined, we can set the foreground during rendering.
- `WithSolidFill` now just apply foreground color to `FullStyle`
- introduce `WithFillStyles` option which set both `FullStyle` and `EmtpyStyle`. It was inspired by `WithFillCharacters`, but can be easily split in both `WithFullStyle` and `WithEmtpyStyle` if you prefer
- `WithColorProfile` is the most touchy part :) It recreates and make them inherit from themselves `FullStyle` and `EmtpyStyle`, but starting from the default renderer, and applies color profile to it

The rest is all about using `FullStyle` and `EmtpyStyle` to render runes, instead of termenv.String.

Happy comments :)