### PR TITLE
(v2) consistency and best practices

### DIFF
--- a/filepicker/filepicker.go
+++ b/filepicker/filepicker.go
@@ -35,7 +35,7 @@ func New() Model {
 		DirAllowed:       false,
 		FileAllowed:      true,
 		AutoHeight:       true,
-		Height:           0,
+		height:           0,
 		max:              0,
 		min:              0,
 		selectedStack:    newStack(),
@@ -152,7 +152,7 @@ type Model struct {
 	maxStack stack
 	minStack stack
 
-	Height     int
+	height     int
 	AutoHeight bool
 
 	Cursor string
@@ -222,6 +222,16 @@ func (m Model) readDir(path string, showHidden bool) tea.Cmd {
 	}
 }
 
+// SetHeight sets the height of the file picker.
+func (m *Model) SetHeight(h int) {
+	m.height = h
+}
+
+// Height returns the height of the file picker.
+func (m Model) Height() int {
+	return m.height
+}
+
 // Init initializes the file picker model.
 func (m Model) Init() (Model, tea.Cmd) {
 	return m, m.readDir(m.CurrentDirectory, m.ShowHidden)
@@ -235,21 +245,21 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			break
 		}
 		m.files = msg.entries
-		m.max = max(m.max, m.Height-1)
+		m.max = max(m.max, m.Height()-1)
 	case tea.WindowSizeMsg:
 		if m.AutoHeight {
-			m.Height = msg.Height - marginBottom
+			m.SetHeight(msg.Height - marginBottom)
 		}
-		m.max = m.Height - 1
+		m.max = m.Height() - 1
 	case tea.KeyPressMsg:
 		switch {
 		case key.Matches(msg, m.KeyMap.GoToTop):
 			m.selected = 0
 			m.min = 0
-			m.max = m.Height - 1
+			m.max = m.Height() - 1
 		case key.Matches(msg, m.KeyMap.GoToLast):
 			m.selected = len(m.files) - 1
-			m.min = len(m.files) - m.Height
+			m.min = len(m.files) - m.Height()
 			m.max = len(m.files) - 1
 		case key.Matches(msg, m.KeyMap.Down):
 			m.selected++
@@ -270,28 +280,28 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 				m.max--
 			}
 		case key.Matches(msg, m.KeyMap.PageDown):
-			m.selected += m.Height
+			m.selected += m.Height()
 			if m.selected >= len(m.files) {
 				m.selected = len(m.files) - 1
 			}
-			m.min += m.Height
-			m.max += m.Height
+			m.min += m.Height()
+			m.max += m.Height()
 
 			if m.max >= len(m.files) {
 				m.max = len(m.files) - 1
-				m.min = m.max - m.Height
+				m.min = m.max - m.Height()
 			}
 		case key.Matches(msg, m.KeyMap.PageUp):
-			m.selected -= m.Height
+			m.selected -= m.Height()
 			if m.selected < 0 {
 				m.selected = 0
 			}
-			m.min -= m.Height
-			m.max -= m.Height
+			m.min -= m.Height()
+			m.max -= m.Height()
 
 			if m.min < 0 {
 				m.min = 0
-				m.max = m.min + m.Height
+				m.max = m.min + m.Height()
 			}
 		case key.Matches(msg, m.KeyMap.Back):
 			m.CurrentDirectory = filepath.Dir(m.CurrentDirectory)
@@ -300,7 +310,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			} else {
 				m.selected = 0
 				m.min = 0
-				m.max = m.Height - 1
+				m.max = m.Height() - 1
 			}
 			return m, m.readDir(m.CurrentDirectory, m.ShowHidden)
 		case key.Matches(msg, m.KeyMap.Open):
@@ -342,7 +352,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			m.pushView(m.selected, m.min, m.max)
 			m.selected = 0
 			m.min = 0
-			m.max = m.Height - 1
+			m.max = m.Height() - 1
 			return m, m.readDir(m.CurrentDirectory, m.ShowHidden)
 		}
 	}
