### PR TITLE
feat: add picker component

### DIFF
--- a/picker/intstate.go
+++ b/picker/intstate.go
@@ -3,18 +3,25 @@ package picker
 type IntState struct {
 	min       int
 	max       int
+	selection int
 	ignoreMin bool
 	ignoreMax bool
-	selection int
 }
 
-func NewIntState(min, max int, ignoreMin, ignoreMax bool) *IntState {
+func NewIntState(min, max, selection int, ignoreMin, ignoreMax bool) *IntState {
+	switch {
+	case selection < min && !ignoreMin:
+		selection = min
+	case selection > max && !ignoreMax:
+		selection = max
+	}
+
 	return &IntState{
 		min:       min,
 		max:       max,
 		ignoreMin: ignoreMin,
 		ignoreMax: ignoreMax,
-		selection: min,
+		selection: selection,
 	}
 }
 

--- a/picker/intstate.go
+++ b/picker/intstate.go
@@ -43,7 +43,7 @@ func (s *IntState) Next(canCycle bool) {
 	switch {
 	case s.NextExists():
 		s.selection++
-		
+
 	case canCycle:
 		s.selection = s.min
 	}
@@ -57,4 +57,12 @@ func (s *IntState) Prev(canCycle bool) {
 	case canCycle:
 		s.selection = s.max
 	}
+}
+
+func (s *IntState) JumpForward() {
+	s.selection = s.max
+}
+
+func (s *IntState) JumpBackward() {
+	s.selection = s.min
 }

--- a/picker/intstate.go
+++ b/picker/intstate.go
@@ -29,14 +29,21 @@ func (s *IntState) GetValue() interface{} {
 	return s.selection
 }
 
+func (s *IntState) NextExists() bool {
+	return s.ignoreMax ||
+		s.selection < s.max
+}
+
+func (s *IntState) PrevExists() bool {
+	return s.ignoreMin ||
+		s.selection > s.min
+}
+
 func (s *IntState) Next(canCycle bool) {
 	switch {
-	case s.ignoreMax:
+	case s.NextExists():
 		s.selection++
-
-	case s.selection < s.max:
-		s.selection++
-
+		
 	case canCycle:
 		s.selection = s.min
 	}
@@ -44,10 +51,7 @@ func (s *IntState) Next(canCycle bool) {
 
 func (s *IntState) Prev(canCycle bool) {
 	switch {
-	case s.ignoreMin:
-		s.selection--
-
-	case s.selection > s.min:
+	case s.PrevExists():
 		s.selection--
 
 	case canCycle:

--- a/picker/intstate.go
+++ b/picker/intstate.go
@@ -3,13 +3,17 @@ package picker
 type IntState struct {
 	min       int
 	max       int
+	ignoreMin bool
+	ignoreMax bool
 	selection int
 }
 
-func NewIntState(min, max int) *IntState {
+func NewIntState(min, max int, ignoreMin, ignoreMax bool) *IntState {
 	return &IntState{
 		min:       min,
 		max:       max,
+		ignoreMin: ignoreMin,
+		ignoreMax: ignoreMax,
 		selection: min,
 	}
 }
@@ -20,6 +24,9 @@ func (s *IntState) GetValue() interface{} {
 
 func (s *IntState) Next(canCycle bool) {
 	switch {
+	case s.ignoreMax:
+		s.selection++
+
 	case s.selection < s.max:
 		s.selection++
 
@@ -30,6 +37,9 @@ func (s *IntState) Next(canCycle bool) {
 
 func (s *IntState) Prev(canCycle bool) {
 	switch {
+	case s.ignoreMin:
+		s.selection--
+
 	case s.selection > s.min:
 		s.selection--
 

--- a/picker/intstate.go
+++ b/picker/intstate.go
@@ -1,0 +1,39 @@
+package picker
+
+type IntState struct {
+	min       int
+	max       int
+	selection int
+}
+
+func NewIntState(min, max int) *IntState {
+	return &IntState{
+		min:       min,
+		max:       max,
+		selection: min,
+	}
+}
+
+func (s *IntState) GetValue() interface{} {
+	return s.selection
+}
+
+func (s *IntState) Next(canCycle bool) {
+	switch {
+	case s.selection < s.max:
+		s.selection++
+
+	case canCycle:
+		s.selection = s.min
+	}
+}
+
+func (s *IntState) Prev(canCycle bool) {
+	switch {
+	case s.selection > s.min:
+		s.selection--
+
+	case canCycle:
+		s.selection = s.max
+	}
+}

--- a/picker/intstate_test.go
+++ b/picker/intstate_test.go
@@ -178,6 +178,65 @@ func TestIntState_NextExists(t *testing.T) {
 	}
 }
 
+func TestIntState_PrevExists(t *testing.T) {
+	tt := map[string]struct {
+		state IntState
+		want  bool
+	}{
+		"enforce min; can decrement": {
+			state: IntState{
+				min:       0,
+				max:       10,
+				selection: 1,
+				ignoreMin: false,
+				ignoreMax: false,
+			},
+			want: true,
+		},
+		"enforce min; cannot decrement": {
+			state: IntState{
+				min:       0,
+				max:       10,
+				selection: 0,
+				ignoreMin: false,
+				ignoreMax: false,
+			},
+			want: false,
+		},
+
+		"ignore min; can decrement": {
+			state: IntState{
+				min:       0,
+				max:       10,
+				selection: 1,
+				ignoreMin: true,
+				ignoreMax: false,
+			},
+			want: true,
+		},
+		"ignore min; cannot decrement": {
+			state: IntState{
+				min:       0,
+				max:       10,
+				selection: 0,
+				ignoreMin: true,
+				ignoreMax: false,
+			},
+			want: true,
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			got := tc.state.PrevExists()
+
+			if tc.want != got {
+				t.Errorf("want %v, got %v", tc.want, got)
+			}
+		})
+	}
+}
+
 func TestIntState_Next(t *testing.T) {
 	tt := map[string]struct {
 		state         IntState

--- a/picker/intstate_test.go
+++ b/picker/intstate_test.go
@@ -334,3 +334,87 @@ func TestIntState_Prev(t *testing.T) {
 		})
 	}
 }
+
+func TestIntState_JumpForward(t *testing.T) {
+	tt := map[string]struct {
+		state IntState
+		want  int
+	}{
+		"from min": {
+			state: IntState{
+				min:       0,
+				max:       10,
+				selection: 0,
+			},
+			want: 10,
+		},
+		"from middle": {
+			state: IntState{
+				min:       0,
+				max:       10,
+				selection: 5,
+			},
+			want: 10,
+		},
+		"from max": {
+			state: IntState{
+				min:       0,
+				max:       10,
+				selection: 10,
+			},
+			want: 10,
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			tc.state.JumpForward()
+
+			if tc.want != tc.state.selection {
+				t.Errorf("want %v, got %v", tc.want, tc.state.selection)
+			}
+		})
+	}
+}
+
+func TestIntState_JumpBackward(t *testing.T) {
+	tt := map[string]struct {
+		state IntState
+		want  int
+	}{
+		"from min": {
+			state: IntState{
+				min:       0,
+				max:       10,
+				selection: 0,
+			},
+			want: 0,
+		},
+		"from middle": {
+			state: IntState{
+				min:       0,
+				max:       10,
+				selection: 5,
+			},
+			want: 0,
+		},
+		"from max": {
+			state: IntState{
+				min:       0,
+				max:       10,
+				selection: 10,
+			},
+			want: 0,
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			tc.state.JumpBackward()
+
+			if tc.want != tc.state.selection {
+				t.Errorf("want %v, got %v", tc.want, tc.state.selection)
+			}
+		})
+	}
+}

--- a/picker/intstate_test.go
+++ b/picker/intstate_test.go
@@ -119,6 +119,65 @@ func TestIntState_GetValue(t *testing.T) {
 	}
 }
 
+func TestIntState_NextExists(t *testing.T) {
+	tt := map[string]struct {
+		state IntState
+		want  bool
+	}{
+		"enforce max; can increment": {
+			state: IntState{
+				min:       0,
+				max:       10,
+				selection: 9,
+				ignoreMin: false,
+				ignoreMax: false,
+			},
+			want: true,
+		},
+		"enforce max; cannot increment": {
+			state: IntState{
+				min:       0,
+				max:       10,
+				selection: 10,
+				ignoreMin: false,
+				ignoreMax: false,
+			},
+			want: false,
+		},
+
+		"ignore max; can increment": {
+			state: IntState{
+				min:       0,
+				max:       10,
+				selection: 9,
+				ignoreMin: false,
+				ignoreMax: true,
+			},
+			want: true,
+		},
+		"ignore max; cannot increment": {
+			state: IntState{
+				min:       0,
+				max:       10,
+				selection: 10,
+				ignoreMin: false,
+				ignoreMax: true,
+			},
+			want: true,
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			got := tc.state.NextExists()
+
+			if tc.want != got {
+				t.Errorf("want %v, got %v", tc.want, got)
+			}
+		})
+	}
+}
+
 func TestIntState_Next(t *testing.T) {
 	tt := map[string]struct {
 		state         IntState

--- a/picker/intstate_test.go
+++ b/picker/intstate_test.go
@@ -226,3 +226,111 @@ func TestIntState_Next(t *testing.T) {
 		})
 	}
 }
+
+func TestIntState_Prev(t *testing.T) {
+	tt := map[string]struct {
+		state         IntState
+		canCycle      bool
+		wantSelection int
+	}{
+		"ignore min; cannot decrement; cannot cycle": {
+			state: IntState{
+				min:       -10,
+				max:       0,
+				selection: -10,
+				ignoreMin: true,
+				ignoreMax: false,
+			},
+			canCycle:      false,
+			wantSelection: -11,
+		},
+		"ignore min; cannot decrement; can cycle": {
+			state: IntState{
+				min:       -10,
+				max:       0,
+				selection: -10,
+				ignoreMin: true,
+				ignoreMax: false,
+			},
+			canCycle:      true,
+			wantSelection: -11,
+		},
+		"ignore min; can decrement; cannot cycle": {
+			state: IntState{
+				min:       -11,
+				max:       0,
+				selection: -10,
+				ignoreMin: true,
+				ignoreMax: false,
+			},
+			canCycle:      false,
+			wantSelection: -11,
+		},
+		"ignore min; can decrement; can cycle": {
+			state: IntState{
+				min:       -11,
+				max:       0,
+				selection: -10,
+				ignoreMin: true,
+				ignoreMax: false,
+			},
+			canCycle:      true,
+			wantSelection: -11,
+		},
+
+		"enforce min; cannot decrement; cannot cycle": {
+			state: IntState{
+				min:       -10,
+				max:       0,
+				selection: -10,
+				ignoreMin: false,
+				ignoreMax: false,
+			},
+			canCycle:      false,
+			wantSelection: -10,
+		},
+		"enforce min; cannot decrement; can cycle": {
+			state: IntState{
+				min:       -10,
+				max:       0,
+				selection: -10,
+				ignoreMin: false,
+				ignoreMax: false,
+			},
+			canCycle:      true,
+			wantSelection: 0,
+		},
+		"enforce min; can decrement; cannot cycle": {
+			state: IntState{
+				min:       -11,
+				max:       0,
+				selection: -10,
+				ignoreMin: false,
+				ignoreMax: false,
+			},
+			canCycle:      false,
+			wantSelection: -11,
+		},
+		"enforce min; can decrement; can cycle": {
+			state: IntState{
+				min:       -11,
+				max:       0,
+				selection: -10,
+				ignoreMin: false,
+				ignoreMax: false,
+			},
+			canCycle:      true,
+			wantSelection: -11,
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			tc.state.Prev(tc.canCycle)
+
+			if tc.wantSelection != tc.state.selection {
+				t.Errorf("want %v, got %v", tc.wantSelection, tc.state.selection)
+			}
+		})
+	}
+}

--- a/picker/intstate_test.go
+++ b/picker/intstate_test.go
@@ -118,3 +118,111 @@ func TestIntState_GetValue(t *testing.T) {
 		t.Errorf("want %v, got %v", want, got)
 	}
 }
+
+func TestIntState_Next(t *testing.T) {
+	tt := map[string]struct {
+		state         IntState
+		canCycle      bool
+		wantSelection int
+	}{
+		"ignore max; cannot increment; cannot cycle": {
+			state: IntState{
+				min:       0,
+				max:       10,
+				selection: 10,
+				ignoreMin: false,
+				ignoreMax: true,
+			},
+			canCycle:      false,
+			wantSelection: 11,
+		},
+		"ignore max; cannot increment; can cycle": {
+			state: IntState{
+				min:       0,
+				max:       10,
+				selection: 10,
+				ignoreMin: false,
+				ignoreMax: true,
+			},
+			canCycle:      true,
+			wantSelection: 11,
+		},
+		"ignore max; can increment; cannot cycle": {
+			state: IntState{
+				min:       0,
+				max:       11,
+				selection: 10,
+				ignoreMin: false,
+				ignoreMax: true,
+			},
+			canCycle:      false,
+			wantSelection: 11,
+		},
+		"ignore max; can increment; can cycle": {
+			state: IntState{
+				min:       0,
+				max:       11,
+				selection: 10,
+				ignoreMin: false,
+				ignoreMax: true,
+			},
+			canCycle:      true,
+			wantSelection: 11,
+		},
+
+		"enforce max; cannot increment; cannot cycle": {
+			state: IntState{
+				min:       0,
+				max:       10,
+				selection: 10,
+				ignoreMin: false,
+				ignoreMax: false,
+			},
+			canCycle:      false,
+			wantSelection: 10,
+		},
+		"enforce max; cannot increment; can cycle": {
+			state: IntState{
+				min:       0,
+				max:       10,
+				selection: 10,
+				ignoreMin: false,
+				ignoreMax: false,
+			},
+			canCycle:      true,
+			wantSelection: 0,
+		},
+		"enforce max; can increment; cannot cycle": {
+			state: IntState{
+				min:       0,
+				max:       11,
+				selection: 10,
+				ignoreMin: false,
+				ignoreMax: false,
+			},
+			canCycle:      false,
+			wantSelection: 11,
+		},
+		"enforce max; can increment; can cycle": {
+			state: IntState{
+				min:       0,
+				max:       11,
+				selection: 10,
+				ignoreMin: false,
+				ignoreMax: false,
+			},
+			canCycle:      true,
+			wantSelection: 11,
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			tc.state.Next(tc.canCycle)
+
+			if tc.wantSelection != tc.state.selection {
+				t.Errorf("want %v, got %v", tc.wantSelection, tc.state.selection)
+			}
+		})
+	}
+}

--- a/picker/intstate_test.go
+++ b/picker/intstate_test.go
@@ -101,3 +101,20 @@ func TestNewIntState(t *testing.T) {
 		})
 	}
 }
