### PR TITLE
fix(table): correctly truncate escaped cells

### DIFF
--- a/table/escape_utils.go
+++ b/table/escape_utils.go
@@ -1,0 +1,126 @@
+package table
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	"github.com/mattn/go-runewidth"
+)
+
+// Much of the following code is credited to https://github.com/MichaelMure/go-term-text.
+
+const (
+	escapeSequenceStart = '\x1b'
+	escapeSequenceEnd   = 'm'
+)
+
+// escapeSequence represents a terminal escape sequence from a string.
+type escapeSequence struct {
+	content string // the literal escape sequence
+	pos     int    // the position of the escape sequence in the un-escaped string
+}
+
+// truncate truncates a string to a given width, replacing the last character with an ellipsis
+// and taking into account escape sequences. The width is the number of cells, not runes.
+func truncate(s string, w int) string {
+	if len(s) == 0 {
+		return s
+	}
+
+	if w <= 0 {
+		return "…"
+	}
+
+	l := lengthWithoutEscapeSequences(s)
+	if l <= w || l == 0 {
+		return s
+	}
+
+	cleaned, escapes := extractEscapeSequences(s)
+	truncated := runewidth.Truncate(cleaned, w-1, "")
+
+	return applyEscapeSequences(truncated, escapes) + "…"
+}
+
+// lengthWithoutEscapeSequences return the length of a string in a terminal, while ignoring terminal escape sequences.
+func lengthWithoutEscapeSequences(s string) int {
+	l := 0
+	inSequence := false
+
+	for _, char := range s {
+		if char == escapeSequenceStart {
+			inSequence = true
+		}
+		if !inSequence {
+			l += runewidth.RuneWidth(char)
+		}
+		if char == escapeSequenceEnd {
+			inSequence = false
+		}
+	}
+
+	return l
+}
+
+// extractEscapeSequences extracts terminal escape sequences from a string and returns the string without
+// escape sequences and a slice of escape sequences. The provided string should not contain '\n' characters.
+func extractEscapeSequences(s string) (string, []escapeSequence) {
+	var sequences []escapeSequence
+	var sb strings.Builder
+
+	pos := 0
+	item := ""
+	occupiedRuneCount := 0
+	inSequence := false
+	for i, r := range []rune(s) {
+		if r == escapeSequenceStart {
+			pos = i
+			item = string(r)
+			inSequence = true
+			continue
+		}
+		if inSequence {
+			item += string(r)
+			if r == escapeSequenceEnd {
+				sequences = append(sequences, escapeSequence{item, pos - occupiedRuneCount})
+				occupiedRuneCount += utf8.RuneCountInString(item)
+				inSequence = false
+			}
+			continue
+		}
+		sb.WriteRune(r)
+	}
+
+	return sb.String(), sequences
+}
+
+// applyEscapeSequences apply the extracted terminal escape sequences to the edited string.
+// Escape sequences need to be ordered by their position.
+// If the position is < 0, the sequence is applied at the beginning of the string.
+// If the position is > len(line), the sequence is applied at the end of the string.
+func applyEscapeSequences(s string, escapes []escapeSequence) string {
+	if len(escapes) == 0 {
+		return s
+	}
+
+	var sb strings.Builder
+
+	currPos := 0
+	currItem := 0
+	for _, r := range s {
+		for currItem < len(escapes) && currPos >= escapes[currItem].pos {
+			sb.WriteString(escapes[currItem].content)
+			currItem++
+		}
+		sb.WriteRune(r)
+		currPos++
+	}
+
+	// Don't forget the trailing escapes, if any.
+	for currItem < len(escapes) {
+		sb.WriteString(escapes[currItem].content)
+		currItem++
+	}
+
+	return sb.String()
+}

--- a/table/escape_utils.go
+++ b/table/escape_utils.go
@@ -28,6 +28,7 @@ func truncate(s string, w int) string {
 	}
 
 	if w <= 0 {
+		// Assumption: we do not want to wrap the ellipsis in the original escape sequences.
 		return "…"
 	}
 
@@ -39,6 +40,7 @@ func truncate(s string, w int) string {
 	cleaned, escapes := extractEscapeSequences(s)
 	truncated := runewidth.Truncate(cleaned, w-1, "")
 
+	// Assumption: we do not want to wrap the ellipsis in the original escape sequences.
 	return applyEscapeSequences(truncated, escapes) + "…"
 }
 

