### PR TITLE
fix: update position constant in JoinHorizontal

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -418,7 +418,7 @@ func (m Model) headersView() string {
 		renderedCell := style.Render(runewidth.Truncate(col.Title, col.Width, "…"))
 		s = append(s, m.styles.Header.Render(renderedCell))
 	}
-	return lipgloss.JoinHorizontal(lipgloss.Left, s...)
+	return lipgloss.JoinHorizontal(lipgloss.Top, s...)
 }
 
 func (m *Model) renderRow(r int) string {
@@ -442,7 +442,7 @@ func (m *Model) renderRow(r int) string {
 		s = append(s, renderedCell)
 	}
 
-	row := lipgloss.JoinHorizontal(lipgloss.Left, s...)
+	row := lipgloss.JoinHorizontal(lipgloss.Top, s...)
 
 	if r == m.cursor {
 		return m.styles.Selected.Render(row)


### PR DESCRIPTION
This PR fixes: https://github.com/charmbracelet/bubbles/issues/553

Ideally, JoinHorizontal should expect `Top`, `Bottom`, or `Center` positions. This PR fixes the cases where the `Left` position constant was used instead of `Top`.

Also while reviewing the JoinHorizontal function I noticed there were no unit tests for JoinHorizontal, so in the linked PR, I added the unit test for the same in lipgloss.
Lipgloss PR: https://github.com/charmbracelet/lipgloss/pull/346