### PR TITLE
feat(key): accept any stringer interface to match keys

### DIFF
--- a/key/key.go
+++ b/key/key.go
@@ -127,7 +127,7 @@ type Help struct {
 }
 
 // Matches checks if the given KeyMsg matches the given bindings.
-func Matches[T fmt.Stringer](k T, b ...Binding) bool {
+func Matches[Key fmt.Stringer](k Key, b ...Binding) bool {
 	keys := k.String()
 	for _, binding := range b {
 		for _, v := range binding.keys {

--- a/key/key.go
+++ b/key/key.go
@@ -36,9 +36,7 @@
 // to render help text for keystrokes in your views.
 package key
 
-import (
-	tea "github.com/charmbracelet/bubbletea"
-)
+import "fmt"
 
 // Binding describes a set of keybindings and, optionally, their associated
 // help text.
@@ -129,7 +127,7 @@ type Help struct {
 }
 
 // Matches checks if the given KeyMsg matches the given bindings.
-func Matches(k tea.KeyMsg, b ...Binding) bool {
+func Matches[T fmt.Stringer](k T, b ...Binding) bool {
 	keys := k.String()
 	for _, binding := range b {
 		for _, v := range binding.keys {

--- a/key/key.go
+++ b/key/key.go
@@ -126,7 +126,7 @@ type Help struct {
 	Desc string
 }
 
-// Matches checks if the given KeyMsg matches the given bindings.
+// Matches checks if the given key matches the given bindings.
 func Matches[Key fmt.Stringer](k Key, b ...Binding) bool {
 	keys := k.String()
 	for _, binding := range b {


### PR DESCRIPTION
This allows any `fmt.Stringer` interface to match key bindings. We need this in the upcoming v2 changes.