--- a/table/escape_utils_test.go
+++ b/table/escape_utils_test.go
@@ -1,0 +1,381 @@
+package table
+
+import "testing"
+
+func TestTruncate(t *testing.T) {
+	tt := map[string]struct {
+		in    string
+		width int
+		want  string
+	}{
+		"empty string": {
+			in:    "",
+			width: 0,
+			want:  "",
+		},
+		"string without escape sequence; not truncated": {
+			in:    "hello",
+			width: 5,
+			want:  "hello",
+		},
+		"string without escape sequence; truncated": {
+			in:    "hello",
+			width: 3,
+			want:  "he…",
+		},
+		"string with escape sequence; not truncated": {
+			in:    "\x1b[31mhello\x1b[0m",
+			width: 5,
+			want:  "\u001B[31mhello\u001B[0m",
+		},
+		"string with escape sequence; truncated": {
+			// TODO(?): should the ellipsis be included inside the escape sequence?
+
+			in:    "\x1b[31mhello\x1b[0m",
+			width: 3,
+			want:  "\u001B[31mhe\u001B[0m…",
+		},
+		"string with escape sequence and emoji; not truncated": {
+			in:    "\x1b[31m👋\x1b[0m",
+			width: 2,
+			want:  "\u001B[31m👋\u001B[0m",
+		},
+		// TODO: fix the following emoji test case
+		//"string with escape sequence, emoji, and combining character; truncated": {
+		//	// NOTE: The combining character may not be rendered correctly in the test output.
+		//	in:    "\x1b[31m👋\u0308\x1b[0m",
+		//	width: 2,
+		//	want:  "\x1b[31m👋\x1b[0m…",
+		//},
+		//"string with escape sequence, emoji, and non-print character": {
+		//	in:    "\x1b[31m👋\u0000\x1b[0m",
+		//	width: 1,
+		//	want:  "\x1b[31m👋\x1b[0m…",
+		//},
+		"string with double escape sequences; truncated between": {
+			in:    "\x1b[31mhello\x1b[0m\x1b[31mhello\x1b[0m",
+			width: 6,
+			want:  "\u001B[31mhello\u001B[0m\u001B[31m\u001B[0m…",
+		},
+		"string with double escape sequences; truncated inside first": {
+			in:    "\x1b[31mhello\x1b[0m\x1b[31mhello\x1b[0m",
+			width: 3,
+			want:  "\u001B[31mhe\u001B[0m\u001B[31m\u001B[0m…",
+		},
+		"string with double escape sequences; truncated inside second": {
+			in:    "\x1b[31mhello\x1b[0m\x1b[31mhello\x1b[0m",
+			width: 7,
+			want:  "\u001B[31mhello\u001B[0m\u001B[31mh\u001B[0m…",
+		},
+		"string with newline; truncated before": {
+			in:    "hello\nworld",
+			width: 4,
+			want:  "hel…",
+		},
+		"string with newline; truncated after": {
+			in:    "hello\nworld",
+			width: 8,
+			want:  "hello\nwo…",
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			got := truncate(tc.in, tc.width)
+
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLengthWithoutEscapeSequences(t *testing.T) {
+	tt := map[string]struct {
+		in   string
+		want int
+	}{
+		"empty string": {
+			in:   "",
+			want: 0,
+		},
+		"string without escape sequence": {
+			in:   "hello",
+			want: 5,
+		},
+		"string with escape sequence": {
+			in:   "\x1b[31mhello\x1b[0m",
+			want: 5,
+		},
+		"string with escape sequence and emoji": {
+			in:   "\x1b[31m👋\x1b[0m",
+			want: 2,
+		},
+		"string with escape sequence, emoji, and combining character": {
+			in:   "\x1b[31m👋\u0308\x1b[0m",
+			want: 2,
+		},
+		"string with escape sequence, emoji, and non-print character": {
+			in:   "\x1b[31m👋\u0000\x1b[0m",
+			want: 2,
+		},
+		"string with double escape sequences": {
+			in:   "\x1b[31mhello\x1b[0m\x1b[31mhello\x1b[0m",
+			want: 10,
+		},
+		"string with newline": {
+			in:   "hello\nworld",
+			want: 10,
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			got := lengthWithoutEscapeSequences(tc.in)
+
+			if got != tc.want {
+				t.Errorf("got %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtractEscapeSequences(t *testing.T) {
+	tt := map[string]struct {
+		in            string
+		wantStr       string
+		wantSequences []escapeSequence
+	}{
+		"empty string": {
+			in:            "",
+			wantStr:       "",
+			wantSequences: []escapeSequence{},
+		},
+		"string without escape sequence": {
+			in:            "hello",
+			wantStr:       "hello",
+			wantSequences: []escapeSequence{},
+		},
+		"string with escape sequence": {
+			in:      "\x1b[31mhello\x1b[0m",
+			wantStr: "hello",
+			wantSequences: []escapeSequence{
+				{
+					content: "\x1b[31m",
+					pos:     0,
+				},
+				{
+					content: "\x1b[0m",
+					pos:     5,
+				},
+			},
+		},
+		"string with escape sequence and emoji": {
+			in:      "\x1b[31m👋\x1b[0m",
+			wantStr: "👋",
+			wantSequences: []escapeSequence{
+				{
+					content: "\x1b[31m",
+					pos:     0,
+				},
+				{
+					content: "\x1b[0m",
+					pos:     1,
+				},
+			},
+		},
+		"string with escape sequence, emoji, and combining character": {
+			// NOTE: The combining character may not be rendered correctly in the test output.
+			in:      "\x1b[31m👋\u0308\x1b[0m",
+			wantStr: "👋\u0308",
+			wantSequences: []escapeSequence{
+				{
+					content: "\x1b[31m",
+					pos:     0,
+				},
+				{
+					content: "\x1b[0m",
+					pos:     2,
+				},
+			},
+		},
+		"string with escape sequence, emoji, and non-print character": {
+			in:      "\x1b[31m👋\u0000\x1b[0m",
+			wantStr: "👋\u0000",
+			wantSequences: []escapeSequence{
+				{
+					content: "\x1b[31m",
+					pos:     0,
+				},
+				{
+					content: "\x1b[0m",
+					pos:     2,
+				},
+			},
+		},
+		"string with double escape sequences": {
+			in:      "\x1b[31mhello\x1b[0m\x1b[31mhello\x1b[0m",
+			wantStr: "hellohello",
+			wantSequences: []escapeSequence{
+				{
+					content: "\x1b[31m",
+					pos:     0,
+				},
+				{
+					content: "\x1b[0m",
+					pos:     5,
+				},
+				{
+					content: "\x1b[31m",
+					pos:     5,
+				},
+				{
+					content: "\x1b[0m",
+					pos:     10,
+				},
+			},
+		},
+		"string with newline": {
+			in:            "hello\nworld",
+			wantStr:       "hello\nworld",
+			wantSequences: []escapeSequence{},
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			gotStr, gotSequences := extractEscapeSequences(tc.in)
+
+			if gotStr != tc.wantStr {
+				t.Errorf("string: got %q, want %q", gotStr, tc.wantStr)
+			}
+
+			if len(gotSequences) != len(tc.wantSequences) {
+				t.Errorf("escape sequences: got %d, want %d", len(gotSequences), len(tc.wantSequences))
+			}
+
+			for i := range gotSequences {
+				if gotSequences[i].content != tc.wantSequences[i].content {
+					t.Errorf("sequence %d content: got %q, want %q", i, gotSequences[i].content, tc.wantSequences[i].content)
+				}
+
+				if gotSequences[i].pos != tc.wantSequences[i].pos {
+					t.Errorf("sequence %d pos: got %d, want %d", i, gotSequences[i].pos, tc.wantSequences[i].pos)
+				}
+			}
+		})
+	}
+}
+
+func TestApplyEscapeSequences(t *testing.T) {
+	tt := map[string]struct {
+		in        string
+		sequences []escapeSequence
+		want      string
+	}{
+		"empty string": {
+			in:        "",
+			sequences: []escapeSequence{},
+			want:      "",
+		},
+		"string without escape sequence": {
+			in:        "hello",
+			sequences: []escapeSequence{},
+			want:      "hello",
+		},
+		"string with escape sequence": {
+			in: "hello",
+			sequences: []escapeSequence{
+				{
+					content: "\x1b[31m",
+					pos:     0,
+				},
+				{
+					content: "\x1b[0m",
+					pos:     5,
+				},
+			},
+			want: "\u001B[31mhello\u001B[0m",
+		},
+		"string with escape sequence and emoji": {
+			in: "👋",
+			sequences: []escapeSequence{
+				{
+					content: "\x1b[31m",
+					pos:     0,
+				},
+				{
+					content: "\x1b[0m",
+					pos:     1,
+				},
+			},
+			want: "\u001B[31m👋\u001B[0m",
+		},
+		"string with escape sequence, emoji, and combining character": {
+			// NOTE: The combining character may not be rendered correctly in the test output.
+			in: "👋\u0308",
+			sequences: []escapeSequence{
+				{
+					content: "\x1b[31m",
+					pos:     0,
+				},
+				{
+					content: "\x1b[0m",
+					pos:     2,
+				},
+			},
+			want: "\u001B[31m👋̈\u001B[0m",
+		},
+		"string with escape sequence, emoji, and non-print character": {
+			in: "👋\u0000",
+			sequences: []escapeSequence{
+				{
+					content: "\x1b[31m",
+					pos:     0,
+				},
+				{
+					content: "\x1b[0m",
+					pos:     2,
+				},
+			},
+			want: "\u001B[31m👋\u0000\u001B[0m",
+		},
+		"string with double escape sequences": {
+			in: "hellohello",
+			sequences: []escapeSequence{
+				{
+					content: "\x1b[31m",
+					pos:     0,
+				},
+				{
+					content: "\x1b[0m",
+					pos:     5,
+				},
+				{
+					content: "\x1b[31m",
+					pos:     5,
+				},
+				{
+					content: "\x1b[0m",
+					pos:     10,
+				},
+			},
+			want: "\u001B[31mhello\u001B[0m\u001B[31mhello\u001B[0m",
+		},
+		"string with newline": {
+			in:        "hello\nworld",
+			sequences: []escapeSequence{},
+			want:      "hello\nworld",
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			got := applyEscapeSequences(tc.in, tc.sequences)
+
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/table/escape_utils_test.go
+++ b/table/escape_utils_test.go
@@ -29,8 +29,6 @@ func TestTruncate(t *testing.T) {
 			want:  "\u001B[31mhello\u001B[0m",
 		},
 		"string with escape sequence; truncated": {
-			// TODO(?): should the ellipsis be included inside the escape sequence?
-
 			in:    "\x1b[31mhello\x1b[0m",
 			width: 3,
 			want:  "\u001B[31mhe\u001B[0m…",
@@ -40,18 +38,30 @@ func TestTruncate(t *testing.T) {
 			width: 2,
 			want:  "\u001B[31m👋\u001B[0m",
 		},
-		// TODO: fix the following emoji test case
-		//"string with escape sequence, emoji, and combining character; truncated": {
-		//	// NOTE: The combining character may not be rendered correctly in the test output.
-		//	in:    "\x1b[31m👋\u0308\x1b[0m",
-		//	width: 2,
-		//	want:  "\x1b[31m👋\x1b[0m…",
-		//},
-		//"string with escape sequence, emoji, and non-print character": {
-		//	in:    "\x1b[31m👋\u0000\x1b[0m",
-		//	width: 1,
-		//	want:  "\x1b[31m👋\x1b[0m…",
-		//},
+		"string with escape sequence, emoji, and combining character; not truncated": {
+			// NOTE: The combining character may not be rendered correctly in the test output.
+			// NOTE: The combining character has a width of 0, so it will always be included alongside the preceding character.
+			in:    "\x1b[31m👋\u0308\x1b[0m",
+			width: 2,
+			want:  "\x1b[31m👋\u0308\x1b[0m",
+		},
+		"string with escape sequence, emoji, and combining character; truncated": {
+			// NOTE: The combining character may not be rendered correctly in the test output.
+			// NOTE: The emoji has a width of 2. Truncating in the "middle" of an emoji will remove the entire emoji.
+			in:    "\x1b[31m👋\u0308\x1b[0m",
+			width: 1,
+			want:  "\x1b[31m\x1b[0m…",
+		},
+		"string with escape sequence, emoji, and non-print character; not truncated": {
+			in:    "\x1b[31m👋\u0000\x1b[0m",
+			width: 2,
+			want:  "\x1b[31m👋\u0000\x1b[0m",
+		},
+		"string with escape sequence, emoji, and non-print character; truncated": {
+			in:    "\x1b[31m👋\u0000\x1b[0m",
+			width: 1,
+			want:  "\x1b[31m\x1b[0m…",
+		},
 		"string with double escape sequences; truncated between": {
 			in:    "\x1b[31mhello\x1b[0m\x1b[31mhello\x1b[0m",
 			width: 6,
@@ -106,6 +116,14 @@ func TestLengthWithoutEscapeSequences(t *testing.T) {
 		"string with escape sequence": {
 			in:   "\x1b[31mhello\x1b[0m",
 			want: 5,
+		},
+		"string with emoji": {
+			in:   "👋",
+			want: 2,
+		},
+		"string with combining character": {
+			in:   "\u0308",
+			want: 0,
 		},
 		"string with escape sequence and emoji": {
 			in:   "\x1b[31m👋\x1b[0m",

--- a/table/table.go
+++ b/table/table.go
@@ -8,7 +8,6 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/mattn/go-runewidth"
 )
 
 // Model defines a state for the table widget.
@@ -414,7 +413,7 @@ func (m Model) headersView() string {
 			continue
 		}
 		style := lipgloss.NewStyle().Width(col.Width).MaxWidth(col.Width).Inline(true)
-		renderedCell := style.Render(runewidth.Truncate(col.Title, col.Width, "…"))
+		renderedCell := style.Render(truncate(col.Title, col.Width))
 		s = append(s, m.styles.Header.Render(renderedCell))
 	}
 	return lipgloss.JoinHorizontal(lipgloss.Top, s...)
@@ -427,7 +426,7 @@ func (m *Model) renderRow(r int) string {
 			continue
 		}
 		style := lipgloss.NewStyle().Width(m.cols[i].Width).MaxWidth(m.cols[i].Width).Inline(true)
-		renderedCell := m.styles.Cell.Render(style.Render(runewidth.Truncate(value, m.cols[i].Width, "…")))
+		renderedCell := m.styles.Cell.Render(style.Render(truncate(value, m.cols[i].Width)))
 		s = append(s, renderedCell)
 	}
 


### PR DESCRIPTION
Fixes #502.

This pull request introduces new utility functions for handling terminal escape sequences and updates the table rendering logic to use these utilities. It also includes comprehensive unit tests for the new functions. Much of the new utility functions is derived from [here](https://github.com/MichaelMure/go-term-text) (I made the assumption that this project is aiming for minimal dependencies).

### New Utility Functions for Escape Sequences:

* [`table/escape_utils.go`](diffhunk://#diff-2e6e52417c7ad6c1d0373a98416266aa286c11c2b0923e11e9218972ff8cac8aR1-R126): Added functions to handle terminal escape sequences, including `truncate`, `lengthWithoutEscapeSequences`, `extractEscapeSequences`, and `applyEscapeSequences`.

### Tests for New Utility Functions:

* [`table/escape_utils_test.go`](diffhunk://#diff-e797a43029b1c37f02b132c379a591971d707c62b6eb40a20e0ded2ef976f4fcR1-R381): Added tests for `truncate`, `lengthWithoutEscapeSequences`, `extractEscapeSequences`, and `applyEscapeSequences` to ensure they work correctly with various types of strings, including those with escape sequences, emojis, and combining characters.

### Updates to Table Rendering Logic:

* [`table/table.go`](diffhunk://#diff-fe73c81e8568426b411674a2d6e36dc46725f6b436fd86bb0a1172fdafb2c632L417-R416): Replaced `runewidth.Truncate` with the new `truncate` function in the `headersView` and `renderRow` methods to properly handle escape sequences. [[1]](diffhunk://#diff-fe73c81e8568426b411674a2d6e36dc46725f6b436fd86bb0a1172fdafb2c632L417-R416) [[2]](diffhunk://#diff-fe73c81e8568426b411674a2d6e36dc46725f6b436fd86bb0a1172fdafb2c632L430-R429)

### Assumptions:
* When truncating a string an ellipsis (...) is used. When truncating, any escape sequences from the cut-off portion of the string are instead placed at the end of the truncated string. Closing these is import. The assumption I've made is that when the ellipsis is appended to the truncated string it will not be placed within these closing ellipsis. The consequences this are:
  * If for example the original string was to be colored red. The truncated string will still be colored red however the ellipsis will be the default text color (likely either white or black depending on terminal theme).
  * If the user has used a nonsensical combination of escape sequences which prevents the terminal from rendering the string, the ellipsis will still be shown. This is only true if the user included closing sequences (which is the users' responsibility).