### PR TITLE
feat(list): implement GlobalIndex helper

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -52,6 +52,7 @@ type ItemDelegate interface {
 }
 
 type filteredItem struct {
+	index   int   // index in the unfiltered list
 	item    Item  // item matched
 	matches []int // rune indices of matched items
 }
@@ -459,6 +460,18 @@ func (m Model) MatchesForItem(index int) []int {
 // entire slice of items.
 func (m Model) Index() int {
 	return m.Paginator.Page*m.Paginator.PerPage + m.cursor
+}
+
+// GlobalIndex returns the index of the currently selected item as it is stored
+// in the unfiltered list of items. This value can be used with SetItem().
+func (m Model) GlobalIndex() int {
+	index := m.Index()
+
+	if m.filteredItems == nil || index >= len(m.filteredItems) {
+		return index
+	}
+
+	return m.filteredItems[index].index
 }
 
 // Cursor returns the index of the cursor on the current page.
@@ -1227,6 +1240,7 @@ func filterItems(m Model) tea.Cmd {
 		filterMatches := []filteredItem{}
 		for _, r := range m.Filter(m.FilterInput.Value(), targets) {
 			filterMatches = append(filterMatches, filteredItem{
+				index:   r.Index,
 				item:    items[r.Index],
 				matches: r.MatchedIndexes,
 			})

--- a/list/list.go
+++ b/list/list.go
@@ -456,8 +456,10 @@ func (m Model) MatchesForItem(index int) []int {
 	return m.filteredItems[index].matches
 }
 
-// Index returns the index of the currently selected item as it appears in the
-// entire slice of items.
+// Index returns the index of the currently selected item as it is stored in the
+// filtered list of items.
+// Using this value with SetItem() might be incorrect, consider using
+// GlobalIndex() instead.
 func (m Model) Index() int {
 	return m.Paginator.Page*m.Paginator.PerPage + m.cursor
 }


### PR DESCRIPTION
This commit introduces a new `filteredItem` field called `index` which stores the index of the filtered item in the unfiltered list. This allows to get at runtime the unfiltered list index for the selected (and possibly filtered) item.

This is the only solution I found to use `SetItem` with a filtered list.

The name `GlobalIndex` might not be ideal, I'm happy to change it to something else. (`UnfilteredIndex`?)

Fixes: #550


<details><summary>Example</summary>

Consider the following code:

```go
package main

import (
	"fmt"
	"io"
	"log"
	"os"

	"github.com/charmbracelet/bubbles/list"
	tea "github.com/charmbracelet/bubbletea"
)

type item struct {
	title   string
	checked bool
}

func (i item) Title() string       { return i.title }
func (_ item) Description() string { return "" }
func (i item) FilterValue() string { return i.title }

type itemDelegate struct{}

func (_ itemDelegate) Height() int                             { return 1 }
func (_ itemDelegate) Spacing() int                            { return 0 }
func (_ itemDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd { return nil }
func (_ itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list.Item) {
	i, ok := listItem.(item)
	if !ok {
		return
	}

	cursor := " "
	if index == m.Index() {
		cursor = ">"
	}

	checked := " "
	if i.checked {
		checked = "x"
	}

	fmt.Fprint(w, cursor+checked+i.title)
}

type model struct {
	list list.Model
}

func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
	switch msg := msg.(type) {

	case tea.KeyMsg:
		switch msg.String() {
		case "q":
			return m, tea.Quit

		case " ":
			log.Print("using global index")
			i := m.list.SelectedItem().(item)
			i.checked = !i.checked
			return m, m.list.SetItem(m.list.GlobalIndex(), i)

		case "x":
			log.Print("using index")
			i := m.list.SelectedItem().(item)
			i.checked = !i.checked
			return m, m.list.SetItem(m.list.Index(), i)
		}
	}

	var cmd tea.Cmd
	m.list, cmd = m.list.Update(msg)
	return m, cmd
}

func (_ model) Init() tea.Cmd { return nil }
func (m model) View() string  { return m.list.View() }

func main() {
	choices := []string{"a", "b1", "b2", "b3", "c"}

	items := make([]list.Item, 0, len(choices))
	for _, i := range choices {
		items = append(items, item{title: i})
	}

	l := list.New(items, itemDelegate{}, 0, 0)
	l.SetHeight(20)

	f, err := tea.LogToFile("debug.log", "debug")
	if err != nil {
		fmt.Println("fatal:", err)
		os.Exit(1)
	}
	defer f.Close()

	model := model{list: l}
	p := tea.NewProgram(model)
	if _, err := p.Run(); err != nil {
		panic(err)
	}

	fmt.Printf("%#v\n", items)
}
```

Selecting with `" "` and `"x"` behaves similarly before filtering. Upon filtering, `"x"` behaves as described in #550 (i.e. wrongly) and `" "` behaves correctly: it updates the correct item in place.


</details>
