### PR TITLE
feat: Substitute mutex with atomic operations.

### DIFF
--- a/filepicker/filepicker.go
+++ b/filepicker/filepicker.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
+	"sync/atomic"
 
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
@@ -15,17 +15,12 @@ import (
 	"github.com/dustin/go-humanize"
 )
 
-var (
-	lastID int
-	idMtx  sync.Mutex
-)
+var lastID atomic.Int64
 
 // Return the next ID we should use on the Model.
 func nextID() int {
-	idMtx.Lock()
-	defer idMtx.Unlock()
-	lastID++
-	return lastID
+	lastID.Add(1)
+	return int(lastID.Load())
 }
 
 // New returns a new filepicker model with default styling and key bindings.


### PR DESCRIPTION
Use atomic operations instead a mutex. This approach avoids locking and increment can be done within a single clock cycle, hence no deadlock nor race condition can occur.