+
+func TestIntState_GetValue(t *testing.T) {
+	state := IntState{
+		min:       0,
+		max:       10,
+		selection: 5,
+		ignoreMin: false,
+		ignoreMax: false,
+	}
+	want := 5
+
+	got := state.GetValue()
+
+	if want != got {
+		t.Errorf("want %v, got %v", want, got)
+	}
+}

--- a/picker/intstate_test.go
+++ b/picker/intstate_test.go
@@ -1,0 +1,103 @@
+package picker
+
+import "testing"
+
+func TestNewIntState(t *testing.T) {
+	tt := map[string]struct {
+		min           int
+		max           int
+		selection     int
+		ignoreMin     bool
+		ignoreMax     bool
+		wantSelection int
+	}{
+		"select min": {
+			min:           0,
+			max:           2,
+			selection:     0,
+			ignoreMin:     false,
+			ignoreMax:     false,
+			wantSelection: 0,
+		},
+		"select max": {
+			min:           0,
+			max:           2,
+			selection:     2,
+			ignoreMin:     false,
+			ignoreMax:     false,
+			wantSelection: 2,
+		},
+
+		"select less than min": {
+			min:           0,
+			max:           2,
+			selection:     -10,
+			ignoreMin:     false,
+			ignoreMax:     false,
+			wantSelection: 0,
+		},
+		"select less than min; ignore min": {
+			min:           0,
+			max:           2,
+			selection:     -10,
+			ignoreMin:     true,
+			ignoreMax:     false,
+			wantSelection: -10,
+		},
+		"select less than min; ignore max": {
+			min:           0,
+			max:           2,
+			selection:     -10,
+			ignoreMin:     false,
+			ignoreMax:     true,
+			wantSelection: 0,
+		},
+
+		"select greater than max": {
+			min:           0,
+			max:           2,
+			selection:     10,
+			ignoreMin:     false,
+			ignoreMax:     false,
+			wantSelection: 2,
+		},
+		"select greater than max; ignore max": {
+			min:           0,
+			max:           2,
+			selection:     10,
+			ignoreMin:     false,
+			ignoreMax:     true,
+			wantSelection: 10,
+		},
+		"select greater than max; ignore min": {
+			min:           0,
+			max:           2,
+			selection:     10,
+			ignoreMin:     true,
+			ignoreMax:     false,
+			wantSelection: 2,
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			got := NewIntState(tc.min, tc.max, tc.selection, tc.ignoreMin, tc.ignoreMax)
+
+			if got.min != tc.min {
+				t.Errorf("min: got %v, want %v", got.min, tc.min)
+			}
+			if got.max != tc.max {
+				t.Errorf("max: got %v, want %v", got.max, tc.max)
+			}
+			if got.selection != tc.wantSelection {
+				t.Errorf("selection: got %v, want %v", got.selection, tc.wantSelection)
+			}
+			if got.ignoreMin != tc.ignoreMin {
+				t.Errorf("ignoreMin: got %v, want %v", got.ignoreMin, tc.ignoreMin)
+			}
+			if got.ignoreMax != tc.ignoreMax {
+				t.Errorf("ignoreMax: got %v, want %v", got.ignoreMax, tc.ignoreMax)
+			}
+		})
+	}
+}

