### PR TITLE
fix(progress): Change reference from tea.Model to Model in Progress.Update

### DIFF
--- a/progress/progress.go
+++ b/progress/progress.go
@@ -213,7 +213,7 @@ func (m Model) Init() tea.Cmd {
 // SetPercent to create the command you'll need to trigger the animation.
 //
 // If you're rendering with ViewAs you won't need this.
-func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case FrameMsg:
 		if msg.id != m.id || msg.tag != m.tag {


### PR DESCRIPTION
Currently `Progress.Update` returns `tea.Model`, therefore making it incompatible with `progress.Model`, which is the intended type. This PR fixes that.