### PR TITLE
(v2) refactor!: viewport: remove deprecated HighPerformanceRendering

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/atotto/clipboard v0.1.4
-	github.com/charmbracelet/bubbletea/v2 v2.0.0-alpha.1
+	github.com/charmbracelet/bubbletea/v2 v2.0.0-alpha.1.0.20240919172237-265996c29bea
 	github.com/charmbracelet/harmonica v0.2.0
 	github.com/charmbracelet/lipgloss v0.13.0
 	github.com/charmbracelet/x/ansi v0.3.2

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWp
 github.com/aymanbagabas/go-udiff v0.2.0/go.mod h1:RE4Ex0qsGkTAJoQdQQCA0uG+nAzJO/pI/QwceO5fgrA=
 github.com/charmbracelet/bubbletea/v2 v2.0.0-alpha.1 h1:OZtpLCsuuPplC+1oyUo+/eAN7e9MC2UyZWKlKrVlUnw=
 github.com/charmbracelet/bubbletea/v2 v2.0.0-alpha.1/go.mod h1:j0gn4ft5CE7NDYNZjAA3hBM8t2OPjI8urxuAD0oR4w8=
+github.com/charmbracelet/bubbletea/v2 v2.0.0-alpha.1.0.20240919172237-265996c29bea h1:i32Z8pIQujNjR2BffDviAnai2L9oLMW7jMd7aCD8Jqg=
+github.com/charmbracelet/bubbletea/v2 v2.0.0-alpha.1.0.20240919172237-265996c29bea/go.mod h1:j0gn4ft5CE7NDYNZjAA3hBM8t2OPjI8urxuAD0oR4w8=
 github.com/charmbracelet/harmonica v0.2.0 h1:8NxJWRWg/bzKqqEaaeFNipOu77YR5t8aSwG4pgaUBiQ=
 github.com/charmbracelet/harmonica v0.2.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
 github.com/charmbracelet/lipgloss v0.13.0 h1:4X3PPeoWEDCMvzDvGmTajSyYPcZM4+y8sCA/SsA3cjw=

--- a/viewport/viewport.go
+++ b/viewport/viewport.go
@@ -42,18 +42,6 @@ type Model struct {
 	// useful for setting borders, margins and padding.
 	Style lipgloss.Style
 
-	// HighPerformanceRendering bypasses the normal Bubble Tea renderer to
-	// provide higher performance rendering. Most of the time the normal Bubble
-	// Tea rendering methods will suffice, but if you're passing content with
-	// a lot of ANSI escape codes you may see improved rendering in certain
-	// terminals with this enabled.
-	//
-	// This should only be used in program occupying the entire terminal,
-	// which is usually via the alternate screen buffer.
-	//
-	// Deprecated: high performance rendering is now deprecated in Bubble Tea.
-	HighPerformanceRendering bool
-
 	initialized bool
 	lines       []string
 }
@@ -126,18 +114,6 @@ func (m Model) visibleLines() (lines []string) {
 	return lines
 }
 
