### PR TITLE
fix(list): do not resize FilterInput if it is not sized

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -650,7 +650,9 @@ func (m *Model) setSize(width, height int) {
 	m.width = width
 	m.height = height
 	m.Help.Width = width
-	m.FilterInput.Width = width - promptWidth - lipgloss.Width(m.spinnerView())
+	if m.FilterInput.Width > 0 {
+		m.FilterInput.Width = width - promptWidth - lipgloss.Width(m.spinnerView())
+	}
 	m.updatePagination()
 }
 

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -72,3 +72,24 @@ func TestCustomStatusBarItemName(t *testing.T) {
 		t.Fatalf("Error: expected view to contain %s", expected)
 	}
 }
+
+func TestSetSizeWithoutResizingFilterInput(t *testing.T) {
+	list := New([]Item{}, itemDelegate{}, 10, 10)
+	filterInputWidth := list.FilterInput.Width
+
+	list.SetSize(20, 20)
+	if list.FilterInput.Width != filterInputWidth {
+		t.Fatalf("Error: expected filter input width to remain the same")
+	}
+}
+
+func TestSetSizeWithResizingFilterInput(t *testing.T) {
+	list := New([]Item{}, itemDelegate{}, 10, 10)
+	list.FilterInput.Width = 10
+	filterInputWidth := list.FilterInput.Width
+
+	list.SetSize(100, 100)
+	if list.FilterInput.Width == filterInputWidth {
+		t.Fatalf("Error: expected filter input width to change")
+	}
+}


### PR DESCRIPTION
I was expecting the size of the filter to be 0 after resizing, but changing the size even if I have not resized it causes my UI to break.