### PR TITLE
fix: allow to use empty style properly

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -1162,7 +1162,7 @@ func (m Model) statusView() string {
 		}
 	} else if len(m.items) == 0 {
 		// Not filtering: no items.
-		status = m.Styles.StatusEmpty.Render("No " + m.itemNamePlural)
+		status = m.Styles.StatusEmpty.Render()
 	} else {
 		// Normal
 		filtered := m.FilterState() == FilterApplied
@@ -1217,7 +1217,7 @@ func (m Model) populatedView() string {
 		if m.filterState == Filtering {
 			return ""
 		}
-		return m.Styles.NoItems.Render("No " + m.itemNamePlural + ".")
+		return m.Styles.NoItems.Render()
 	}
 
 	if len(items) > 0 {

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -55,6 +55,7 @@ func TestStatusBarWithoutItems(t *testing.T) {
 func TestCustomStatusBarItemName(t *testing.T) {
 	list := New([]Item{item("foo"), item("bar")}, itemDelegate{}, 10, 10)
 	list.SetStatusBarItemName("connection", "connections")
+	list.Styles.StatusEmpty = list.Styles.StatusEmpty.SetString("No connections.")
 
 	expected := "2 connections"
 	if !strings.Contains(list.statusView(), expected) {

--- a/list/style.go
+++ b/list/style.go
@@ -67,7 +67,8 @@ func DefaultStyles() (s Styles) {
 		Foreground(lipgloss.AdaptiveColor{Light: "#A49FA5", Dark: "#777777"}).
 		Padding(0, 0, 1, 2) //nolint:mnd
 
-	s.StatusEmpty = lipgloss.NewStyle().Foreground(subduedColor)
+	s.StatusEmpty = lipgloss.NewStyle().Foreground(subduedColor).
+		SetString("No items.")
 
 	s.StatusBarActiveFilter = lipgloss.NewStyle().
 		Foreground(lipgloss.AdaptiveColor{Light: "#1a1a1a", Dark: "#dddddd"})

--- a/list/style.go
+++ b/list/style.go
@@ -76,7 +76,8 @@ func DefaultStyles() (s Styles) {
 	s.StatusBarFilterCount = lipgloss.NewStyle().Foreground(verySubduedColor)
 
 	s.NoItems = lipgloss.NewStyle().
-		Foreground(lipgloss.AdaptiveColor{Light: "#909090", Dark: "#626262"})
+		Foreground(lipgloss.AdaptiveColor{Light: "#909090", Dark: "#626262"}).
+		SetString("No items.")
 
 	s.ArabicPagination = lipgloss.NewStyle().Foreground(subduedColor)
 


### PR DESCRIPTION
alternative to #673

This way users can set the text they want using `SetString` in the style.

closes #673 