--- a/picker/keys.go
+++ b/picker/keys.go
@@ -1,0 +1,23 @@
+package picker
+
+import "github.com/charmbracelet/bubbles/key"
+
+// KeyMap defines the structure of this component's key bindings.
+type KeyMap struct {
+	Next key.Binding
+	Prev key.Binding
+}
+
+// DefaultKeyMap returns a default set of key bindings.
+func DefaultKeyMap() KeyMap {
+	return KeyMap{
+		Next: key.NewBinding(
+			key.WithKeys("right", "l"),
+			key.WithHelp("→/l", "next"),
+		),
+		Prev: key.NewBinding(
+			key.WithKeys("left", "h"),
+			key.WithHelp("←/h", "previous"),
+		),
+	}
+}

--- a/picker/keys.go
+++ b/picker/keys.go
@@ -4,8 +4,10 @@ import "github.com/charmbracelet/bubbles/key"
 
 // KeyMap defines the structure of this component's key bindings.
 type KeyMap struct {
-	Next key.Binding
-	Prev key.Binding
+	Next         key.Binding
+	Prev         key.Binding
+	JumpForward  key.Binding
+	JumpBackward key.Binding
 }
 
 // DefaultKeyMap returns a default set of key bindings.
@@ -18,6 +20,14 @@ func DefaultKeyMap() KeyMap {
 		Prev: key.NewBinding(
 			key.WithKeys("left", "h"),
 			key.WithHelp("←/h", "previous"),
+		),
+		JumpForward: key.NewBinding(
+			key.WithKeys("up", "k"),
+			key.WithHelp("↑/k", "jump forward"),
+		),
+		JumpBackward: key.NewBinding(
+			key.WithKeys("down", "j"),
+			key.WithHelp("↓/j", "jump backward"),
 		),
 	}
 }

--- a/picker/liststate.go
+++ b/picker/liststate.go
@@ -42,3 +42,11 @@ func (s *ListState[T]) Prev(canCycle bool) {
 		s.selection = len(s.state) - 1
 	}
 }
