### PR TITLE
fix(viewport): scroll to last line when borders

### DIFF
--- a/viewport/viewport.go
+++ b/viewport/viewport.go
@@ -140,7 +140,7 @@ func (m *Model) SetContent(s string) {
 // maxYOffset returns the maximum possible value of the y-offset based on the
 // viewport's content and set height.
 func (m Model) maxYOffset() int {
-	return max(0, len(m.lines)-m.Height)
+	return max(0, len(m.lines)-m.Height+m.Style.GetVerticalFrameSize())
 }
 
 // visibleLines returns the lines that should currently be visible in the


### PR DESCRIPTION
If the viewport has borders, they are not currently taken into account when calculating the viewport max y offset, which might cause the last line to not be visible.

This is easily reproducible in `gum pager`.