### PR TITLE
fix(list): `RemoveItem` correctly removes item when filtering

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -438,12 +438,15 @@ func (m *Model) InsertItem(index int, item Item) tea.Cmd {
 // this will be a no-op. O(n) complexity, which probably won't matter in the
 // case of a TUI.
 func (m *Model) RemoveItem(index int) {
-	m.items = removeItemFromSlice(m.items, index)
 	if m.filterState != Unfiltered {
+		itemsIndex := m.filteredItems[index].index
+		m.items = removeItemFromSlice(m.items, itemsIndex)
 		m.filteredItems = removeFilterMatchFromSlice(m.filteredItems, index)
 		if len(m.filteredItems) == 0 {
 			m.resetFiltering()
 		}
+	} else {
+		m.items = removeItemFromSlice(m.items, index)
 	}
 	m.updatePagination()
 }


### PR DESCRIPTION
## Changes

- Added in a fix that allows the correct item to be removed when the list is being filtered
- Previously, when it was in the `filtering state` and the `RemoveItem` method was called, it would remove the item from the `filteredItems` based on the index, however it would use the same index and remove from `unfiltered items` too, which is inconsistent since the index associated to the `filteredItems` may not be the same as the index of the `unfiltered items`
- Hence to fix this, when it is in the `filtering state` and the `RemoveItem` method is called, it retrieves the index index of the `unfiltered items` that's available in the `filteredItems` and then correctly removes the item from `filteredItems` and `unfiltered items`

## Testing Notes



## Other Notes

Related to

- [ ] Not sure how to test