### PR TITLE
refactor!: remove deprecated references

### DIFF
--- a/help/help.go
+++ b/help/help.go
@@ -89,11 +89,6 @@ func New() Model {
 	}
 }
 
-// NewModel creates a new help view with some useful defaults.
-//
-// Deprecated: use [New] instead.
-var NewModel = New
-
 // Update helps satisfy the Bubble Tea Model interface. It's a no-op.
 func (m Model) Update(_ tea.Msg) (Model, tea.Cmd) {
 	return m, nil

--- a/list/list.go
+++ b/list/list.go
@@ -244,11 +244,6 @@ func New(items []Item, delegate ItemDelegate, width, height int) Model {
 	return m
 }
 
-// NewModel returns a new model with sensible defaults.
-//
-// Deprecated: use [New] instead.
-var NewModel = New
-
 // SetFilteringEnabled enables or disables filtering. Note that this is different
 // from ShowFilter, which merely hides or shows the input view.
 func (m *Model) SetFilteringEnabled(v bool) {

--- a/paginator/paginator.go
+++ b/paginator/paginator.go
@@ -52,17 +52,6 @@ type Model struct {
 
 	// KeyMap encodes the keybindings recognized by the widget.
 	KeyMap KeyMap
-
-	// Deprecated: customize [KeyMap] instead.
-	UsePgUpPgDownKeys bool
-	// Deprecated: customize [KeyMap] instead.
-	UseLeftRightKeys bool
-	// Deprecated: customize [KeyMap] instead.
-	UseUpDownKeys bool
-	// Deprecated: customize [KeyMap] instead.
-	UseHLKeys bool
-	// Deprecated: customize [KeyMap] instead.
-	UseJKKeys bool
 }
 
 // SetTotalPages is a helper function for calculating the total number of pages
@@ -152,11 +141,6 @@ func New(opts ...Option) Model {
 
 	return m
 }
-
-// NewModel creates a new model with defaults.
-//
-// Deprecated: use [New] instead.
-var NewModel = New
 
 // WithTotalPages sets the total pages.
 func WithTotalPages(totalPages int) Option {

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -199,11 +199,6 @@ func New(opts ...Option) Model {
 	return m
 }
 
-// NewModel returns a model with default values.
-//
-// Deprecated: use [New] instead.
-var NewModel = New
-
 // Init exists to satisfy the tea.Model interface.
 func (m Model) Init() (tea.Model, tea.Cmd) {
 	return m, nil

--- a/spinner/spinner.go
+++ b/spinner/spinner.go
@@ -126,11 +126,6 @@ func New(opts ...Option) Model {
 	return m
 }
 
-// NewModel returns a model with default values.
-//
-// Deprecated: use [New] instead.
-var NewModel = New
-
 // TickMsg indicates that the timer has ticked and we should render a frame.
 type TickMsg struct {
 	Time time.Time
@@ -200,14 +195,6 @@ func (m Model) tick(id, tag int) tea.Cmd {
 			tag:  tag,
 		}
 	})
-}
-
-// Tick is the command used to advance the spinner one frame. Use this command
-// to effectively start the spinner.
-//
-// Deprecated: Use [Model.Tick] instead.
-func Tick() tea.Msg {
-	return TickMsg{Time: time.Now()}
 }
 
 // Option is used to set options in New. For example:

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -3,7 +3,6 @@ package textinput
 import (
 	"reflect"
 	"strings"
-	"time"
 	"unicode"
 
 	"github.com/atotto/clipboard"
@@ -93,9 +92,6 @@ type Model struct {
 	EchoCharacter rune
 	Cursor        cursor.Model
 
-	// Deprecated: use [cursor.BlinkSpeed] instead.
-	BlinkSpeed time.Duration
-
 	// Styles. These will be applied as inline styles.
 	//
 	// For an introduction to styling with Lip Gloss see:
@@ -104,9 +100,6 @@ type Model struct {
 	TextStyle        lipgloss.Style
 	PlaceholderStyle lipgloss.Style
 	CompletionStyle  lipgloss.Style
-
-	// Deprecated: use Cursor.Style instead.
-	CursorStyle lipgloss.Style
 
 	// CharLimit is the maximum amount of characters this input element will
 	// accept. If 0 or less, there's no limit.
@@ -172,11 +165,6 @@ func New() Model {
 		pos:         0,
 	}
 }
-
-// NewModel creates a new model with default settings.
-//
-// Deprecated: Use [New] instead.
-var NewModel = New
 
 // SetValue sets the value of the text input.
 func (m *Model) SetValue(s string) {
@@ -771,34 +759,6 @@ func max(a, b int) int {
 		return a
 	}
 	return b
-}
-
-// Deprecated.
-
-// Deprecated: use cursor.Mode.
-type CursorMode int
-
-const (
-	// Deprecated: use cursor.CursorBlink.
-	CursorBlink = CursorMode(cursor.CursorBlink)
-	// Deprecated: use cursor.CursorStatic.
-	CursorStatic = CursorMode(cursor.CursorStatic)
-	// Deprecated: use cursor.CursorHide.
-	CursorHide = CursorMode(cursor.CursorHide)
-)
-
-func (c CursorMode) String() string {
-	return cursor.Mode(c).String()
-}
-
-// Deprecated: use cursor.Mode().
-func (m Model) CursorMode() CursorMode {
-	return CursorMode(m.Cursor.Mode())
-}
-
-// Deprecated: use cursor.SetMode().
-func (m *Model) SetCursorMode(mode CursorMode) tea.Cmd {
-	return m.Cursor.SetMode(cursor.Mode(mode))
 }
 
 func (m Model) completionView(offset int) string {


### PR DESCRIPTION
This removes all the `NewModel` functions from all the bubbles and any deprecated fields and types.