### PR TITLE
textarea: quality-of-life stuff

### DIFF
--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -767,10 +767,7 @@ func (m *Model) wordRight() {
 
 func (m *Model) doWordRight(fn func(charIdx int, pos int)) {
 	// Skip spaces forward.
-	for {
-		if m.col < len(m.value[m.row]) && !unicode.IsSpace(m.value[m.row][m.col]) {
-			break
-		}
+	for m.col >= len(m.value[m.row]) || unicode.IsSpace(m.value[m.row][m.col]) {
 		if m.row == len(m.value)-1 && m.col == len(m.value[m.row]) {
 			// End of text.
 			break


### PR DESCRIPTION
This contains a few improvements, generally around enable a background color to be set on the entire `textarea`.

* Styles now inherit from the `Styles.Base`, so you can set a foreground and background color on the base style and have it propagate to the other styles.
* Line number padding is now dynamically calculated based on the maximum number of lines
* End of buffer lines now span the full block allowing the entire row to be styled.

![out](https://github.com/user-attachments/assets/e7ad9a94-aa57-48d1-8234-5f334488c20b)

