### PR TITLE
docs: add example for ValidateFunc

### DIFF
--- a/textinput/textinput_test.go
+++ b/textinput/textinput_test.go
@@ -48,7 +48,7 @@ func ExampleValidateFunc() {
 	creditCardNumber.CharLimit = 20
 	creditCardNumber.Width = 30
 	creditCardNumber.Prompt = ""
-	// The anonymous function is a valid function for ValidateFunc.
+	// This anonymous function is a valid function for ValidateFunc.
 	creditCardNumber.Validate = func(s string) error {
 		// Credit Card Number should a string less than 20 digits
 		// It should include 16 integers and 3 spaces

--- a/textinput/textinput_test.go
+++ b/textinput/textinput_test.go
@@ -1,6 +1,9 @@
 package textinput
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -36,4 +39,38 @@ func Test_SlicingOutsideCap(t *testing.T) {
 	textinput.Placeholder = "作業ディレクトリを指定してください"
 	textinput.Width = 32
 	textinput.View()
+}
+
+func ExampleValidateFunc() {
+	creditCardNumber := New()
+	creditCardNumber.Placeholder = "4505 **** **** 1234"
+	creditCardNumber.Focus()
+	creditCardNumber.CharLimit = 20
+	creditCardNumber.Width = 30
+	creditCardNumber.Prompt = ""
+	// The anonymous function is a valid function for ValidateFunc.
+	creditCardNumber.Validate = func(s string) error {
+		// Credit Card Number should a string less than 20 digits
+		// It should include 16 integers and 3 spaces
+		if len(s) > 16+3 {
+			return fmt.Errorf("CCN is too long")
+		}
+
+		if len(s) == 0 || len(s)%5 != 0 && (s[len(s)-1] < '0' || s[len(s)-1] > '9') {
+			return fmt.Errorf("CCN is invalid")
+		}
+
+		// The last digit should be a number unless it is a multiple of 4 in which
+		// case it should be a space
+		if len(s)%5 == 0 && s[len(s)-1] != ' ' {
+			return fmt.Errorf("CCN must separate groups with spaces")
+		}
+
+		// The remaining digits should be integers
+		c := strings.ReplaceAll(s, " ", "")
+		_, err := strconv.ParseInt(c, 10, 64)
+
+		return err
+	}
+	fmt.Println(creditCardNumber.View())
 }

--- a/textinput/textinput_test.go
+++ b/textinput/textinput_test.go
@@ -72,5 +72,4 @@ func ExampleValidateFunc() {
 
 		return err
 	}
-	fmt.Println(creditCardNumber.View())
 }


### PR DESCRIPTION
Here's what the godoc looks like with this change:
![image](https://github.com/user-attachments/assets/1765d6fa-601f-4fe0-8b16-9b9dc841891b)

@meowgorithm mentioned wanting to clarify usage for textinput's `Validate` in https://github.com/charmbracelet/bubbles/issues/481. This PR includes an example from Bubble Tea's [credit card example](https://github.com/charmbracelet/bubbletea/blob/main/examples/credit-card-form/main.go)