### PR TITLE
feat(textinput): expose `UpdateSuggestions` method

### DIFF
--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -262,7 +262,7 @@ func (m *Model) SetSuggestions(suggestions []string) {
 		m.suggestions[i] = []rune(s)
 	}
 
-	m.updateSuggestions()
+	m.UpdateSuggestions()
 }
 
 // rsan initializes or retrieves the rune sanitizer.
@@ -621,7 +621,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 		// Check again if can be completed
 		// because value might be something that does not match the completion prefix
-		m.updateSuggestions()
+		m.UpdateSuggestions()
 
 	case pasteMsg:
 		m.insertRunesFromUserInput([]rune(msg))
@@ -851,8 +851,8 @@ func (m *Model) canAcceptSuggestion() bool {
 	return len(m.matchedSuggestions) > 0
 }
 
-// updateSuggestions refreshes the list of matching suggestions.
-func (m *Model) updateSuggestions() {
+// UpdateSuggestions refreshes the list of matching suggestions.
+func (m *Model) UpdateSuggestions() {
 	if !m.ShowSuggestions {
 		return
 	}

--- a/textinput/textinput_test.go
+++ b/textinput/textinput_test.go
@@ -22,7 +22,7 @@ func Test_CurrentSuggestion(t *testing.T) {
 	}
 
 	textinput.SetValue("test")
-	textinput.updateSuggestions()
+	textinput.UpdateSuggestions()
 	textinput.nextSuggestion()
 	suggestion = textinput.CurrentSuggestion()
 	expected = "test2"


### PR DESCRIPTION
This enables clients of the lib to update the suggestions at runtime whenever they please.

One direct application of this is when using `m.SetValue()`: After calling it, there is no way to get the updated `m.CurrentSuggestion()` as `m.SetValue()` does not update the suggestion list.

It would be possible to also run `m.updateSuggestions()` somewhere in `m.SetValue`, but that might interfere with other things.

> [!NOTE]
> Doing the following would work, but would require some useless re-calculation.
>  ```go
>  m.SetValue("...")
>  m.SetSuggestions(m.AvailableSuggestions())
>  m.CurrentSuggestion()
>  ```
> 
> See https://github.com/nobe4/gh-not/pull/188/files#diff-9a8a064fb3b750f10c2ed5e1dde89d98645d2984d15b8b541501b5f6829e32e1R25-R30 for a real-life usage.