### PR TITLE
chore(lint): update mnd name, remove deprecated directives

### DIFF
--- a/.golangci-soft.yml
+++ b/.golangci-soft.yml
@@ -20,7 +20,7 @@ linters:
     - goconst
     - godot
     - godox
-    - gomnd
+    - mnd
     - gomoddirectives
     - goprintffuncname
     # - lll
@@ -34,14 +34,11 @@ linters:
 
   # disable default linters, they are already enabled in .golangci.yml
   disable:
-    - deadcode
     - errcheck
     - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
     - predeclared

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,4 +28,6 @@ linters:
     - unconvert
     - unparam
     - whitespace
-    - predeclared
+    # We're isabling predeclared because the linter is running a newer version
+    # of Go than then Go module.
+    # - predeclared


### PR DESCRIPTION
Linter output for this change:

* The linter "deadcode" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle
* The linter "structcheck" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle
* The linter "varcheck" is deprecated (step 2) and deactivated. It should be removed from the list of disabled linters. https://golangci-lint.run/product/roadmap/#linter-deprecation-cycle
* The linter 'gomnd' is deprecated (since v1.58.0) due to: The linter has been renamed. Replaced by mnd.