### PR TITLE
feat: allow textinput to show suggestions with empty input

### DIFF
--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -147,6 +147,9 @@ type Model struct {
 	// Should the input suggest to complete
 	ShowSuggestions bool
 
+	// Whether we should allow suggestions when input is empty
+	AllowSuggestionsForEmptyInput bool
+
 	// suggestions is a list of suggestions that may be used to complete the
 	// input.
 	suggestions            [][]rune
@@ -157,14 +160,15 @@ type Model struct {
 // New creates a new model with default settings.
 func New() Model {
 	return Model{
-		Prompt:           "> ",
-		EchoCharacter:    '*',
-		CharLimit:        0,
-		PlaceholderStyle: lipgloss.NewStyle().Foreground(lipgloss.Color("240")),
-		ShowSuggestions:  false,
-		CompletionStyle:  lipgloss.NewStyle().Foreground(lipgloss.Color("240")),
-		Cursor:           cursor.New(),
-		KeyMap:           DefaultKeyMap,
+		Prompt:                        "> ",
+		EchoCharacter:                 '*',
+		CharLimit:                     0,
+		PlaceholderStyle:              lipgloss.NewStyle().Foreground(lipgloss.Color("240")),
+		ShowSuggestions:               false,
+		AllowSuggestionsForEmptyInput: false,
+		CompletionStyle:               lipgloss.NewStyle().Foreground(lipgloss.Color("240")),
+		Cursor:                        cursor.New(),
+		KeyMap:                        DefaultKeyMap,
 
 		suggestions: [][]rune{},
 		value:       nil,
@@ -859,7 +863,7 @@ func (m *Model) updateSuggestions() {
 		return
 	}
 
-	if len(m.value) <= 0 || len(m.suggestions) <= 0 {
+	if (len(m.value) <= 0 && !m.AllowSuggestionsForEmptyInput) || len(m.suggestions) <= 0 {
 		m.matchedSuggestions = [][]rune{}
 		return
 	}

--- a/textinput/textinput_test.go
+++ b/textinput/textinput_test.go
@@ -27,7 +27,35 @@ func Test_CurrentSuggestion(t *testing.T) {
 	suggestion = textinput.CurrentSuggestion()
 	expected = "test2"
 	if suggestion != expected {
+		t.Fatalf("Error: expected second suggestion but was %s", suggestion)
+	}
+}
+
+func Test_SuggestionWithEmptyInput(t *testing.T) {
+	textinput := New()
+	textinput.ShowSuggestions = true
+	textinput.AllowSuggestionsForEmptyInput = true
+
+	suggestion := textinput.CurrentSuggestion()
+	expected := ""
+	if suggestion != expected {
+		t.Fatalf("Error: expected no current suggestion but was %s", suggestion)
+	}
+
+	textinput.SetSuggestions([]string{"test1", "test2", "test3"})
+	suggestion = textinput.CurrentSuggestion()
+	expected = "test1"
+	if suggestion != expected {
 		t.Fatalf("Error: expected first suggestion but was %s", suggestion)
+	}
+
+	textinput.SetValue("test")
+	textinput.updateSuggestions()
+	textinput.nextSuggestion()
+	suggestion = textinput.CurrentSuggestion()
+	expected = "test2"
+	if suggestion != expected {
+		t.Fatalf("Error: expected second suggestion but was %s", suggestion)
 	}
 }
 


### PR DESCRIPTION
This PR allows textinput to support suggestions with empty input (which is a legit use case for shell programs to use history commands as suggestions for example), while keeping the default behavior the same so we don't introduce a breaking change. 

Tested via both existing and new test cases -
```bash
bubbles master*! ❯ go test ./textinput/...
ok      github.com/charmbracelet/bubbles/textinput      0.796s
```