### PR TITLE
fix(help): wrong full help sep rendering

### DIFF
--- a/help/help.go
+++ b/help/help.go
@@ -124,28 +124,23 @@ func (m Model) ShortHelpView(bindings []key.Binding) string {
 			continue
 		}
 
+		// Sep
 		var sep string
 		if totalWidth > 0 && i < len(bindings) {
 			sep = separator
 		}
 
+		// Item
 		str := sep +
 			m.Styles.ShortKey.Inline(true).Render(kb.Help().Key) + " " +
 			m.Styles.ShortDesc.Inline(true).Render(kb.Help().Desc)
-
 		w := lipgloss.Width(str)
 
-		// If adding this help item would go over the available width, stop
-		// drawing.
-		if m.Width > 0 && totalWidth+w > m.Width {
-			// Although if there's room for an ellipsis, print that.
-			tail := " " + m.Styles.Ellipsis.Inline(true).Render(m.Ellipsis)
-			tailWidth := lipgloss.Width(tail)
-
-			if totalWidth+tailWidth < m.Width {
+		// Tail
+		if tail, ok := m.shouldAddItem(totalWidth, w); !ok {
+			if tail != "" {
 				b.WriteString(tail)
 			}
-
 			break
 		}
 
@@ -170,8 +165,7 @@ func (m Model) FullHelpView(groups [][]key.Binding) string {
 		out []string
 
 		totalWidth int
-		sep        = m.Styles.FullSeparator.Render(m.FullSeparator)
-		sepWidth   = lipgloss.Width(sep)
+		separator  = m.Styles.FullSeparator.Inline(true).Render(m.FullSeparator)
 	)
 
 	// Iterate over groups to build columns
@@ -179,11 +173,16 @@ func (m Model) FullHelpView(groups [][]key.Binding) string {
 		if group == nil || !shouldRenderColumn(group) {
 			continue
 		}
-
 		var (
+			sep          string
 			keys         []string
 			descriptions []string
 		)
+
+		// Sep
+		if totalWidth > 0 && i < len(groups) {
+			sep = separator
+		}
 
 		// Separate keys and descriptions into different slices
 		for _, kb := range group {
@@ -194,31 +193,40 @@ func (m Model) FullHelpView(groups [][]key.Binding) string {
 			descriptions = append(descriptions, kb.Help().Desc)
 		}
 
+		// Column
 		col := lipgloss.JoinHorizontal(lipgloss.Top,
+			sep,
 			m.Styles.FullKey.Render(strings.Join(keys, "\n")),
-			m.Styles.FullKey.Render(" "),
+			" ",
 			m.Styles.FullDesc.Render(strings.Join(descriptions, "\n")),
 		)
+		w := lipgloss.Width(col)
 
-		// Column
-		totalWidth += lipgloss.Width(col)
-		if m.Width > 0 && totalWidth > m.Width {
+		// Tail
+		if tail, ok := m.shouldAddItem(totalWidth, w); !ok {
+			if tail != "" {
+				out = append(out, tail)
+			}
 			break
 		}
 
+		totalWidth += w
 		out = append(out, col)
-
-		// Separator
-		if i < len(group)-1 {
-			totalWidth += sepWidth
-			if m.Width > 0 && totalWidth > m.Width {
-				break
-			}
-			out = append(out, sep)
-		}
 	}
 
 	return lipgloss.JoinHorizontal(lipgloss.Top, out...)
+}
+
+func (m Model) shouldAddItem(totalWidth, width int) (tail string, ok bool) {
+	// If there's room for an ellipsis, print that.
+	if m.Width > 0 && totalWidth+width > m.Width {
+		tail = " " + m.Styles.Ellipsis.Inline(true).Render(m.Ellipsis)
+
+		if totalWidth+lipgloss.Width(tail) < m.Width {
+			return tail, false
+		}
+	}
+	return "", true
 }
 
 func shouldRenderColumn(b []key.Binding) (ok bool) {


### PR DESCRIPTION
No matter the available horizontal space, sometimes the separator for the full help is not rendered. For example:

![image](https://github.com/user-attachments/assets/60b58f2f-883b-47d7-b0ec-efafc4319238)
![image](https://github.com/user-attachments/assets/54b5013e-5680-46c9-b9bf-c95d079864ea)

The issue is that the check if a separator needs to be rendered is done on `group` (the column) and not `groups` (the total columns). With this fixed:

![image](https://github.com/user-attachments/assets/e924efc8-329e-4085-9ed3-b20e6e6a40e4)
![image](https://github.com/user-attachments/assets/d33bd27a-b556-43a0-899f-bd403186abd1)

However, when there is enough space for the separator but not the column itself it renders the separator at the end:
![image](https://github.com/user-attachments/assets/375d9757-ce87-4fa3-86fe-494f141e8ab4)

This PR fixes these 2 issues and matches the behavior of the short help (adding a tail if needed/possible, rendering the separator inline, etc.). Behavior now:
![image](https://github.com/user-attachments/assets/0538624e-a296-4f72-a1e2-fc7397e2643d)
![image](https://github.com/user-attachments/assets/36c3eda1-a5e4-482b-94f4-99bbeea48032)
![image](https://github.com/user-attachments/assets/5e9b9e40-131c-4d70-bed4-04050927da0e)
