### PR TITLE
fix(help): use length of groups, not items within a group, for separator behavior

### DIFF
--- a/help/help.go
+++ b/help/help.go
@@ -209,7 +209,7 @@ func (m Model) FullHelpView(groups [][]key.Binding) string {
 		out = append(out, col)
 
 		// Separator
-		if i < len(group)-1 {
+		if i < len(groups)-1 {
 			totalWidth += sepWidth
 			if m.Width > 0 && totalWidth > m.Width {
 				break


### PR DESCRIPTION
Fixes #568

In the demos below, I'm using `xxxxxx` as the `FullSeparator` to clearly demonstrate the behavior before/after.

<details>
  <summary>Behavior before this fix</summary>

![before fix](https://github.com/user-attachments/assets/b0a88c27-b46b-4bdc-9e4a-1b103aead19a)

</details>

<details>
  <summary>Behavior after this fix:</summary>

![after_fix](https://github.com/user-attachments/assets/cbc42bba-f3e4-4e2f-93e3-c3dda94c721e)

</details>