+
+func (s *ListState[T]) JumpForward() {
+	s.selection = len(s.state) - 1
+}
+
+func (s *ListState[T]) JumpBackward() {
+	s.selection = 0
+}

--- a/picker/liststate.go
+++ b/picker/liststate.go
@@ -15,9 +15,17 @@ func (s *ListState[T]) GetValue() interface{} {
 	return s.state[s.selection]
 }
 
+func (s *ListState[T]) NextExists() bool {
+	return s.selection < len(s.state)-1
+}
+
+func (s *ListState[T]) PrevExists() bool {
+	return s.selection > 0
+}
+
 func (s *ListState[T]) Next(canCycle bool) {
 	switch {
-	case s.selection < len(s.state)-1:
+	case s.NextExists():
 		s.selection++
 
 	case canCycle:
@@ -27,7 +35,7 @@ func (s *ListState[T]) Next(canCycle bool) {
 
 func (s *ListState[T]) Prev(canCycle bool) {
 	switch {
-	case s.selection > 0:
+	case s.PrevExists():
 		s.selection--
 
 	case canCycle:

--- a/picker/liststate.go
+++ b/picker/liststate.go
@@ -1,0 +1,57 @@
+package picker
+
+import "fmt"
+
+type ListState[T any] struct {
+	state     []T
+	selection int
+	canCycle  bool
+}
+
+func NewListState[T any](state []T, opts ...func(listState *ListState[T])) *ListState[T] {
+	s := &ListState[T]{
+		state: state,
+	}
+
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	return s
+}
+
+func (s *ListState[T]) GetValue() interface{} {
+	return s.state[s.selection]
+}
+
+func (s *ListState[T]) GetDisplayValue() string {
+	return fmt.Sprintf("%v", s.GetValue())
+}
+
+func (s *ListState[T]) Next() {
+	switch {
+	case s.selection < len(s.state)-1:
+		s.selection++
+
+	case s.canCycle:
+		s.selection = 0
+	}
+}
+
+func (s *ListState[T]) Prev() {
+	switch {
+	case s.selection > 0:
+		s.selection--
+
+	case s.canCycle:
+		s.selection = len(s.state) - 1
+	}
+}
+
+// ListState Options --------------------
+
+func WithCycles[T any]() func(state *ListState[T]) {
+	return func(s *ListState[T]) {
+		s.canCycle = true
+	}
+}

--- a/picker/liststate.go
+++ b/picker/liststate.go
@@ -1,57 +1,36 @@
 package picker
 
-import "fmt"
-
 type ListState[T any] struct {
 	state     []T
 	selection int
-	canCycle  bool
 }
 
-func NewListState[T any](state []T, opts ...func(listState *ListState[T])) *ListState[T] {
-	s := &ListState[T]{
+func NewListState[T any](state []T) *ListState[T] {
+	return &ListState[T]{
 		state: state,
 	}
-
-	for _, opt := range opts {
-		opt(s)
-	}
-
-	return s
 }
 
 func (s *ListState[T]) GetValue() interface{} {
 	return s.state[s.selection]
 }
 
-func (s *ListState[T]) GetDisplayValue() string {
-	return fmt.Sprintf("%v", s.GetValue())
-}
-
-func (s *ListState[T]) Next() {
+func (s *ListState[T]) Next(canCycle bool) {
 	switch {
 	case s.selection < len(s.state)-1:
 		s.selection++
 
-	case s.canCycle:
+	case canCycle:
 		s.selection = 0
 	}
 }
 
-func (s *ListState[T]) Prev() {
+func (s *ListState[T]) Prev(canCycle bool) {
 	switch {
 	case s.selection > 0:
 		s.selection--
 
-	case s.canCycle:
+	case canCycle:
 		s.selection = len(s.state) - 1
-	}
-}
-
-// ListState Options --------------------
-
-func WithCycles[T any]() func(state *ListState[T]) {
-	return func(s *ListState[T]) {
-		s.canCycle = true
 	}
 }

--- a/picker/liststate_test.go
+++ b/picker/liststate_test.go
@@ -1,0 +1,137 @@
+package picker
+
+import "testing"
+
+func TestNewListState(t *testing.T) {
+	want := ListState[string]{
+		state: []string{"One", "Two", "Three"},
+	}
+
+	got := NewListState([]string{"One", "Two", "Three"})
+
+	for i := range got.state {
+		if got.state[i] != want.state[i] {
+			t.Errorf("state[%d]: want %v, got %v", i, want.state[i], got.state[i])
+		}
+	}
+
+	if got.selection != 0 {
+		t.Errorf("selection: want 0, got %v", got.selection)
+	}
+}
+
+func TestListState_GetValue(t *testing.T) {
+	state := ListState[string]{
+		state:     []string{"One", "Two", "Three"},
+		selection: 1,
+	}
+	want := "Two"
+
+	got := state.GetValue()
+
+	if want != got {
+		t.Errorf("want %v, got %v", want, got)
+	}
+}
+
+func TestListState_Next(t *testing.T) {
+	tt := map[string]struct {
+		state         ListState[string]
+		canCycle      bool
+		wantSelection int
+	}{
+		"can increment; can cycle": {
+			state: ListState[string]{
+				state:     []string{"One", "Two", "Three"},
+				selection: 1,
+			},
+			canCycle:      true,
+			wantSelection: 2,
+		},
+		"can increment; cannot cycle": {
+			state: ListState[string]{
+				state:     []string{"One", "Two", "Three"},
+				selection: 1,
+			},
+			canCycle:      false,
+			wantSelection: 2,
+		},
+		"cannot increment; can cycle": {
+			state: ListState[string]{
+				state:     []string{"One", "Two", "Three"},
+				selection: 2,
+			},
+			canCycle:      true,
+			wantSelection: 0,
+		},
+		"cannot increment; cannot cycle": {
+			state: ListState[string]{
+				state:     []string{"One", "Two", "Three"},
+				selection: 2,
+			},
+			canCycle:      false,
+			wantSelection: 2,
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			tc.state.Next(tc.canCycle)
+
+			if tc.wantSelection != tc.state.selection {
+				t.Errorf("want %v, got %v", tc.wantSelection, tc.state.selection)
+			}
+		})
+	}
+}
+
+func TestListState_Prev(t *testing.T) {
+	tt := map[string]struct {
+		state         ListState[string]
+		canCycle      bool
+		wantSelection int
+	}{
+		"can decrement; can cycle": {
+			state: ListState[string]{
+				state:     []string{"One", "Two", "Three"},
+				selection: 1,
+			},
+			canCycle:      true,
+			wantSelection: 0,
+		},
+		"can decrement; cannot cycle": {
+			state: ListState[string]{
+				state:     []string{"One", "Two", "Three"},
+				selection: 1,
+			},
+			canCycle:      false,
+			wantSelection: 0,
+		},
+		"cannot decrement; can cycle": {
+			state: ListState[string]{
+				state:     []string{"One", "Two", "Three"},
+				selection: 0,
+			},
+			canCycle:      true,
+			wantSelection: 2,
+		},
+		"cannot decrement; cannot cycle": {
+			state: ListState[string]{
+				state:     []string{"One", "Two", "Three"},
+				selection: 0,
+			},
+			canCycle:      false,
+			wantSelection: 0,
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			tc.state.Prev(tc.canCycle)
+
+			if tc.wantSelection != tc.state.selection {
+				t.Errorf("want %v, got %v", tc.wantSelection, tc.state.selection)
+			}
+		})
+	}
+}

--- a/picker/liststate_test.go
+++ b/picker/liststate_test.go
@@ -34,6 +34,70 @@ func TestListState_GetValue(t *testing.T) {
 	}
 }
 
+func TestListState_NextExists(t *testing.T) {
+	tt := map[string]struct {
+		state ListState[string]
+		want  bool
+	}{
+		"can increment": {
+			state: ListState[string]{
+				state:     []string{"One", "Two", "Three"},
+				selection: 1,
+			},
+			want: true,
+		},
+		"cannot increment": {
+			state: ListState[string]{
+				state:     []string{"One", "Two", "Three"},
+				selection: 2,
+			},
+			want: false,
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			got := tc.state.NextExists()
+
+			if tc.want != got {
+				t.Errorf("want %v, got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestListState_PrevExists(t *testing.T) {
+	tt := map[string]struct {
+		state ListState[string]
+		want  bool
+	}{
+		"can increment": {
+			state: ListState[string]{
+				state:     []string{"One", "Two", "Three"},
+				selection: 1,
+			},
+			want: true,
+		},
+		"cannot increment": {
+			state: ListState[string]{
+				state:     []string{"One", "Two", "Three"},
+				selection: 0,
+			},
+			want: false,
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			got := tc.state.PrevExists()
+
+			if tc.want != got {
+				t.Errorf("want %v, got %v", tc.want, got)
+			}
+		})
+	}
+}
+
 func TestListState_Next(t *testing.T) {
 	tt := map[string]struct {
 		state         ListState[string]

--- a/picker/liststate_test.go
+++ b/picker/liststate_test.go
@@ -199,3 +199,81 @@ func TestListState_Prev(t *testing.T) {
 		})
 	}
 }
+
+func TestListState_JumpForward(t *testing.T) {
+	tt := map[string]struct {
+		state ListState[string]
+		want  int
+	}{
+		"from min": {
+			state: ListState[string]{
+				state:     []string{"One", "Two", "Three"},
+				selection: 0,
+			},
+			want: 2,
+		},
+		"from middle": {
+			state: ListState[string]{
+				state:     []string{"One", "Two", "Three"},
+				selection: 1,
+			},
+			want: 2,
+		},
+		"from max": {
+			state: ListState[string]{
+				state:     []string{"One", "Two", "Three"},
+				selection: 2,
+			},
+			want: 2,
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			tc.state.JumpForward()
+
+			if tc.want != tc.state.selection {
+				t.Errorf("want %v, got %v", tc.want, tc.state.selection)
+			}
+		})
+	}
+}
+
+func TestListState_JumpBackward(t *testing.T) {
+	tt := map[string]struct {
+		state ListState[string]
+		want  int
+	}{
+		"from min": {
+			state: ListState[string]{
+				state:     []string{"One", "Two", "Three"},
+				selection: 0,
+			},
+			want: 0,
+		},
+		"from middle": {
+			state: ListState[string]{
+				state:     []string{"One", "Two", "Three"},
+				selection: 1,
+			},
+			want: 0,
+		},
+		"from max": {
+			state: ListState[string]{
+				state:     []string{"One", "Two", "Three"},
+				selection: 2,
+			},
+			want: 0,
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			tc.state.JumpBackward()
+
+			if tc.want != tc.state.selection {
+				t.Errorf("want %v, got %v", tc.want, tc.state.selection)
+			}
+		})
+	}
+}

--- a/picker/picker.go
+++ b/picker/picker.go
@@ -7,6 +7,9 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
+// Model is a picker component.
+// By default the View method will render it as a horizontal picker.
+// Methods are exposed to get the value and indicators separately, allowing you to build your own UI (vertical, 4-dimensional, etc).
 type Model struct {
 	State          State
 	ShowIndicators bool

--- a/picker/picker.go
+++ b/picker/picker.go
@@ -1,0 +1,17 @@
+package picker
+
+import tea "github.com/charmbracelet/bubbletea"
+
+type Model struct{}
+
+func (m Model) Init() tea.Cmd {
+	return nil
+}
+
+func (m Model) Update(_ tea.Msg) (tea.Model, tea.Cmd) {
+	return m, nil
+}
+
+func (m Model) View() string {
+	return ""
+}

--- a/picker/picker.go
+++ b/picker/picker.go
@@ -11,6 +11,7 @@ type Model struct {
 	State          State
 	ShowIndicators bool
 	CanCycle       bool
+	CanJump        bool
 	DisplayFunc    DisplayFunc
 	Keys           KeyMap
 	Styles         Styles
@@ -24,6 +25,8 @@ type State interface {
 
 	Next(canCycle bool)
 	Prev(canCycle bool)
+	JumpForward()
+	JumpBackward()
 }
 
 type DisplayFunc func(stateValue interface{}) string
@@ -58,8 +61,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch {
 		case key.Matches(msg, m.Keys.Next):
 			m.State.Next(m.CanCycle)
+
 		case key.Matches(msg, m.Keys.Prev):
 			m.State.Prev(m.CanCycle)
+
+		case key.Matches(msg, m.Keys.JumpForward):
+			if m.CanJump {
+				m.State.JumpForward()
+			}
+
+		case key.Matches(msg, m.Keys.JumpBackward):
+			if m.CanJump {
+				m.State.JumpBackward()
+			}
 		}
 	}
 
@@ -138,5 +152,11 @@ func WithDisplayFunc(df DisplayFunc) func(*Model) {
 func WithStyles(s Styles) func(*Model) {
 	return func(m *Model) {
 		m.Styles = s
+	}
+}
+
+func WithJumping() func(*Model) {
+	return func(m *Model) {
+		m.CanJump = true
 	}
 }

--- a/picker/picker.go
+++ b/picker/picker.go
@@ -118,8 +118,8 @@ func (m Model) GetNextIndicator() string {
 	return getIndicator(m.Styles.Next, m.State.NextExists())
 }
 
-func getIndicator(styles IndicatorStyles, exists bool) string {
-	switch exists {
+func getIndicator(styles IndicatorStyles, enabled bool) string {
+	switch enabled {
 	case false:
 		return styles.Disabled.Render(styles.Value)
 	default:

--- a/picker/picker.go
+++ b/picker/picker.go
@@ -7,11 +7,11 @@ import (
 )
 
 type Model struct {
-	state          State
-	showIndicators bool
-	canCycle       bool
-	displayFunc    DisplayFunc
-	keys           KeyMap
+	State          State
+	ShowIndicators bool
+	CanCycle       bool
+	DisplayFunc    DisplayFunc
+	Keys           KeyMap
 }
 
 type State interface {
@@ -28,11 +28,11 @@ func NewModel(state State, opts ...func(*Model)) Model {
 	}
 
 	m := Model{
-		state:          state,
-		showIndicators: true,
-		canCycle:       false,
-		displayFunc:    defaultDisplayFunc,
-		keys:           DefaultKeyMap(),
+		State:          state,
+		ShowIndicators: true,
+		CanCycle:       false,
+		DisplayFunc:    defaultDisplayFunc,
+		Keys:           DefaultKeyMap(),
 	}
 
 	for _, opt := range opts {
@@ -49,10 +49,10 @@ func (m Model) Init() tea.Cmd {
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if msg, ok := msg.(tea.KeyMsg); ok {
 		switch {
-		case key.Matches(msg, m.keys.Next):
-			m.state.Next(m.canCycle)
-		case key.Matches(msg, m.keys.Prev):
-			m.state.Prev(m.canCycle)
+		case key.Matches(msg, m.Keys.Next):
+			m.State.Next(m.CanCycle)
+		case key.Matches(msg, m.Keys.Prev):
+			m.State.Prev(m.CanCycle)
 		}
 	}
 
@@ -61,20 +61,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m Model) View() string {
 	var prevInd, nextInd string
-	if m.showIndicators {
+	if m.ShowIndicators {
 		prevInd = m.GetPrevIndicator()
 		nextInd = m.GetNextIndicator()
 	}
 
-	return fmt.Sprintf("%s%s%s", prevInd, m.GetDisplayValue(), nextInd)
+	return prevInd + m.GetDisplayValue() + nextInd
 }
 
 func (m Model) GetValue() interface{} {
-	return m.state.GetValue()
+	return m.State.GetValue()
 }
 
 func (m Model) GetDisplayValue() string {
-	return m.displayFunc(m.state.GetValue())
+	return m.DisplayFunc(m.State.GetValue())
 }
 
 func (m Model) GetPrevIndicator() string {
@@ -89,24 +89,24 @@ func (m Model) GetNextIndicator() string {
 
 func WithKeys(keys KeyMap) func(*Model) {
 	return func(m *Model) {
-		m.keys = keys
+		m.Keys = keys
 	}
 }
 
 func WithoutIndicators() func(*Model) {
 	return func(m *Model) {
-		m.showIndicators = false
+		m.ShowIndicators = false
 	}
 }
 
 func WithCycles() func(*Model) {
 	return func(m *Model) {
-		m.canCycle = true
+		m.CanCycle = true
 	}
 }
 
 func WithDisplayFunc(df DisplayFunc) func(*Model) {
 	return func(m *Model) {
-		m.displayFunc = df
+		m.DisplayFunc = df
 	}
 }

--- a/picker/picker.go
+++ b/picker/picker.go
@@ -20,7 +20,7 @@ type State interface {
 	Prev(canCycle bool)
 }
 
-type DisplayFunc func(interface{}) string
+type DisplayFunc func(stateValue interface{}) string
 
 func NewModel(state State, opts ...func(*Model)) Model {
 	defaultDisplayFunc := func(v interface{}) string {
@@ -60,17 +60,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) View() string {
-	var leftIndicator, rightIndicator string
+	var prevInd, nextInd string
 	if m.showIndicators {
-		leftIndicator = "<"
-		rightIndicator = ">"
+		prevInd = m.GetPrevIndicator()
+		nextInd = m.GetNextIndicator()
 	}
 
-	var output string
-
-	output += fmt.Sprintf("%s%s%s", leftIndicator, m.GetDisplayValue(), rightIndicator)
-
-	return output
+	return fmt.Sprintf("%s%s%s", prevInd, m.GetDisplayValue(), nextInd)
 }
 
 func (m Model) GetValue() interface{} {
@@ -79,6 +75,14 @@ func (m Model) GetValue() interface{} {
 
 func (m Model) GetDisplayValue() string {
 	return m.displayFunc(m.state.GetValue())
+}
+
+func (m Model) GetPrevIndicator() string {
+	return "<"
+}
+
+func (m Model) GetNextIndicator() string {
+	return ">"
 }
 
 // Model Options --------------------

--- a/picker/picker.go
+++ b/picker/picker.go
@@ -1,17 +1,66 @@
 package picker
 
-import tea "github.com/charmbracelet/bubbletea"
+import (
+	"fmt"
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+)
 
-type Model struct{}
+type Model struct {
+	state State
+
+	keys KeyMap
+}
+
+type State interface {
+	GetValue() interface{}
+	GetDisplayValue() string
+	Next()
+	Prev()
+}
+
+func NewModel(state State, opts ...func(*Model)) Model {
+	m := Model{
+		state: state,
+		keys:  DefaultKeyMap(),
+	}
+
+	for _, opt := range opts {
+		opt(&m)
+	}
+
+	return m
+}
 
 func (m Model) Init() tea.Cmd {
 	return nil
 }
 
-func (m Model) Update(_ tea.Msg) (tea.Model, tea.Cmd) {
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if msg, ok := msg.(tea.KeyMsg); ok {
+		switch {
+		case key.Matches(msg, m.keys.Next):
+			m.state.Next()
+		case key.Matches(msg, m.keys.Prev):
+			m.state.Prev()
+		}
+	}
+
 	return m, nil
 }
 
 func (m Model) View() string {
-	return ""
+	var output string
+
+	output += fmt.Sprintf("< %v >", m.state.GetDisplayValue())
+
+	return output
+}
+
+// Model Options --------------------
+
+func WithKeys(keys KeyMap) func(*Model) {
+	return func(m *Model) {
+		m.keys = keys
+	}
 }

--- a/picker/picker.go
+++ b/picker/picker.go
@@ -7,9 +7,9 @@ import (
 )
 
 type Model struct {
-	state State
-
-	keys KeyMap
+	state          State
+	showIndicators bool
+	keys           KeyMap
 }
 
 type State interface {
@@ -21,8 +21,9 @@ type State interface {
 
 func NewModel(state State, opts ...func(*Model)) Model {
 	m := Model{
-		state: state,
-		keys:  DefaultKeyMap(),
+		state:          state,
+		showIndicators: true,
+		keys:           DefaultKeyMap(),
 	}
 
 	for _, opt := range opts {
@@ -50,9 +51,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) View() string {
+	var leftIndicator, rightIndicator string
+	if m.showIndicators {
+		leftIndicator = "<"
+		rightIndicator = ">"
+	}
+
 	var output string
 
-	output += fmt.Sprintf("< %v >", m.state.GetDisplayValue())
+	output += fmt.Sprintf("%s%s%s", leftIndicator, m.state.GetDisplayValue(), rightIndicator)
 
 	return output
 }
@@ -62,5 +69,11 @@ func (m Model) View() string {
 func WithKeys(keys KeyMap) func(*Model) {
 	return func(m *Model) {
 		m.keys = keys
+	}
+}
+
+func WithoutIndicators() func(*Model) {
+	return func(m *Model) {
+		m.showIndicators = false
 	}
 }

--- a/picker/picker.go
+++ b/picker/picker.go
@@ -43,6 +43,7 @@ func NewModel(state State, opts ...func(*Model)) Model {
 		State:          state,
 		ShowIndicators: true,
 		CanCycle:       false,
+		CanJump:        false,
 		DisplayFunc:    defaultDisplayFunc,
 		Keys:           DefaultKeyMap(),
 		Styles:         DefaultStyles(),

--- a/picker/picker_test.go
+++ b/picker/picker_test.go
@@ -194,3 +194,49 @@ func TestNewModel(t *testing.T) {
 		})
 	}
 }
+
+func TestModel_GetValue(t *testing.T) {
+	tt := map[string]struct {
+		state State
+		want  interface{}
+	}{
+		"min": {
+			state: &ListState[string]{
+				state:     []string{"One", "Two", "Three"},
+				selection: 0,
+			},
+			want: "One",
+		},
+		"middle": {
+			state: &ListState[string]{
+				state:     []string{"One", "Two", "Three"},
+				selection: 1,
+			},
+			want: "Two",
+		},
+		"end": {
+			state: &ListState[string]{
+				state:     []string{"One", "Two", "Three"},
+				selection: 2,
+			},
+			want: "Three",
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			model := Model{
+				State: tc.state,
+				DisplayFunc: func(v interface{}) string {
+					return fmt.Sprintf("%v", v)
+				},
+			}
+
+			got := model.GetDisplayValue()
+
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("\ngot: \n%v \nwant: \n%v", got, tc.want)
+			}
+		})
+	}
+}

--- a/picker/picker_test.go
+++ b/picker/picker_test.go
@@ -196,6 +196,24 @@ func TestNewModel(t *testing.T) {
 	}
 }
 
+func TestModel_View(t *testing.T) {
+	model := NewModel(
+		&ListState[string]{
+			state:     []string{"One", "Two", "Three"},
+			selection: 1,
+		},
+	)
+	want := heredoc.Doc(`
+		< Two >`,
+	)
+
+	got := model.View()
+
+	if want != got {
+		t.Errorf("View: \ngot: \n%q\nwant: \n%q", got, want)
+	}
+}
+
 func TestModel_GetValue(t *testing.T) {
 	tt := map[string]struct {
 		state State

--- a/picker/picker_test.go
+++ b/picker/picker_test.go
@@ -2,6 +2,7 @@ package picker
 
 import (
 	"fmt"
+	"github.com/MakeNowJust/heredoc"
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/lipgloss"
 	"reflect"
@@ -236,6 +237,49 @@ func TestModel_GetValue(t *testing.T) {
 
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("\ngot: \n%v \nwant: \n%v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetIndicator(t *testing.T) {
+	tt := map[string]struct {
+		styles  IndicatorStyles
+		enabled bool
+		want    string
+	}{
+		"enabled": {
+			styles: IndicatorStyles{
+				Value:    "test",
+				Enabled:  lipgloss.NewStyle().BorderStyle(lipgloss.NormalBorder()).BorderTop(true),
+				Disabled: lipgloss.NewStyle().BorderStyle(lipgloss.NormalBorder()).BorderBottom(true),
+			},
+			enabled: true,
+			want: heredoc.Doc(`
+				────
+				test`,
+			),
+		},
+		"disabled": {
+			styles: IndicatorStyles{
+				Value:    "test",
+				Enabled:  lipgloss.NewStyle().BorderStyle(lipgloss.NormalBorder()).BorderTop(true),
+				Disabled: lipgloss.NewStyle().BorderStyle(lipgloss.NormalBorder()).BorderBottom(true),
+			},
+			enabled: false,
+			want: heredoc.Doc(`
+				test
+				────`,
+			),
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			got := getIndicator(tc.styles, tc.enabled)
+
+			if got != tc.want {
+				t.Errorf("\ngot: \n%q \nwant: \n%q", got, tc.want)
 			}
 		})
 	}

--- a/picker/picker_test.go
+++ b/picker/picker_test.go
@@ -1,0 +1,196 @@
+package picker
+
+import (
+	"fmt"
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/lipgloss"
+	"reflect"
+	"testing"
+)
+
+func TestNewModel(t *testing.T) {
+	tt := map[string]struct {
+		state    State
+		opts     []func(*Model)
+		wantFunc func() Model
+	}{
+		"default": {
+			state: NewListState([]string{"One", "Two", "Three"}),
+			opts:  nil,
+			wantFunc: func() Model {
+				return Model{
+					State:          NewListState([]string{"One", "Two", "Three"}),
+					ShowIndicators: true,
+					CanCycle:       false,
+					CanJump:        false,
+					DisplayFunc: func(v interface{}) string {
+						return fmt.Sprintf("%v", v)
+					},
+					Keys:   DefaultKeyMap(),
+					Styles: DefaultStyles(),
+				}
+			},
+		},
+		"WithKeys": {
+			state: NewListState([]string{"One", "Two", "Three"}),
+			opts: []func(*Model){
+				WithKeys(KeyMap{
+					Next: key.NewBinding(key.WithKeys("test", "key")),
+				}),
+			},
+			wantFunc: func() Model {
+				return Model{
+					State:          NewListState([]string{"One", "Two", "Three"}),
+					ShowIndicators: true,
+					CanCycle:       false,
+					CanJump:        false,
+					DisplayFunc: func(v interface{}) string {
+						return fmt.Sprintf("%v", v)
+					},
+					Keys: KeyMap{
+						Next: key.NewBinding(key.WithKeys("test", "key")),
+					},
+					Styles: DefaultStyles(),
+				}
+			},
+		},
+		"WithoutIndicators": {
+			state: NewListState([]string{"One", "Two", "Three"}),
+			opts: []func(*Model){
+				WithoutIndicators(),
+			},
+			wantFunc: func() Model {
+				return Model{
+					State:          NewListState([]string{"One", "Two", "Three"}),
+					ShowIndicators: false,
+					CanCycle:       false,
+					CanJump:        false,
+					DisplayFunc: func(v interface{}) string {
+						return fmt.Sprintf("%v", v)
+					},
+					Keys:   DefaultKeyMap(),
+					Styles: DefaultStyles(),
+				}
+			},
+		},
+		"WithCycles": {
+			state: NewListState([]string{"One", "Two", "Three"}),
+			opts: []func(*Model){
+				WithCycles(),
+			},
+			wantFunc: func() Model {
+				return Model{
+					State:          NewListState([]string{"One", "Two", "Three"}),
+					ShowIndicators: true,
+					CanCycle:       true,
+					CanJump:        false,
+					DisplayFunc: func(v interface{}) string {
+						return fmt.Sprintf("%v", v)
+					},
+					Keys:   DefaultKeyMap(),
+					Styles: DefaultStyles(),
+				}
+			},
+		},
+		"WithDisplayFunc": {
+			state: NewListState([]string{"One", "Two", "Three"}),
+			opts: []func(*Model){
+				WithDisplayFunc(func(_ interface{}) string {
+					return fmt.Sprint("test")
+				}),
+			},
+			wantFunc: func() Model {
+				return Model{
+					State:          NewListState([]string{"One", "Two", "Three"}),
+					ShowIndicators: true,
+					CanCycle:       false,
+					CanJump:        false,
+					DisplayFunc: func(_ interface{}) string {
+						return fmt.Sprint("test")
+					},
+					Keys:   DefaultKeyMap(),
+					Styles: DefaultStyles(),
+				}
+			},
+		},
+		"WithStyles": {
+			state: NewListState([]string{"One", "Two", "Three"}),
+			opts: []func(*Model){
+				WithStyles(Styles{
+					Selection: lipgloss.NewStyle().Width(555).Height(-555),
+				}),
+			},
+			wantFunc: func() Model {
+				return Model{
+					State:          NewListState([]string{"One", "Two", "Three"}),
+					ShowIndicators: true,
+					CanCycle:       false,
+					CanJump:        false,
+					DisplayFunc: func(v interface{}) string {
+						return fmt.Sprintf("%v", v)
+					},
+					Keys: DefaultKeyMap(),
+					Styles: Styles{
+						Selection: lipgloss.NewStyle().Width(555).Height(-555),
+					},
+				}
+			},
+		},
+		"WithJumping": {
+			state: NewListState([]string{"One", "Two", "Three"}),
+			opts: []func(*Model){
+				WithJumping(),
+			},
+			wantFunc: func() Model {
+				return Model{
+					State:          NewListState([]string{"One", "Two", "Three"}),
+					ShowIndicators: true,
+					CanCycle:       false,
+					CanJump:        true,
+					DisplayFunc: func(v interface{}) string {
+						return fmt.Sprintf("%v", v)
+					},
+					Keys:   DefaultKeyMap(),
+					Styles: DefaultStyles(),
+				}
+			},
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			want := tc.wantFunc()
+			got := NewModel(tc.state, tc.opts...)
+
+			if !reflect.DeepEqual(got.State, want.State) {
+				t.Errorf("State: \ngot: \n%v \nwant: \n%v", got, want)
+			}
+
+			if got.ShowIndicators != want.ShowIndicators {
+				t.Errorf("ShowIndicators: \ngot: \n%v \nwant: \n%v", got, want)
+			}
+
+			if got.CanCycle != want.CanCycle {
+				t.Errorf("CanCycle: \ngot: \n%v \nwant: \n%v", got, want)
+			}
+
+			if got.CanJump != want.CanJump {
+				t.Errorf("CanJump: \ngot: \n%v \nwant: \n%v", got, want)
+			}
+
+			if got.DisplayFunc == nil {
+				t.Errorf("DisplayFunc: \ngot: \n%v \nwant: \n%v", got, want)
+			} else if got.GetDisplayValue() != want.GetDisplayValue() {
+				t.Errorf("GetDisplayValue: \ngot: \n%v \nwant: \n%v", got, want)
+			}
+
+			if !reflect.DeepEqual(got.Keys, want.Keys) {
+				t.Errorf("Keys: \ngot: \n%v \nwant: \n%v", got, want)
+			}
+
+			if !reflect.DeepEqual(got.Styles, want.Styles) {
+				t.Errorf("Styles: \ngot: \n%v \nwant: \n%v", got, want)
+			}
+		})
+	}
+}

--- a/picker/styles.go
+++ b/picker/styles.go
@@ -1,0 +1,36 @@
+package picker
+
+import (
+	"github.com/charmbracelet/lipgloss"
+)
+
+type Styles struct {
+	Selection lipgloss.Style
+	Next      IndicatorStyles
+	Previous  IndicatorStyles
+}
+
+type IndicatorStyles struct {
+	Value    string
+	Enabled  lipgloss.Style
+	Disabled lipgloss.Style
+}
+
+func DefaultStyles() Styles {
+	indEnabled := lipgloss.NewStyle().Foreground(lipgloss.ANSIColor(7))
+	indDisabled := lipgloss.NewStyle().Foreground(lipgloss.ANSIColor(8))
+
+	return Styles{
+		Selection: lipgloss.NewStyle().Padding(0, 1),
+		Next: IndicatorStyles{
+			Value:    ">",
+			Enabled:  indEnabled,
+			Disabled: indDisabled,
+		},
+		Previous: IndicatorStyles{
+			Value:    "<",
+			Enabled:  indEnabled,
+			Disabled: indDisabled,
+		},
+	}
+}


### PR DESCRIPTION
Resolves https://github.com/charmbracelet/bubbles/issues/9.

Adds a new "picker" component. By default this component takes an implementation of the `State` interface and displays it in a horizontal picker manner (as requested in the issue).

- Two implementations of the `State` interface are included:
  - `ListState` takes a generic slice/list to display.
  - `IntState` allows you to set a maximum and minimum integer, or decide to ignore max or min.
- In addition to moving incrementally through the choices you can also enable "jumping" which will go to the first/last element (or max/min in the case of `IntState`).
- "Cycling" is another option which allows you to go past the first/last item (or max/min) and it will loop back to the other end of the list.
  - For `IntState` you can enable this on a per-end basis. Meaning you can set a min of 0 and max of 5, and also ignore the max. Going above 5 will continue incrementing, but going below 0 will set the value to 5. This can of course be enabled or disable for both min and max.
- By default indicators will be displayed to show when the user can increment / decrement the value.
- Methods are also included on the `Model` to get the individual, styled display components (indicators and the value). This allows the user to build a visually different component (such as a vertical picker).