@@ -352,7 +362,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 // View returns the view of the file picker.
 func (m Model) View() string {
 	if len(m.files) == 0 {
-		return m.Styles.EmptyDirectory.Height(m.Height).MaxHeight(m.Height).String()
+		return m.Styles.EmptyDirectory.Height(m.Height()).MaxHeight(m.Height()).String()
 	}
 	var s strings.Builder
 
@@ -418,7 +428,7 @@ func (m Model) View() string {
 		s.WriteRune('\n')
 	}
 
-	for i := lipgloss.Height(s.String()); i <= m.Height; i++ {
+	for i := lipgloss.Height(s.String()); i <= m.Height(); i++ {
 		s.WriteRune('\n')
 	}
 

--- a/list/list.go
+++ b/list/list.go
@@ -691,7 +691,7 @@ func (m *Model) setSize(width, height int) {
 	m.width = width
 	m.height = height
 	m.Help.Width = width
-	m.FilterInput.Width = width - promptWidth - lipgloss.Width(m.spinnerView())
+	m.FilterInput.SetWidth(width - promptWidth - lipgloss.Width(m.spinnerView()))
 	m.updatePagination()
 }
 

--- a/paginator/paginator.go
+++ b/paginator/paginator.go
@@ -28,9 +28,11 @@ type KeyMap struct {
 
 // DefaultKeyMap is the default set of key bindings for navigating and acting
 // upon the paginator.
-var DefaultKeyMap = KeyMap{
-	PrevPage: key.NewBinding(key.WithKeys("pgup", "left", "h")),
-	NextPage: key.NewBinding(key.WithKeys("pgdown", "right", "l")),
+func DefaultKeyMap() KeyMap {
+	return KeyMap{
+		PrevPage: key.NewBinding(key.WithKeys("pgup", "left", "h")),
+		NextPage: key.NewBinding(key.WithKeys("pgdown", "right", "l")),
+	}
 }
 
 // Model is the Bubble Tea model for this user interface.
@@ -129,7 +131,7 @@ func New(opts ...Option) Model {
 		Page:         0,
 		PerPage:      1,
 		TotalPages:   1,
-		KeyMap:       DefaultKeyMap,
+		KeyMap:       DefaultKeyMap(),
 		ActiveDot:    "•",
 		InactiveDot:  "○",
 		ArabicFormat: "%d/%d",

--- a/progress/progress.go
+++ b/progress/progress.go
@@ -92,7 +92,7 @@ func WithoutPercentage() Option {
 // waiting for a tea.WindowSizeMsg.
 func WithWidth(w int) Option {
 	return func(m *Model) {
-		m.Width = w
+		m.width = w
 	}
 }
 
@@ -131,7 +131,7 @@ type Model struct {
 	tag int
 
 	// Total width of the progress bar, including percentage, if set.
-	Width int
+	width int
 
 	// "Filled" sections of the progress bar.
 	Full      rune
@@ -171,7 +171,7 @@ type Model struct {
 func New(opts ...Option) Model {
 	m := Model{
 		id:             nextID(),
-		Width:          defaultWidth,
+		width:          defaultWidth,
 		Full:           '█',
 		FullColor:      "#7571F9",
 		Empty:          '░',
@@ -278,6 +278,16 @@ func (m Model) ViewAs(percent float64) string {
 	return b.String()
 }
 
+// SetWidth sets the width of the progress bar.
+func (m *Model) SetWidth(w int) {
+	m.width = w
+}
+
+// Width returns the width of the progress bar.
+func (m Model) Width() int {
+	return m.width
+}
+
 func (m *Model) nextFrame() tea.Cmd {
 	return tea.Tick(time.Second/time.Duration(fps), func(time.Time) tea.Msg {
 		return FrameMsg{id: m.id, tag: m.tag}
@@ -286,7 +296,7 @@ func (m *Model) nextFrame() tea.Cmd {
 
 func (m Model) barView(b *strings.Builder, percent float64, textWidth int) {
 	var (
-		tw = max(0, m.Width-textWidth)                // total width
+		tw = max(0, m.width-textWidth)                // total width
 		fw = int(math.Round((float64(tw) * percent))) // filled width
 		p  float64
 	)

--- a/progress/progress_test.go
+++ b/progress/progress_test.go
@@ -43,7 +43,7 @@ func TestGradient(t *testing.T) {
 			expLast := strings.Split(sb.String(), AnsiReset)[0]
 
 			for _, width := range []int{3, 5, 50} {
-				p.Width = width
+				p.SetWidth(width)
 				res := p.ViewAs(1.0)
 
 				// extract colors from the progrss bar by splitting at p.Full+AnsiReset, leaving us with just the color sequences

--- a/spinner/spinner.go
+++ b/spinner/spinner.go
@@ -195,14 +195,14 @@ func (m Model) tick(id, tag int) tea.Cmd {
 //	spinner := New(WithSpinner(Dot))
 type Option func(*Model)
 
-// WithSpinner is an option to set the spinner.
+// WithSpinner is an option to set the spinner. Pass this to [Spinner.New].
 func WithSpinner(spinner Spinner) Option {
 	return func(m *Model) {
 		m.Spinner = spinner
 	}
 }
 
-// WithStyle is an option to set the spinner style.
+// WithStyle is an option to set the spinner style. Pass this to [Spinner.New].
 func WithStyle(style lipgloss.Style) Option {
 	return func(m *Model) {
 		m.Style = style

--- a/stopwatch/stopwatch.go
+++ b/stopwatch/stopwatch.go
@@ -14,6 +14,19 @@ func nextID() int {
 	return int(atomic.AddInt64(&lastID, 1))
 }
 
+// Option is a configuration option in [New]. For example:
+//
+//	timer := New(time.Second*10, WithInterval(5*time.Second))
+type Option func(*Model)
+
+// WithInterval is an option for setting the interval between ticks. Pass as
+// an argument to [New].
+func WithInterval(interval time.Duration) Option {
+	return func(m *Model) {
+		m.Interval = interval
+	}
+}
+
 // TickMsg is a message that is sent on every timer tick.
 type TickMsg struct {
 	// ID is the identifier of the stopwatch that sends the message. This makes
@@ -47,18 +60,16 @@ type Model struct {
 	Interval time.Duration
 }
 
-// NewWithInterval creates a new stopwatch with the given timeout and tick
-// interval.
-func NewWithInterval(interval time.Duration) Model {
-	return Model{
-		Interval: interval,
-		id:       nextID(),
-	}
-}
-
 // New creates a new stopwatch with 1s interval.
-func New() Model {
-	return NewWithInterval(time.Second)
+func New(opts ...Option) Model {
+	m := Model{
+		id: nextID(),
+	}
+
+	for _, opt := range opts {
+		opt(&m)
+	}
+	return m
 }
 
 // ID returns the unique ID of the model.

--- a/table/table.go
+++ b/table/table.go
@@ -132,7 +132,7 @@ type Option func(*Model)
 func New(opts ...Option) Model {
 	m := Model{
 		cursor:   0,
-		viewport: viewport.New(0, 20), //nolint:mnd
+		viewport: viewport.New(viewport.WithHeight(20)), //nolint:mnd
 
 		KeyMap: DefaultKeyMap(),
 		Help:   help.New(),

--- a/table/table.go
+++ b/table/table.go
@@ -165,14 +165,14 @@ func WithRows(rows []Row) Option {
 // WithHeight sets the height of the table.
 func WithHeight(h int) Option {
 	return func(m *Model) {
-		m.viewport.Height = h - lipgloss.Height(m.headersView())
+		m.viewport.SetHeight(h - lipgloss.Height(m.headersView()))
 	}
 }
 
 // WithWidth sets the width of the table.
 func WithWidth(w int) Option {
 	return func(m *Model) {
-		m.viewport.Width = w
+		m.viewport.SetWidth(w)
 	}
 }
 
@@ -211,13 +211,13 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		case key.Matches(msg, m.KeyMap.LineDown):
 			m.MoveDown(1)
 		case key.Matches(msg, m.KeyMap.PageUp):
-			m.MoveUp(m.viewport.Height)
+			m.MoveUp(m.viewport.Height())
 		case key.Matches(msg, m.KeyMap.PageDown):
-			m.MoveDown(m.viewport.Height)
+			m.MoveDown(m.viewport.Height())
 		case key.Matches(msg, m.KeyMap.HalfPageUp):
-			m.MoveUp(m.viewport.Height / 2) //nolint:mnd
+			m.MoveUp(m.viewport.Height() / 2) //nolint:mnd
 		case key.Matches(msg, m.KeyMap.HalfPageDown):
-			m.MoveDown(m.viewport.Height / 2) //nolint:mnd
+			m.MoveDown(m.viewport.Height() / 2) //nolint:mnd
 		case key.Matches(msg, m.KeyMap.GotoTop):
 			m.GotoTop()
 		case key.Matches(msg, m.KeyMap.GotoBottom):
@@ -267,11 +267,11 @@ func (m *Model) UpdateViewport() {
 	// Constant runtime, independent of number of rows in a table.
 	// Limits the number of renderedRows to a maximum of 2*m.viewport.Height
 	if m.cursor >= 0 {
-		m.start = clamp(m.cursor-m.viewport.Height, 0, m.cursor)
+		m.start = clamp(m.cursor-m.viewport.Height(), 0, m.cursor)
 	} else {
 		m.start = 0
 	}
-	m.end = clamp(m.cursor+m.viewport.Height, m.cursor, len(m.rows))
+	m.end = clamp(m.cursor+m.viewport.Height(), m.cursor, len(m.rows))
 	for i := m.start; i < m.end; i++ {
 		renderedRows = append(renderedRows, m.renderRow(i))
 	}
@@ -315,24 +315,24 @@ func (m *Model) SetColumns(c []Column) {
 
 // SetWidth sets the width of the viewport of the table.
 func (m *Model) SetWidth(w int) {
-	m.viewport.Width = w
+	m.viewport.SetWidth(w)
 	m.UpdateViewport()
 }
 
 // SetHeight sets the height of the viewport of the table.
 func (m *Model) SetHeight(h int) {
-	m.viewport.Height = h - lipgloss.Height(m.headersView())
+	m.viewport.SetHeight(h - lipgloss.Height(m.headersView()))
 	m.UpdateViewport()
 }
 
 // Height returns the viewport height of the table.
 func (m Model) Height() int {
-	return m.viewport.Height
+	return m.viewport.Height()
 }
 
 // Width returns the viewport width of the table.
 func (m Model) Width() int {
-	return m.viewport.Width
+	return m.viewport.Width()
 }
 
 // Cursor returns the index of the selected row.
@@ -353,10 +353,10 @@ func (m *Model) MoveUp(n int) {
 	switch {
 	case m.start == 0:
 		m.viewport.SetYOffset(clamp(m.viewport.YOffset, 0, m.cursor))
-	case m.start < m.viewport.Height:
-		m.viewport.YOffset = (clamp(clamp(m.viewport.YOffset+n, 0, m.cursor), 0, m.viewport.Height))
+	case m.start < m.viewport.Height():
+		m.viewport.YOffset = (clamp(clamp(m.viewport.YOffset+n, 0, m.cursor), 0, m.viewport.Height()))
 	case m.viewport.YOffset >= 1:
-		m.viewport.YOffset = clamp(m.viewport.YOffset+n, 1, m.viewport.Height)
+		m.viewport.YOffset = clamp(m.viewport.YOffset+n, 1, m.viewport.Height())
 	}
 	m.UpdateViewport()
 }
@@ -369,11 +369,11 @@ func (m *Model) MoveDown(n int) {
 
 	switch {
 	case m.end == len(m.rows) && m.viewport.YOffset > 0:
-		m.viewport.SetYOffset(clamp(m.viewport.YOffset-n, 1, m.viewport.Height))
+		m.viewport.SetYOffset(clamp(m.viewport.YOffset-n, 1, m.viewport.Height()))
 	case m.cursor > (m.end-m.start)/2 && m.viewport.YOffset > 0:
 		m.viewport.SetYOffset(clamp(m.viewport.YOffset-n, 1, m.cursor))
 	case m.viewport.YOffset > 1:
-	case m.cursor > m.viewport.YOffset+m.viewport.Height-1:
+	case m.cursor > m.viewport.YOffset+m.viewport.Height()-1:
 		m.viewport.SetYOffset(clamp(m.viewport.YOffset+1, 0, 1))
 	}
 }

--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -286,7 +286,7 @@ type Model struct {
 
 // New creates a new model with default settings.
 func New() Model {
-	vp := viewport.New(0, 0)
+	vp := viewport.New()
 	vp.KeyMap = viewport.KeyMap{}
 	cur := cursor.New()
 

--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -63,33 +63,35 @@ type KeyMap struct {
 	TransposeCharacterBackward key.Binding
 }
 
-// DefaultKeyMap is the default set of key bindings for navigating and acting
+// DefaultKeyMap returns the default set of key bindings for navigating and acting
 // upon the textarea.
-var DefaultKeyMap = KeyMap{
-	CharacterForward:        key.NewBinding(key.WithKeys("right", "ctrl+f"), key.WithHelp("right", "character forward")),
-	CharacterBackward:       key.NewBinding(key.WithKeys("left", "ctrl+b"), key.WithHelp("left", "character backward")),
-	WordForward:             key.NewBinding(key.WithKeys("alt+right", "alt+f"), key.WithHelp("alt+right", "word forward")),
-	WordBackward:            key.NewBinding(key.WithKeys("alt+left", "alt+b"), key.WithHelp("alt+left", "word backward")),
-	LineNext:                key.NewBinding(key.WithKeys("down", "ctrl+n"), key.WithHelp("down", "next line")),
-	LinePrevious:            key.NewBinding(key.WithKeys("up", "ctrl+p"), key.WithHelp("up", "previous line")),
-	DeleteWordBackward:      key.NewBinding(key.WithKeys("alt+backspace", "ctrl+w"), key.WithHelp("alt+backspace", "delete word backward")),
-	DeleteWordForward:       key.NewBinding(key.WithKeys("alt+delete", "alt+d"), key.WithHelp("alt+delete", "delete word forward")),
-	DeleteAfterCursor:       key.NewBinding(key.WithKeys("ctrl+k"), key.WithHelp("ctrl+k", "delete after cursor")),
-	DeleteBeforeCursor:      key.NewBinding(key.WithKeys("ctrl+u"), key.WithHelp("ctrl+u", "delete before cursor")),
-	InsertNewline:           key.NewBinding(key.WithKeys("enter", "ctrl+m"), key.WithHelp("enter", "insert newline")),
-	DeleteCharacterBackward: key.NewBinding(key.WithKeys("backspace", "ctrl+h"), key.WithHelp("backspace", "delete character backward")),
-	DeleteCharacterForward:  key.NewBinding(key.WithKeys("delete", "ctrl+d"), key.WithHelp("delete", "delete character forward")),
-	LineStart:               key.NewBinding(key.WithKeys("home", "ctrl+a"), key.WithHelp("home", "line start")),
-	LineEnd:                 key.NewBinding(key.WithKeys("end", "ctrl+e"), key.WithHelp("end", "line end")),
-	Paste:                   key.NewBinding(key.WithKeys("ctrl+v"), key.WithHelp("ctrl+v", "paste")),
-	InputBegin:              key.NewBinding(key.WithKeys("alt+<", "ctrl+home"), key.WithHelp("alt+<", "input begin")),
-	InputEnd:                key.NewBinding(key.WithKeys("alt+>", "ctrl+end"), key.WithHelp("alt+>", "input end")),
+func DefaultKeyMap() KeyMap {
+	return KeyMap{
+		CharacterForward:        key.NewBinding(key.WithKeys("right", "ctrl+f"), key.WithHelp("right", "character forward")),
+		CharacterBackward:       key.NewBinding(key.WithKeys("left", "ctrl+b"), key.WithHelp("left", "character backward")),
+		WordForward:             key.NewBinding(key.WithKeys("alt+right", "alt+f"), key.WithHelp("alt+right", "word forward")),
+		WordBackward:            key.NewBinding(key.WithKeys("alt+left", "alt+b"), key.WithHelp("alt+left", "word backward")),
+		LineNext:                key.NewBinding(key.WithKeys("down", "ctrl+n"), key.WithHelp("down", "next line")),
+		LinePrevious:            key.NewBinding(key.WithKeys("up", "ctrl+p"), key.WithHelp("up", "previous line")),
+		DeleteWordBackward:      key.NewBinding(key.WithKeys("alt+backspace", "ctrl+w"), key.WithHelp("alt+backspace", "delete word backward")),
+		DeleteWordForward:       key.NewBinding(key.WithKeys("alt+delete", "alt+d"), key.WithHelp("alt+delete", "delete word forward")),
+		DeleteAfterCursor:       key.NewBinding(key.WithKeys("ctrl+k"), key.WithHelp("ctrl+k", "delete after cursor")),
+		DeleteBeforeCursor:      key.NewBinding(key.WithKeys("ctrl+u"), key.WithHelp("ctrl+u", "delete before cursor")),
+		InsertNewline:           key.NewBinding(key.WithKeys("enter", "ctrl+m"), key.WithHelp("enter", "insert newline")),
+		DeleteCharacterBackward: key.NewBinding(key.WithKeys("backspace", "ctrl+h"), key.WithHelp("backspace", "delete character backward")),
+		DeleteCharacterForward:  key.NewBinding(key.WithKeys("delete", "ctrl+d"), key.WithHelp("delete", "delete character forward")),
+		LineStart:               key.NewBinding(key.WithKeys("home", "ctrl+a"), key.WithHelp("home", "line start")),
+		LineEnd:                 key.NewBinding(key.WithKeys("end", "ctrl+e"), key.WithHelp("end", "line end")),
+		Paste:                   key.NewBinding(key.WithKeys("ctrl+v"), key.WithHelp("ctrl+v", "paste")),
+		InputBegin:              key.NewBinding(key.WithKeys("alt+<", "ctrl+home"), key.WithHelp("alt+<", "input begin")),
+		InputEnd:                key.NewBinding(key.WithKeys("alt+>", "ctrl+end"), key.WithHelp("alt+>", "input end")),
 
-	CapitalizeWordForward: key.NewBinding(key.WithKeys("alt+c"), key.WithHelp("alt+c", "capitalize word forward")),
-	LowercaseWordForward:  key.NewBinding(key.WithKeys("alt+l"), key.WithHelp("alt+l", "lowercase word forward")),
-	UppercaseWordForward:  key.NewBinding(key.WithKeys("alt+u"), key.WithHelp("alt+u", "uppercase word forward")),
+		CapitalizeWordForward: key.NewBinding(key.WithKeys("alt+c"), key.WithHelp("alt+c", "capitalize word forward")),
+		LowercaseWordForward:  key.NewBinding(key.WithKeys("alt+l"), key.WithHelp("alt+l", "lowercase word forward")),
+		UppercaseWordForward:  key.NewBinding(key.WithKeys("alt+u"), key.WithHelp("alt+u", "uppercase word forward")),
 
-	TransposeCharacterBackward: key.NewBinding(key.WithKeys("ctrl+t"), key.WithHelp("ctrl+t", "transpose character backward")),
+		TransposeCharacterBackward: key.NewBinding(key.WithKeys("ctrl+t"), key.WithHelp("ctrl+t", "transpose character backward")),
+	}
 }
 
 // LineInfo is a helper for keeping track of line information regarding
@@ -301,7 +303,7 @@ func New() Model {
 		EndOfBufferCharacter: ' ',
 		ShowLineNumbers:      true,
 		Cursor:               cur,
-		KeyMap:               DefaultKeyMap,
+		KeyMap:               DefaultKeyMap(),
 
 		value: make([][]rune, minHeight, defaultMaxHeight),
 		focus: false,

--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -867,7 +867,7 @@ func (m Model) LineInfo() LineInfo {
 // scrolling behavior.
 func (m *Model) repositionView() {
 	min := m.viewport.YOffset
-	max := min + m.viewport.Height - 1
+	max := min + m.viewport.Height() - 1
 
 	if row := m.cursorLineNumber(); row < min {
 		m.viewport.LineUp(min - row)
@@ -933,7 +933,7 @@ func (m *Model) SetWidth(w int) {
 	// borders, prompt and line numbers, we need to calculate it by subtracting
 	// the reserved width from them.
 
-	m.viewport.Width = inputWidth - reservedOuter
+	m.viewport.SetWidth(inputWidth - reservedOuter)
 	m.width = inputWidth - reservedOuter - reservedInner
 }
 
@@ -958,10 +958,10 @@ func (m Model) Height() int {
 func (m *Model) SetHeight(h int) {
 	if m.MaxHeight > 0 {
 		m.height = clamp(h, minHeight, m.MaxHeight)
-		m.viewport.Height = clamp(h, minHeight, m.MaxHeight)
+		m.viewport.SetHeight(clamp(h, minHeight, m.MaxHeight))
 	} else {
 		m.height = max(h, minHeight)
-		m.viewport.Height = max(h, minHeight)
+		m.viewport.SetHeight(max(h, minHeight))
 	}
 }
 

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -62,23 +62,25 @@ type KeyMap struct {
 
 // DefaultKeyMap is the default set of key bindings for navigating and acting
 // upon the textinput.
-var DefaultKeyMap = KeyMap{
-	CharacterForward:        key.NewBinding(key.WithKeys("right", "ctrl+f")),
-	CharacterBackward:       key.NewBinding(key.WithKeys("left", "ctrl+b")),
-	WordForward:             key.NewBinding(key.WithKeys("alt+right", "ctrl+right", "alt+f")),
-	WordBackward:            key.NewBinding(key.WithKeys("alt+left", "ctrl+left", "alt+b")),
-	DeleteWordBackward:      key.NewBinding(key.WithKeys("alt+backspace", "ctrl+w")),
-	DeleteWordForward:       key.NewBinding(key.WithKeys("alt+delete", "alt+d")),
-	DeleteAfterCursor:       key.NewBinding(key.WithKeys("ctrl+k")),
-	DeleteBeforeCursor:      key.NewBinding(key.WithKeys("ctrl+u")),
-	DeleteCharacterBackward: key.NewBinding(key.WithKeys("backspace", "ctrl+h")),
-	DeleteCharacterForward:  key.NewBinding(key.WithKeys("delete", "ctrl+d")),
-	LineStart:               key.NewBinding(key.WithKeys("home", "ctrl+a")),
-	LineEnd:                 key.NewBinding(key.WithKeys("end", "ctrl+e")),
-	Paste:                   key.NewBinding(key.WithKeys("ctrl+v")),
-	AcceptSuggestion:        key.NewBinding(key.WithKeys("tab")),
-	NextSuggestion:          key.NewBinding(key.WithKeys("down", "ctrl+n")),
-	PrevSuggestion:          key.NewBinding(key.WithKeys("up", "ctrl+p")),
+func DefaultKeyMap() KeyMap {
+	return KeyMap{
+		CharacterForward:        key.NewBinding(key.WithKeys("right", "ctrl+f")),
+		CharacterBackward:       key.NewBinding(key.WithKeys("left", "ctrl+b")),
+		WordForward:             key.NewBinding(key.WithKeys("alt+right", "ctrl+right", "alt+f")),
+		WordBackward:            key.NewBinding(key.WithKeys("alt+left", "ctrl+left", "alt+b")),
+		DeleteWordBackward:      key.NewBinding(key.WithKeys("alt+backspace", "ctrl+w")),
+		DeleteWordForward:       key.NewBinding(key.WithKeys("alt+delete", "alt+d")),
+		DeleteAfterCursor:       key.NewBinding(key.WithKeys("ctrl+k")),
+		DeleteBeforeCursor:      key.NewBinding(key.WithKeys("ctrl+u")),
+		DeleteCharacterBackward: key.NewBinding(key.WithKeys("backspace", "ctrl+h")),
+		DeleteCharacterForward:  key.NewBinding(key.WithKeys("delete", "ctrl+d")),
+		LineStart:               key.NewBinding(key.WithKeys("home", "ctrl+a")),
+		LineEnd:                 key.NewBinding(key.WithKeys("end", "ctrl+e")),
+		Paste:                   key.NewBinding(key.WithKeys("ctrl+v")),
+		AcceptSuggestion:        key.NewBinding(key.WithKeys("tab")),
+		NextSuggestion:          key.NewBinding(key.WithKeys("down", "ctrl+n")),
+		PrevSuggestion:          key.NewBinding(key.WithKeys("up", "ctrl+p")),
+	}
 }
 
 // Model is the Bubble Tea model for this text input element.
@@ -157,7 +159,7 @@ func New() Model {
 		ShowSuggestions:  false,
 		CompletionStyle:  lipgloss.NewStyle().Foreground(lipgloss.Color("240")),
 		Cursor:           cursor.New(),
-		KeyMap:           DefaultKeyMap,
+		KeyMap:           DefaultKeyMap(),
 
 		suggestions: [][]rune{},
 		value:       nil,

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -110,7 +110,7 @@ type Model struct {
 	// Width is the maximum number of characters that can be displayed at once.
 	// It essentially treats the text field like a horizontally scrolling
 	// viewport. If 0 or less this setting is ignored.
-	Width int
+	width int
 
 	// KeyMap encodes the keybindings recognized by the widget.
 	KeyMap KeyMap
@@ -166,6 +166,16 @@ func New() Model {
 		focus:       false,
 		pos:         0,
 	}
+}
+
+// SetWidth sets the width of the text input.
+func (m Model) Width() int {
+	return m.width
+}
+
+// SetWidth sets the width of the text input.
+func (m *Model) SetWidth(w int) {
+	m.width = w
 }
 
 // SetValue sets the value of the text input.
@@ -315,7 +325,7 @@ func (m *Model) insertRunesFromUserInput(v []rune) {
 // If a max width is defined, perform some logic to treat the visible area
 // as a horizontally scrolling viewport.
 func (m *Model) handleOverflow() {
-	if m.Width <= 0 || uniseg.StringWidth(string(m.value)) <= m.Width {
+	if m.Width() <= 0 || uniseg.StringWidth(string(m.value)) <= m.Width() {
 		m.offset = 0
 		m.offsetRight = len(m.value)
 		return
@@ -331,9 +341,9 @@ func (m *Model) handleOverflow() {
 		i := 0
 		runes := m.value[m.offset:]
 
-		for i < len(runes) && w <= m.Width {
+		for i < len(runes) && w <= m.Width() {
 			w += rw.RuneWidth(runes[i])
-			if w <= m.Width+1 {
+			if w <= m.Width()+1 {
 				i++
 			}
 		}
@@ -346,9 +356,9 @@ func (m *Model) handleOverflow() {
 		runes := m.value[:m.offsetRight]
 		i := len(runes) - 1
 
-		for i > 0 && w < m.Width {
+		for i > 0 && w < m.Width() {
 			w += rw.RuneWidth(runes[i])
-			if w <= m.Width {
+			if w <= m.Width() {
 				i--
 			}
 		}
@@ -678,9 +688,9 @@ func (m Model) View() string {
 	// If a max width and background color were set fill the empty spaces with
 	// the background color.
 	valWidth := uniseg.StringWidth(string(value))
-	if m.Width > 0 && valWidth <= m.Width {
-		padding := max(0, m.Width-valWidth)
-		if valWidth+padding <= m.Width && pos < len(value) {
+	if m.Width() > 0 && valWidth <= m.Width() {
+		padding := max(0, m.Width()-valWidth)
+		if valWidth+padding <= m.Width() && pos < len(value) {
 			padding++
 		}
 		v += styleText(strings.Repeat(" ", padding))
@@ -702,15 +712,15 @@ func (m Model) placeholderView() string {
 	v += m.Cursor.View()
 
 	// If the entire placeholder is already set and no padding is needed, finish
-	if m.Width < 1 && len(p) <= 1 {
+	if m.Width() < 1 && len(p) <= 1 {
 		return m.PromptStyle.Render(m.Prompt) + v
 	}
 
 	// If Width is set then size placeholder accordingly
-	if m.Width > 0 {
+	if m.Width() > 0 {
 		// available width is width - len + cursor offset of 1
 		minWidth := lipgloss.Width(m.Placeholder)
-		availWidth := m.Width - minWidth + 1
+		availWidth := m.Width() - minWidth + 1
 
 		// if width < len, 'subtract'(add) number to len and dont add padding
 		if availWidth < 0 {

--- a/timer/timer.go
+++ b/timer/timer.go
@@ -14,6 +14,19 @@ func nextID() int {
 	return int(atomic.AddInt64(&lastID, 1))
 }
 
+// Option is a configuration option in [New]. For example:
+//
+//	timer := New(time.Second*10, WithInterval(5*time.Second))
+type Option func(*Model)
+
+// WithInterval is an option for setting the interval between ticks. Pass as
+// an argument to [New].
+func WithInterval(interval time.Duration) Option {
+	return func(m *Model) {
+		m.Interval = interval
+	}
+}
+
 // Authors note with regard to start and stop commands:
 //
 // Technically speaking, sending commands to start and stop the timer in this
@@ -83,19 +96,17 @@ type Model struct {
 	running bool
 }
 
-// NewWithInterval creates a new timer with the given timeout and tick interval.
-func NewWithInterval(timeout, interval time.Duration) Model {
-	return Model{
-		Timeout:  timeout,
-		Interval: interval,
-		running:  true,
-		id:       nextID(),
-	}
-}
-
 // New creates a new timer with the given timeout and default 1s interval.
-func New(timeout time.Duration) Model {
-	return NewWithInterval(timeout, time.Second)
+func New(timeout time.Duration, opts ...Option) Model {
+	m := Model{
+		Timeout: timeout,
+		running: true,
+		id:      nextID(),
+	}
+	for _, opt := range opts {
+		opt(&m)
+	}
+	return m
 }
 
 // ID returns the model's identifier. This can be used to determine if messages

--- a/viewport/viewport.go
+++ b/viewport/viewport.go
@@ -19,7 +19,7 @@ type Option func(*Model)
 // viewport. Pass as an argument to [New].
 func WithWidth(w int) Option {
 	return func(m *Model) {
-		m.Width = w
+		m.width = w
 	}
 }
 
@@ -27,7 +27,7 @@ func WithWidth(w int) Option {
 // viewport. Pass as an argument to [New].
 func WithHeight(h int) Option {
 	return func(m *Model) {
-		m.Height = h
+		m.height = h
 	}
 }
 
@@ -43,8 +43,8 @@ func New(opts ...Option) (m Model) {
 
 // Model is the Bubble Tea model for this viewport element.
 type Model struct {
-	Width  int
-	Height int
+	width  int
+	height int
 	KeyMap KeyMap
 
 	// Whether or not to respond to the mouse. The mouse must be enabled in
@@ -81,6 +81,26 @@ func (m Model) Init() (Model, tea.Cmd) {
 	return m, nil
 }
 
+// Height returns the height of the viewport.
+func (m Model) Height() int {
+	return m.height
+}
+
+// SetHeight sets the height of the viewport.
+func (m *Model) SetHeight(h int) {
+	m.height = h
+}
+
+// Width returns the width of the viewport.
+func (m Model) Width() int {
+	return m.width
+}
+
+// SetWidth sets the width of the viewport.
+func (m *Model) SetWidth(w int) {
+	m.width = w
+}
+
 // AtTop returns whether or not the viewport is at the very top position.
 func (m Model) AtTop() bool {
 	return m.YOffset <= 0
@@ -100,11 +120,11 @@ func (m Model) PastBottom() bool {
 
 // ScrollPercent returns the amount scrolled as a float between 0 and 1.
 func (m Model) ScrollPercent() float64 {
-	if m.Height >= len(m.lines) {
+	if m.Height() >= len(m.lines) {
 		return 1.0
 	}
 	y := float64(m.YOffset)
-	h := float64(m.Height)
+	h := float64(m.Height())
 	t := float64(len(m.lines))
 	v := y / (t - h)
 	return math.Max(0.0, math.Min(1.0, v))
@@ -123,7 +143,7 @@ func (m *Model) SetContent(s string) {
 // maxYOffset returns the maximum possible value of the y-offset based on the
 // viewport's content and set height.
 func (m Model) maxYOffset() int {
-	return max(0, len(m.lines)-m.Height)
+	return max(0, len(m.lines)-m.Height())
 }
 
 // visibleLines returns the lines that should currently be visible in the
@@ -131,7 +151,7 @@ func (m Model) maxYOffset() int {
 func (m Model) visibleLines() (lines []string) {
 	if len(m.lines) > 0 {
 		top := max(0, m.YOffset)
-		bottom := clamp(m.YOffset+m.Height, top, len(m.lines))
+		bottom := clamp(m.YOffset+m.Height(), top, len(m.lines))
 		lines = m.lines[top:bottom]
 	}
 	return lines
@@ -149,7 +169,7 @@ func (m *Model) ViewDown() {
 		return
 	}
 
-	m.LineDown(m.Height)
+	m.LineDown(m.Height())
 }
 
 // ViewUp moves the view up by one height of the viewport. Basically, "page up".
@@ -158,7 +178,7 @@ func (m *Model) ViewUp() {
 		return
 	}
 
-	m.LineUp(m.Height)
+	m.LineUp(m.Height())
 }
 
 // HalfViewDown moves the view down by half the height of the viewport.
@@ -167,7 +187,7 @@ func (m *Model) HalfViewDown() {
 		return
 	}
 
-	m.LineDown(m.Height / 2) //nolint:mnd
+	m.LineDown(m.Height() / 2) //nolint:mnd
 }
 
 // HalfViewUp moves the view up by half the height of the viewport.
@@ -176,7 +196,7 @@ func (m *Model) HalfViewUp() {
 		return
 	}
 
-	m.LineUp(m.Height / 2) //nolint:mnd
+	m.LineUp(m.Height() / 2) //nolint:mnd
 }
 
 // LineDown moves the view down by the given number of lines.
@@ -283,7 +303,7 @@ func (m Model) updateAsModel(msg tea.Msg) Model {
 
 // View renders the viewport into a string.
 func (m Model) View() string {
-	w, h := m.Width, m.Height
+	w, h := m.Width(), m.Height()
 	if sw := m.Style.GetWidth(); sw != 0 {
 		w = min(w, sw)
 	}

--- a/viewport/viewport.go
+++ b/viewport/viewport.go
@@ -9,11 +9,34 @@ import (
 	"github.com/charmbracelet/lipgloss/v2"
 )
 
+// Option is a configuration option that works in conjunction with [New]. For
+// example:
+//
+//	timer := New(WithWidth(10, WithHeight(5)))
+type Option func(*Model)
+
+// WithWidth is an initialization option that sets the width of the
+// viewport. Pass as an argument to [New].
+func WithWidth(w int) Option {
+	return func(m *Model) {
+		m.Width = w
+	}
+}
+
+// WithHeight is an initialization option that sets the height of the
+// viewport. Pass as an argument to [New].
+func WithHeight(h int) Option {
+	return func(m *Model) {
+		m.Height = h
+	}
+}
+
 // New returns a new model with the given width and height as well as default
 // key mappings.
-func New(width, height int) (m Model) {
-	m.Width = width
-	m.Height = height
+func New(opts ...Option) (m Model) {
+	for _, opt := range opts {
+		opt(&m)
+	}
 	m.setInitialValues()
 	return m
 }


### PR DESCRIPTION
This is a set of breaking changes to enforce consistency and best practices in Bubbles v2.

The two big package-wide ones are:

1. All bubbles now use getters and setters for width and height. This will prevent us from having to make breaking changes in the future when changing size needs to affect other parameters.

```go
// Before
type Model struct {
    Height int
}

// After
func (m Model) Height() int
func (m *Model) SetHeight(int)
```

2. Default keymaps are no longer global. This guards against the default keycap being altered on the package level.

```go
// Before
var DefaultKeyMap = KeyMap{/* ... */}

// After
func DefaultKeyMap() KeyMap
```

There are also a series of small package-level adjustments which we'll outline in the release notes.