### PR TITLE
feat(cursor): Add a method to retrieve the character underneath the cursor.

### DIFF
--- a/cursor/cursor.go
+++ b/cursor/cursor.go
@@ -209,6 +209,11 @@ func (m *Model) SetChar(char string) {
 	m.char = char
 }
 
+// GetChar retrieves the character under the cursor.
+func (m Model) GetChar() string {
+	return m.char
+}
+
 // View displays the cursor.
 func (m Model) View() string {
 	if m.Blink {


### PR DESCRIPTION
Added a method to get the character beneath the Cursor. 

- `func (m Model) GetChar() string`

Ran into an edge case that can benefit from just knowing the character that is underneath the cursor.