### PR TITLE
feat(textinput): expose matched suggestions and index

### DIFF
--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -813,14 +813,27 @@ func (m Model) completionView(offset int) string {
 	return ""
 }
 
-// AvailableSuggestions returns the list of available suggestions.
-func (m *Model) AvailableSuggestions() []string {
-	suggestions := make([]string, len(m.suggestions))
-	for i, s := range m.suggestions {
+func (m *Model) getSuggestions(sugs [][]rune) []string {
+	suggestions := make([]string, len(sugs))
+	for i, s := range sugs {
 		suggestions[i] = string(s)
 	}
-
 	return suggestions
+}
+
+// AvailableSuggestions returns the list of available suggestions.
+func (m *Model) AvailableSuggestions() []string {
+	return m.getSuggestions(m.suggestions)
+}
+
+// MatchedSuggestions returns the list of matched suggestions.
+func (m *Model) MatchedSuggestions() []string {
+	return m.getSuggestions(m.matchedSuggestions)
+}
+
+// CurrentSuggestion returns the currently selected suggestion index.
+func (m *Model) CurrentSuggestionIndex() int {
+	return m.currentSuggestionIndex
 }
 
 // CurrentSuggestion returns the currently selected suggestion.


### PR DESCRIPTION
In its current state, if I want to get the matched suggestions (and their index) I need to recalculate that myself when the bubble already does this for free (as in already available). This allows to use the matching suggestions data to display any sort of custom views.

For example, in its current state, if I want to list the suggestions I only have access to the `Available` ones, and this is all I can display (without recalculating myself):
![image](https://github.com/user-attachments/assets/7ec361b2-19af-428c-bdf6-02d0dd037a8b)
![image](https://github.com/user-attachments/assets/77adba3d-dca7-4a5f-a743-ae12b2b3db33)

With these exposed methods, now I can display more "complex" views, such as:
![image](https://github.com/user-attachments/assets/55a99848-f020-4743-a444-aaa501478fc0)

Pardon the styling, just a placeholder.