-// scrollArea returns the scrollable boundaries for high performance rendering.
-//
-// XXX: high performance rendering is deprecated in Bubble Tea.
-func (m Model) scrollArea() (top, bottom int) {
-	top = max(0, m.YPosition)
-	bottom = max(top, top+m.Height)
-	if top > 0 && bottom > top {
-		bottom--
-	}
-	return top, bottom
-}
-
 // SetYOffset sets the Y offset.
 func (m *Model) SetYOffset(n int) {
 	m.YOffset = clamp(n, 0, m.maxYOffset())
@@ -145,77 +121,63 @@ func (m *Model) SetYOffset(n int) {
 
 // ViewDown moves the view down by the number of lines in the viewport.
 // Basically, "page down".
-func (m *Model) ViewDown() []string {
+func (m *Model) ViewDown() {
 	if m.AtBottom() {
-		return nil
+		return
 	}
 
-	return m.LineDown(m.Height)
+	m.LineDown(m.Height)
 }
 
 // ViewUp moves the view up by one height of the viewport. Basically, "page up".
-func (m *Model) ViewUp() []string {
+func (m *Model) ViewUp() {
 	if m.AtTop() {
-		return nil
+		return
 	}
 
-	return m.LineUp(m.Height)
+	m.LineUp(m.Height)
 }
 
 // HalfViewDown moves the view down by half the height of the viewport.
-func (m *Model) HalfViewDown() (lines []string) {
+func (m *Model) HalfViewDown() {
 	if m.AtBottom() {
-		return nil
+		return
 	}
 
-	return m.LineDown(m.Height / 2)
+	m.LineDown(m.Height / 2)
 }
 
 // HalfViewUp moves the view up by half the height of the viewport.
-func (m *Model) HalfViewUp() (lines []string) {
+func (m *Model) HalfViewUp() {
 	if m.AtTop() {
-		return nil
+		return
 	}
 
-	return m.LineUp(m.Height / 2)
+	m.LineUp(m.Height / 2)
 }
 
 // LineDown moves the view down by the given number of lines.
-func (m *Model) LineDown(n int) (lines []string) {
+func (m *Model) LineDown(n int) {
 	if m.AtBottom() || n == 0 || len(m.lines) == 0 {
-		return nil
+		return
 	}
 
 	// Make sure the number of lines by which we're going to scroll isn't
 	// greater than the number of lines we actually have left before we reach
 	// the bottom.
 	m.SetYOffset(m.YOffset + n)
-
-	// Gather lines to send off for performance scrolling.
-	//
-	// XXX: high performance rendering is deprecated in Bubble Tea.
-	bottom := clamp(m.YOffset+m.Height, 0, len(m.lines))
-	top := clamp(m.YOffset+m.Height-n, 0, bottom)
-	return m.lines[top:bottom]
 }
 
 // LineUp moves the view down by the given number of lines. Returns the new
 // lines to show.
-func (m *Model) LineUp(n int) (lines []string) {
+func (m *Model) LineUp(n int) {
 	if m.AtTop() || n == 0 || len(m.lines) == 0 {
-		return nil
+		return
 	}
 
 	// Make sure the number of lines by which we're going to scroll isn't
 	// greater than the number of lines we are from the top.
 	m.SetYOffset(m.YOffset - n)
-
-	// Gather lines to send off for performance scrolling.
-	//
-	// XXX: high performance rendering is deprecated in Bubble Tea.
-	top := max(0, m.YOffset)
-	bottom := clamp(m.YOffset+n, 0, m.maxYOffset())
-	return m.lines[top:bottom]
 }
 
 // TotalLineCount returns the total number of lines (both hidden and visible) within the viewport.
@@ -244,106 +206,39 @@ func (m *Model) GotoBottom() (lines []string) {
 	return m.visibleLines()
 }
 
-// Sync tells the renderer where the viewport will be located and requests
-// a render of the current state of the viewport. It should be called for the
-// first render and after a window resize.
-//
-// For high performance rendering only.
-//
-// Deprecated: high performance rendering is deprecated in Bubble Tea.
-func Sync(m Model) tea.Cmd {
-	if len(m.lines) == 0 {
-		return nil
-	}
-	top, bottom := m.scrollArea()
-	return tea.SyncScrollArea(m.visibleLines(), top, bottom)
-}
-
-// ViewDown is a high performance command that moves the viewport up by a given
-// number of lines. Use Model.ViewDown to get the lines that should be rendered.
-// For example:
-//
-//	lines := model.ViewDown(1)
-//	cmd := ViewDown(m, lines)
-func ViewDown(m Model, lines []string) tea.Cmd {
-	if len(lines) == 0 {
-		return nil
-	}
-	top, bottom := m.scrollArea()
-
-	// XXX: high performance rendering is deprecated in Bubble Tea. In a v2 we
-	// won't need to return a command here.
-	return tea.ScrollDown(lines, top, bottom)
-}
-
-// ViewUp is a high performance command the moves the viewport down by a given
-// number of lines height. Use Model.ViewUp to get the lines that should be
-// rendered.
-func ViewUp(m Model, lines []string) tea.Cmd {
-	if len(lines) == 0 {
-		return nil
-	}
-	top, bottom := m.scrollArea()
-
-	// XXX: high performance rendering is deprecated in Bubble Tea. In a v2 we
-	// won't need to return a command here.
-	return tea.ScrollUp(lines, top, bottom)
-}
-
 // Update handles standard message-based viewport updates.
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
-	var cmd tea.Cmd
-	m, cmd = m.updateAsModel(msg)
-	return m, cmd
+	m = m.updateAsModel(msg)
+	return m, nil
 }
 
 // Author's note: this method has been broken out to make it easier to
 // potentially transition Update to satisfy tea.Model.
-func (m Model) updateAsModel(msg tea.Msg) (Model, tea.Cmd) {
+func (m Model) updateAsModel(msg tea.Msg) Model {
 	if !m.initialized {
 		m.setInitialValues()
 	}
-
-	var cmd tea.Cmd
 
 	switch msg := msg.(type) {
 	case tea.KeyPressMsg:
 		switch {
 		case key.Matches(msg, m.KeyMap.PageDown):
-			lines := m.ViewDown()
-			if m.HighPerformanceRendering {
-				cmd = ViewDown(m, lines)
-			}
+			m.ViewDown()
 
 		case key.Matches(msg, m.KeyMap.PageUp):
-			lines := m.ViewUp()
-			if m.HighPerformanceRendering {
-				cmd = ViewUp(m, lines)
-			}
+			m.ViewUp()
 
 		case key.Matches(msg, m.KeyMap.HalfPageDown):
-			lines := m.HalfViewDown()
-			if m.HighPerformanceRendering {
-				cmd = ViewDown(m, lines)
-			}
+			m.HalfViewDown()
 
 		case key.Matches(msg, m.KeyMap.HalfPageUp):
-			lines := m.HalfViewUp()
-			if m.HighPerformanceRendering {
-				cmd = ViewUp(m, lines)
-			}
+			m.HalfViewUp()
 
 		case key.Matches(msg, m.KeyMap.Down):
-			lines := m.LineDown(1)
-			if m.HighPerformanceRendering {
-				cmd = ViewDown(m, lines)
-			}
+			m.LineDown(1)
 
 		case key.Matches(msg, m.KeyMap.Up):
-			lines := m.LineUp(1)
-			if m.HighPerformanceRendering {
-				cmd = ViewUp(m, lines)
-			}
+			m.LineUp(1)
 		}
 
 	case tea.MouseWheelMsg:
@@ -353,32 +248,18 @@ func (m Model) updateAsModel(msg tea.Msg) (Model, tea.Cmd) {
 
 		switch msg.Button {
 		case tea.MouseWheelDown:
-			lines := m.LineDown(m.MouseWheelDelta)
-			if m.HighPerformanceRendering {
-				cmd = ViewDown(m, lines)
-			}
+			m.LineDown(m.MouseWheelDelta)
 
 		case tea.MouseWheelUp:
-			lines := m.LineUp(m.MouseWheelDelta)
-			if m.HighPerformanceRendering {
-				cmd = ViewUp(m, lines)
-			}
+			m.LineUp(m.MouseWheelDelta)
 		}
 	}
 
-	return m, cmd
+	return m
 }
 
 // View renders the viewport into a string.
 func (m Model) View() string {
-	if m.HighPerformanceRendering {
-		// Just send newlines since we're going to be rendering the actual
-		// content separately. We still need to send something that equals the
-		// height of this view so that the Bubble Tea standard renderer can
-		// position anything below this view properly.
-		return strings.Repeat("\n", max(0, m.Height-1))
-	}
-
 	w, h := m.Width, m.Height
 	if sw := m.Style.GetWidth(); sw != 0 {
 		w = min(w, sw)


### PR DESCRIPTION
This breaks the API and removes high performance rendering and its related methods from the viewport package. It changes the API and makes the methods return nothing instead of lines to render.