### PR TITLE
fix: stopwatch.Start()

### DIFF
--- a/stopwatch/stopwatch.go
+++ b/stopwatch/stopwatch.go
@@ -75,7 +75,7 @@ func (m Model) Init() tea.Cmd {
 
 // Start starts the stopwatch.
 func (m Model) Start() tea.Cmd {
-	return tea.Batch(func() tea.Msg {
+	return tea.Sequence(func() tea.Msg {
 		return StartStopMsg{ID: m.id, running: true}
 	}, tick(m.id, m.tag, m.Interval))
 }


### PR DESCRIPTION
stopwatch currently has a non deterministic way of starting. This is easily fixed by using `tea.Sequence` instead of `tea.Batch`.
timer is not affected as it doesn't use batch on `Start()`

## Bug

Relevant code parts from stopwatch's file:

```go
// Start starts the stopwatch.
func (m Model) Start() tea.Cmd {
	return tea.Batch(func() tea.Msg {
		return StartStopMsg{ID: m.id, running: true}
	}, tick(m.id, m.tag, m.Interval))
}

...

func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
	...
	case TickMsg:
		if !m.running || msg.ID != m.id {
			break
		}
	...
}
```

Batch's description:

> Batch performs a bunch of commands concurrently **with no ordering guarantees** about the results.

So what basically happens is sometimes `TickMsg` arrives before `StartStopMsg`, as `running` is still `false` this is thrown away.
After that the `StartStopMsg` finally comes in and switches `running` to `true`, however as the `TickMsg` is already thrown away, nothing happens (except messing up someone's code who uses `Toggle()`)

## Workaround

```go
func (sl *StatusLine) StartIOBuffer(msg string) tea.Cmd {
	sl.isIOInProgress = true
	sl.msg = msg
	// workaround until it's fixed in the stopwatch package
	bmsg := sl.stopwatch.Start()().(tea.BatchMsg)
	return tea.Batch(sl.spinner.Tick, tea.Sequence(sl.stopwatch.Reset(), bmsg[0], bmsg[1]))
}
```

As a temp workaround, because I (annoyingly) can't set `StartStopMsg.running` to true, `BatchMsg`'s type is `[]tea.Cmd`, so I unpacked it into a `Sequence`.

## Contrib notes

Steps to reproduce are... well basically just use the package, calling `Start` and `Stop`/reinit model. Way I figured out what happens is set a UI texts to `Running()` and whether `TickMsg` was received or not.
