### PR TITLE
(v2) textarea,cursor: wrap up real cursor API

### DIFF
--- a/cursor/cursor.go
+++ b/cursor/cursor.go
@@ -1,8 +1,5 @@
 // Package cursor provides a virtual cursor to support the textinput and
 // textarea elements.
-//
-// Both the textinput and textarea elements also use this package to style an
-// optional real cursor.
 package cursor
 
 import (
@@ -57,28 +54,14 @@ func (c Mode) String() string {
 // Model is the Bubble Tea model for this cursor element.
 type Model struct {
 	// Style styles the cursor block.
-	//
-	// For real cursors, the foreground color set here will be used as the
-	// cursor color.
 	Style lipgloss.Style
 
-	// Shape is the cursor shape. The following shapes are available:
-	//
-	// - tea.CursorBlock
-	// - tea.CursorUnderline
-	// - tea.CursorBar
-	//
-	// This is only used for real cursors.
-	Shape tea.CursorShape
-
 	// BlinkedStyle is the style used for the cursor when it is blinking
-	// (hidden), i.e. displaying normal text. This has no effect on real
-	// cursors.
+	// (hidden), i.e. displaying normal text.
 	BlinkedStyle lipgloss.Style
 
 	// BlinkSpeed is the speed at which the cursor blinks. This has no effect
-	// on real cursors as well as no effect if the [CursorMode] is not set to
-	// [CursorBlink].
+	// unless [CursorMode] is not set to [CursorBlink].
 	BlinkSpeed time.Duration
 
 	// Blink is the cursor blink state.

--- a/cursor/cursor.go
+++ b/cursor/cursor.go
@@ -56,15 +56,15 @@ type Model struct {
 	// Style styles the cursor block.
 	Style lipgloss.Style
 
-	// BlinkedStyle is the style used for the cursor when it is blinking
+	// TextStyle is the style used for the cursor when it is blinking
 	// (hidden), i.e. displaying normal text.
-	BlinkedStyle lipgloss.Style
+	TextStyle lipgloss.Style
 
 	// BlinkSpeed is the speed at which the cursor blinks. This has no effect
 	// unless [CursorMode] is not set to [CursorBlink].
 	BlinkSpeed time.Duration
 
-	// Blink is the cursor blink state.
+	// Blink is the state of the cursor blink. When true, the cursor is hidden.
 	Blink bool
 
 	// char is the character under the cursor
@@ -224,7 +224,7 @@ func (m *Model) SetChar(char string) {
 // View displays the cursor.
 func (m Model) View() string {
 	if m.Blink {
-		return m.BlinkedStyle.Inline(true).Render(m.char)
+		return m.TextStyle.Inline(true).Render(m.char)
 	}
 	return m.Style.Inline(true).Reverse(true).Render(m.char)
 }

--- a/cursor/cursor.go
+++ b/cursor/cursor.go
@@ -1,3 +1,8 @@
+// Package cursor provides a virtual cursor to support the textinput and
+// textarea elements.
+//
+// Both the textinput and textarea elements also use this package to style an
+// optional real cursor.
 package cursor
 
 import (
@@ -51,25 +56,49 @@ func (c Mode) String() string {
 
 // Model is the Bubble Tea model for this cursor element.
 type Model struct {
-	BlinkSpeed time.Duration
-	// Style for styling the cursor block.
+	// Style styles the cursor block.
+	//
+	// For real cursors, the foreground color set here will be used as the
+	// cursor color.
 	Style lipgloss.Style
-	// TextStyle is the style used for the cursor when it is hidden (when blinking).
-	// I.e. displaying normal text.
-	TextStyle lipgloss.Style
+
+	// Shape is the cursor shape. The following shapes are available:
+	//
+	// - tea.CursorBlock
+	// - tea.CursorUnderline
+	// - tea.CursorBar
+	//
+	// This is only used for real cursors.
+	Shape tea.CursorShape
+
+	// BlinkedStyle is the style used for the cursor when it is blinking
+	// (hidden), i.e. displaying normal text. This has no effect on real
+	// cursors.
+	BlinkedStyle lipgloss.Style
+
+	// BlinkSpeed is the speed at which the cursor blinks. This has no effect
+	// on real cursors as well as no effect if the [CursorMode] is not set to
+	// [CursorBlink].
+	BlinkSpeed time.Duration
+
+	// Blink is the cursor blink state.
+	Blink bool
 
 	// char is the character under the cursor
 	char string
+
 	// The ID of this Model as it relates to other cursors
 	id int
+
 	// focus indicates whether the containing input is focused
 	focus bool
-	// Cursor Blink state.
-	Blink bool
+
 	// Used to manage cursor blink
 	blinkCtx *blinkCtx
+
 	// The ID of the blink message we're expecting to receive.
 	blinkTag int
+
 	// mode determines the behavior of the cursor
 	mode Mode
 }
@@ -212,7 +241,7 @@ func (m *Model) SetChar(char string) {
 // View displays the cursor.
 func (m Model) View() string {
 	if m.Blink {
-		return m.TextStyle.Inline(true).Render(m.char)
+		return m.BlinkedStyle.Inline(true).Render(m.char)
 	}
 	return m.Style.Inline(true).Reverse(true).Render(m.char)
 }

--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -241,7 +241,7 @@ type Model struct {
 	// When changing the value of Prompt after the model has been
 	// initialized, ensure that SetWidth() gets called afterwards.
 	//
-	// See also SetPromptFunc().
+	// See also [SetPromptFunc] for a dynamic prompt.
 	Prompt string
 
 	// Placeholder is the text displayed when the user
@@ -983,9 +983,11 @@ func (m *Model) moveToEnd() {
 // It is important that the width of the textarea be exactly the given width
 // and no more.
 func (m *Model) SetWidth(w int) {
-	// Update prompt width only if there is no prompt function as SetPromptFunc
-	// updates the prompt width when it is called.
+	// Update prompt width only if there is no prompt function as
+	// [SetPromptFunc] updates the prompt width when it is called.
 	if m.promptFunc == nil {
+		// XXX: This should account for a styled prompt and use lipglosss.Width
+		// instead of uniseg.StringWidth.
 		m.promptWidth = uniseg.StringWidth(m.Prompt)
 	}
 
@@ -997,6 +999,7 @@ func (m *Model) SetWidth(w int) {
 
 	// Add line number width to reserved inner width.
 	if m.ShowLineNumbers {
+		// XXX: this should almost certainly not be hardcoded.
 		const lnWidth = 4 // Up to 3 digits for line number plus 1 margin.
 		reservedInner += lnWidth
 	}
@@ -1019,14 +1022,13 @@ func (m *Model) SetWidth(w int) {
 	m.width = inputWidth - reservedOuter - reservedInner
 }
 
-// SetPromptFunc supersedes the Prompt field and sets a dynamic prompt
-// instead.
-// If the function returns a prompt that is shorter than the
-// specified promptWidth, it will be padded to the left.
-// If it returns a prompt that is longer, display artifacts
-// may occur; the caller is responsible for computing an adequate
-// promptWidth.
-func (m *Model) SetPromptFunc(promptWidth int, fn func(lineIdx int) string) {
+// SetPromptFunc supersedes the Prompt field and sets a dynamic prompt instead.
+//
+// If the function returns a prompt that is shorter than the specified
+// promptWidth, it will be padded to the left. If it returns a prompt that is
+// longer, display artifacts may occur; the caller is responsible for computing
+// an adequate promptWidth.
+func (m *Model) SetPromptFunc(promptWidth int, fn func(lineIndex int) string) {
 	m.promptFunc = fn
 	m.promptWidth = promptWidth
 }

--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -422,7 +422,7 @@ func (m *Model) SetStyles(s Styles) {
 	m.virtualCursor.Style = s.Focused.Cursor.Style
 	m.virtualCursor.BlinkedStyle = s.Focused.Cursor.BlinkedStyle
 
-	// By default, the blink speed of the cursor is set to a deafault
+	// By default, the blink speed of the cursor is set to a default
 	// internally.
 	if s.Focused.Cursor.BlinkSpeed > 0 {
 		m.virtualCursor.BlinkSpeed = m.activeStyle.Cursor.BlinkSpeed

--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -3,6 +3,7 @@ package textarea
 import (
 	"crypto/sha256"
 	"fmt"
+	"image/color"
 	"strconv"
 	"strings"
 	"time"
@@ -135,12 +136,7 @@ type CursorStyle struct {
 	//
 	// For real cursors, the foreground color set here will be used as the
 	// cursor color.
-	Style lipgloss.Style
-
-	// BlinkedStyle is the style used for the cursor when it is blinking
-	// (hidden), i.e. displaying normal text. This is only used for virtual
-	// cursors.
-	BlinkedStyle lipgloss.Style
+	Color color.Color
 
 	// Shape is the cursor shape. The following shapes are available:
 	//
@@ -395,7 +391,8 @@ func DefaultStyles(isDark bool) Styles {
 		Text:             lipgloss.NewStyle().Foreground(lightDark(lipgloss.Color("245"), lipgloss.Color("7"))),
 	}
 	s.Cursor = CursorStyle{
-		Style: lipgloss.NewStyle().Foreground(lipgloss.Color("7")),
+		Color: lipgloss.Color("7"),
+		Shape: tea.CursorBlock,
 		Blink: true,
 	}
 	return s
@@ -419,8 +416,7 @@ func (m *Model) updateVirtualCursorStyle() {
 		return
 	}
 
-	m.virtualCursor.Style = m.Styles.Cursor.Style
-	m.virtualCursor.BlinkedStyle = m.Styles.Cursor.BlinkedStyle
+	m.virtualCursor.Style = lipgloss.NewStyle().Foreground(m.Styles.Cursor.Color)
 
 	// By default, the blink speed of the cursor is set to a default
 	// internally.
@@ -1194,7 +1190,7 @@ func (m Model) View() string {
 	if m.Value() == "" && m.row == 0 && m.col == 0 && m.Placeholder != "" {
 		return m.placeholderView()
 	}
-	m.virtualCursor.BlinkedStyle = m.activeStyle.computedCursorLine()
+	m.virtualCursor.TextStyle = m.activeStyle.computedCursorLine()
 
 	var (
 		s                strings.Builder
@@ -1370,7 +1366,7 @@ func (m Model) placeholderView() string {
 		// first line
 		case i == 0:
 			// first character of first line as cursor with character
-			m.virtualCursor.BlinkedStyle = m.activeStyle.computedPlaceholder()
+			m.virtualCursor.TextStyle = m.activeStyle.computedPlaceholder()
 			m.virtualCursor.SetChar(string(plines[0][0]))
 			s.WriteString(lineStyle.Render(m.virtualCursor.View()))
 
@@ -1423,7 +1419,7 @@ func (m Model) Cursor() *tea.Cursor {
 
 	c := tea.NewCursor(x, y)
 	c.Blink = m.Styles.Cursor.Blink
-	c.Color = m.Styles.Cursor.Style.GetForeground()
+	c.Color = m.Styles.Cursor.Color
 	c.Shape = m.Styles.Cursor.Shape
 	return c
 }

--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -546,7 +546,7 @@ func (m *Model) insertRunesFromUserInput(runes []rune) {
 	// Finally add the tail at the end of the last line inserted.
 	m.value[m.row] = append(m.value[m.row], tail...)
 
-	m.SetCursor(m.col)
+	m.SetCursorColumn(m.col)
 }
 
 // Value returns the value of the text input.
@@ -654,9 +654,9 @@ func (m *Model) CursorUp() {
 	}
 }
 
-// SetCursor moves the cursor to the given position. If the position is
+// SetCursorColumn moves the cursor to the given position. If the position is
 // out of bounds the cursor will be moved to the start or end accordingly.
-func (m *Model) SetCursor(col int) {
+func (m *Model) SetCursorColumn(col int) {
 	m.col = clamp(col, 0, len(m.value[m.row]))
 	// Any time that we move the cursor horizontally we need to reset the last
 	// offset so that the horizontal position when navigating is adjusted.
@@ -665,12 +665,12 @@ func (m *Model) SetCursor(col int) {
 
 // CursorStart moves the cursor to the start of the input field.
 func (m *Model) CursorStart() {
-	m.SetCursor(0)
+	m.SetCursorColumn(0)
 }
 
 // CursorEnd moves the cursor to the end of the input field.
 func (m *Model) CursorEnd() {
-	m.SetCursor(len(m.value[m.row]))
+	m.SetCursorColumn(len(m.value[m.row]))
 }
 
 // Focused returns the focus state on the model.
@@ -700,7 +700,7 @@ func (m *Model) Reset() {
 	m.col = 0
 	m.row = 0
 	m.viewport.GotoTop()
-	m.SetCursor(0)
+	m.SetCursorColumn(0)
 }
 
 // san initializes or retrieves the rune sanitizer.
@@ -717,7 +717,7 @@ func (m *Model) san() runeutil.Sanitizer {
 // not the cursor blink should be reset.
 func (m *Model) deleteBeforeCursor() {
 	m.value[m.row] = m.value[m.row][m.col:]
-	m.SetCursor(0)
+	m.SetCursorColumn(0)
 }
 
 // deleteAfterCursor deletes all text after the cursor. Returns whether or not
@@ -725,7 +725,7 @@ func (m *Model) deleteBeforeCursor() {
 // the cursor so as not to reveal word breaks in the masked input.
 func (m *Model) deleteAfterCursor() {
 	m.value[m.row] = m.value[m.row][:m.col]
-	m.SetCursor(len(m.value[m.row]))
+	m.SetCursorColumn(len(m.value[m.row]))
 }
 
 // transposeLeft exchanges the runes at the cursor and immediately
@@ -737,11 +737,11 @@ func (m *Model) transposeLeft() {
 		return
 	}
 	if m.col >= len(m.value[m.row]) {
-		m.SetCursor(m.col - 1)
+		m.SetCursorColumn(m.col - 1)
 	}
 	m.value[m.row][m.col-1], m.value[m.row][m.col] = m.value[m.row][m.col], m.value[m.row][m.col-1]
 	if m.col < len(m.value[m.row]) {
-		m.SetCursor(m.col + 1)
+		m.SetCursorColumn(m.col + 1)
 	}
 }
 
@@ -757,22 +757,22 @@ func (m *Model) deleteWordLeft() {
 	// call into the corresponding if clause does not apply here.
 	oldCol := m.col //nolint:ifshort
 
-	m.SetCursor(m.col - 1)
+	m.SetCursorColumn(m.col - 1)
 	for unicode.IsSpace(m.value[m.row][m.col]) {
 		if m.col <= 0 {
 			break
 		}
 		// ignore series of whitespace before cursor
-		m.SetCursor(m.col - 1)
+		m.SetCursorColumn(m.col - 1)
 	}
 
 	for m.col > 0 {
 		if !unicode.IsSpace(m.value[m.row][m.col]) {
-			m.SetCursor(m.col - 1)
+			m.SetCursorColumn(m.col - 1)
 		} else {
 			if m.col > 0 {
 				// keep the previous space
-				m.SetCursor(m.col + 1)
+				m.SetCursorColumn(m.col + 1)
 			}
 			break
 		}
@@ -795,12 +795,12 @@ func (m *Model) deleteWordRight() {
 
 	for m.col < len(m.value[m.row]) && unicode.IsSpace(m.value[m.row][m.col]) {
 		// ignore series of whitespace after cursor
-		m.SetCursor(m.col + 1)
+		m.SetCursorColumn(m.col + 1)
 	}
 
 	for m.col < len(m.value[m.row]) {
 		if !unicode.IsSpace(m.value[m.row][m.col]) {
-			m.SetCursor(m.col + 1)
+			m.SetCursorColumn(m.col + 1)
 		} else {
 			break
 		}
@@ -812,13 +812,13 @@ func (m *Model) deleteWordRight() {
 		m.value[m.row] = append(m.value[m.row][:oldCol], m.value[m.row][m.col:]...)
 	}
 
-	m.SetCursor(oldCol)
+	m.SetCursorColumn(oldCol)
 }
 
 // characterRight moves the cursor one character to the right.
 func (m *Model) characterRight() {
 	if m.col < len(m.value[m.row]) {
-		m.SetCursor(m.col + 1)
+		m.SetCursorColumn(m.col + 1)
 	} else {
 		if m.row < len(m.value)-1 {
 			m.row++
@@ -839,7 +839,7 @@ func (m *Model) characterLeft(insideLine bool) {
 		}
 	}
 	if m.col > 0 {
-		m.SetCursor(m.col - 1)
+		m.SetCursorColumn(m.col - 1)
 	}
 }
 
@@ -858,7 +858,7 @@ func (m *Model) wordLeft() {
 		if unicode.IsSpace(m.value[m.row][m.col-1]) {
 			break
 		}
-		m.SetCursor(m.col - 1)
+		m.SetCursorColumn(m.col - 1)
 	}
 }
 
@@ -885,7 +885,7 @@ func (m *Model) doWordRight(fn func(charIdx int, pos int)) {
 			break
 		}
 		fn(charIdx, m.col)
-		m.SetCursor(m.col + 1)
+		m.SetCursorColumn(m.col + 1)
 		charIdx++
 	}
 }
@@ -975,13 +975,13 @@ func (m Model) Width() int {
 // moveToBegin moves the cursor to the beginning of the input.
 func (m *Model) moveToBegin() {
 	m.row = 0
-	m.SetCursor(0)
+	m.SetCursorColumn(0)
 }
 
 // moveToEnd moves the cursor to the end of the input.
 func (m *Model) moveToEnd() {
 	m.row = len(m.value) - 1
-	m.SetCursor(len(m.value[m.row]))
+	m.SetCursorColumn(len(m.value[m.row]))
 }
 
 // SetWidth sets the width of the textarea to fit exactly within the given width.
@@ -1104,7 +1104,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			if len(m.value[m.row]) > 0 {
 				m.value[m.row] = append(m.value[m.row][:max(0, m.col-1)], m.value[m.row][m.col:]...)
 				if m.col > 0 {
-					m.SetCursor(m.col - 1)
+					m.SetCursorColumn(m.col - 1)
 				}
 			}
 		case key.Matches(msg, m.KeyMap.DeleteCharacterForward):

--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -1441,8 +1441,20 @@ func Blink() tea.Msg {
 func (m Model) Cursor() *tea.Cursor {
 	lineInfo := m.LineInfo()
 	w := lipgloss.Width
-	xOffset := lineInfo.CharOffset + w(m.promptView(0)) + w(m.lineNumberView(0, false))
-	yOffset := m.cursorLineNumber() - m.viewport.YOffset
+	baseStyle := m.activeStyle().Base
+
+	xOffset := lineInfo.CharOffset +
+		w(m.promptView(0)) +
+		w(m.lineNumberView(0, false)) +
+		baseStyle.GetMarginLeft() +
+		baseStyle.GetPaddingLeft() +
+		baseStyle.GetBorderLeftSize()
+
+	yOffset := m.cursorLineNumber() +
+		m.viewport.YOffset +
+		baseStyle.GetMarginTop() +
+		baseStyle.GetPaddingTop() +
+		baseStyle.GetBorderTopSize()
 
 	c := tea.NewCursor(xOffset, yOffset)
 	c.Blink = m.Styles.Cursor.Blink

--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -1341,18 +1341,16 @@ func (m Model) lineNumberView(n int, isCursorLine bool) (str string) {
 	return textStyle.Render(lineNumberStyle.Render(str))
 }
 
-// placeholderView returns the prompt and placeholder view, if any.
+// placeholderView returns the prompt and placeholder, if any.
 func (m Model) placeholderView() string {
 	var (
 		s      strings.Builder
 		p      = m.Placeholder
 		styles = m.activeStyle()
-		// placeholderStyle = m.activeStyle().computedPlaceholder()
 	)
-
 	// word wrap lines
 	pwordwrap := ansi.Wordwrap(p, m.width, "")
-	// wrap lines (handles lines that could not be word wrapped)
+	// hard wrap lines (handles lines that could not be word wrapped)
 	pwrap := ansi.Hardwrap(pwordwrap, m.width, true)
 	// split string by new lines
 	plines := strings.Split(strings.TrimSpace(pwrap), "\n")
@@ -1360,10 +1358,9 @@ func (m Model) placeholderView() string {
 	for i := 0; i < m.height; i++ {
 		isLineNumber := len(plines) > i
 
-		// XXX: This will go.
-		lineStyle := m.activeStyle().computedPlaceholder()
+		lineStyle := styles.computedPlaceholder()
 		if len(plines) > i {
-			lineStyle = m.activeStyle().computedCursorLine()
+			lineStyle = styles.computedCursorLine()
 		}
 
 		// render prompt
@@ -1397,12 +1394,17 @@ func (m Model) placeholderView() string {
 			s.WriteString(lineStyle.Render(m.virtualCursor.View()))
 
 			// the rest of the first line
-			s.WriteString(lineStyle.Render(plines[0][1:] + strings.Repeat(" ", max(0, m.width-uniseg.StringWidth(plines[0])))))
+			placeholderTail := plines[0][1:]
+			gap := strings.Repeat(" ", max(0, m.width-uniseg.StringWidth(plines[0])))
+			renderedPlaceholder := styles.computedPlaceholder().Render(placeholderTail + gap)
+			s.WriteString(lineStyle.Render(renderedPlaceholder))
 		// remaining lines
 		case len(plines) > i:
 			// current line placeholder text
 			if len(plines) > i {
-				s.WriteString(lineStyle.Render(plines[i] + strings.Repeat(" ", max(0, m.width-uniseg.StringWidth(plines[i])))))
+				placeholderLine := plines[i]
+				gap := strings.Repeat(" ", max(0, m.width-uniseg.StringWidth(plines[i])))
+				s.WriteString(lineStyle.Render(placeholderLine + gap))
 			}
 		default:
 			// end of line buffer character

--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -988,6 +988,9 @@ func (m *Model) SetWidth(w int) {
 	if m.promptFunc == nil {
 		// XXX: This should account for a styled prompt and use lipglosss.Width
 		// instead of uniseg.StringWidth.
+		//
+		// XXX: Do we even need this or can we calculate the prompt width
+		// at render time?
 		m.promptWidth = uniseg.StringWidth(m.Prompt)
 	}
 
@@ -999,9 +1002,13 @@ func (m *Model) SetWidth(w int) {
 
 	// Add line number width to reserved inner width.
 	if m.ShowLineNumbers {
-		// XXX: this should almost certainly not be hardcoded.
-		const lnWidth = 4 // Up to 3 digits for line number plus 1 margin.
-		reservedInner += lnWidth
+		// XXX: this was originally documented as needing "1 cell" but was,
+		// in practice, hardcoded to effectively 2 cells. We can, and should,
+		// reduce this to one gap and update the tests accordingly.
+		const gap = 2
+
+		// Number of digits plus 1 cell for the margin.
+		reservedInner += numDigits(m.MaxHeight) + gap
 	}
 
 	// Input width must be at least one more than the reserved inner and outer
@@ -1610,6 +1617,20 @@ func repeatSpaces(n int) []rune {
 	return []rune(strings.Repeat(string(' '), n))
 }
 
+// numDigits returns the number of digits in an integer.
+func numDigits(n int) int {
+	if n == 0 {
+		return 1
+	}
+	count := 0
+	num := abs(n)
+	for num > 0 {
+		count++
+		num /= 10
+	}
+	return count
+}
+
 func clamp(v, low, high int) int {
 	if high < low {
 		low, high = high, low
@@ -1629,4 +1650,11 @@ func max(a, b int) int {
 		return a
 	}
 	return b
+}
+
+func abs(n int) int {
+	if n < 0 {
+		return -n
+	}
+	return n
 }

--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -1412,7 +1412,7 @@ func Blink() tea.Msg {
 //
 //	// In your top-level View function:
 //	f := tea.NewFrame(m.textarea.View())
-//	f.Cursor = m.textarea.RealCursor()
+//	f.Cursor = m.textarea.Cursor()
 //	f.Cursor.Position.X += offsetX
 //	f.Cursor.Position.Y += offsetY
 //

--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -1443,7 +1443,9 @@ func Blink() tea.Msg {
 // false.
 func (m Model) Cursor() *tea.Cursor {
 	lineInfo := m.LineInfo()
-	x, y := lineInfo.CharOffset, m.cursorLineNumber()-m.viewport.YOffset
+	w := lipgloss.Width
+	x := lineInfo.CharOffset + w(m.promptView(0)) + w(m.lineNumberView(0, false))
+	y := m.cursorLineNumber() - m.viewport.YOffset
 
 	c := tea.NewCursor(x, y)
 	c.Blink = m.Styles.Cursor.Blink

--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -986,9 +986,6 @@ func (m *Model) SetWidth(w int) {
 	// Update prompt width only if there is no prompt function as
 	// [SetPromptFunc] updates the prompt width when it is called.
 	if m.promptFunc == nil {
-		// XXX: This should account for a styled prompt and use lipglosss.Width
-		// instead of uniseg.StringWidth.
-		//
 		// XXX: Do we even need this or can we calculate the prompt width
 		// at render time?
 		m.promptWidth = uniseg.StringWidth(m.Prompt)
@@ -1003,7 +1000,7 @@ func (m *Model) SetWidth(w int) {
 	// Add line number width to reserved inner width.
 	if m.ShowLineNumbers {
 		// XXX: this was originally documented as needing "1 cell" but was,
-		// in practice, hardcoded to effectively 2 cells. We can, and should,
+		// in practice, effectively hardcoded to 2 cells. We can, and should,
 		// reduce this to one gap and update the tests accordingly.
 		const gap = 2
 
@@ -1238,7 +1235,7 @@ func (m Model) View() string {
 			}
 
 			// Note the widest line number for padding purposes later.
-			lnw := lipgloss.Width(ln)
+			lnw := uniseg.StringWidth(ln)
 			if lnw > widestLineNumber {
 				widestLineNumber = lnw
 			}
@@ -1283,7 +1280,7 @@ func (m Model) View() string {
 
 		// Write end of buffer content
 		leftGutter := string(m.EndOfBufferCharacter)
-		rightGapWidth := m.Width() - lipgloss.Width(leftGutter) + widestLineNumber
+		rightGapWidth := m.Width() - uniseg.StringWidth(leftGutter) + widestLineNumber
 		rightGap := strings.Repeat(" ", max(0, rightGapWidth))
 		s.WriteString(styles.computedEndOfBuffer().Render(leftGutter + rightGap))
 		s.WriteRune('\n')
@@ -1444,10 +1441,10 @@ func Blink() tea.Msg {
 func (m Model) Cursor() *tea.Cursor {
 	lineInfo := m.LineInfo()
 	w := lipgloss.Width
-	x := lineInfo.CharOffset + w(m.promptView(0)) + w(m.lineNumberView(0, false))
-	y := m.cursorLineNumber() - m.viewport.YOffset
+	xOffset := lineInfo.CharOffset + w(m.promptView(0)) + w(m.lineNumberView(0, false))
+	yOffset := m.cursorLineNumber() - m.viewport.YOffset
 
-	c := tea.NewCursor(x, y)
+	c := tea.NewCursor(xOffset, yOffset)
 	c.Blink = m.Styles.Cursor.Blink
 	c.Color = m.Styles.Cursor.Color
 	c.Shape = m.Styles.Cursor.Shape

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -671,7 +671,7 @@ func (m Model) View() string {
 		if m.canAcceptSuggestion() {
 			suggestion := m.matchedSuggestions[m.currentSuggestionIndex]
 			if len(value) < len(suggestion) {
-				m.Cursor.BlinkedStyle = m.CompletionStyle
+				m.Cursor.TextStyle = m.CompletionStyle
 				m.Cursor.SetChar(m.echoTransform(string(suggestion[pos])))
 				v += m.Cursor.View()
 				v += m.completionView(1)
@@ -709,7 +709,7 @@ func (m Model) placeholderView() string {
 	p := make([]rune, m.Width()+1)
 	copy(p, []rune(m.Placeholder))
 
-	m.Cursor.BlinkedStyle = m.PlaceholderStyle
+	m.Cursor.TextStyle = m.PlaceholderStyle
 	m.Cursor.SetChar(string(p[:1]))
 	v += m.Cursor.View()
 

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -671,7 +671,7 @@ func (m Model) View() string {
 		if m.canAcceptSuggestion() {
 			suggestion := m.matchedSuggestions[m.currentSuggestionIndex]
 			if len(value) < len(suggestion) {
-				m.Cursor.TextStyle = m.CompletionStyle
+				m.Cursor.BlinkedStyle = m.CompletionStyle
 				m.Cursor.SetChar(m.echoTransform(string(suggestion[pos])))
 				v += m.Cursor.View()
 				v += m.completionView(1)
@@ -709,7 +709,7 @@ func (m Model) placeholderView() string {
 	p := make([]rune, m.Width()+1)
 	copy(p, []rune(m.Placeholder))
 
-	m.Cursor.TextStyle = m.PlaceholderStyle
+	m.Cursor.BlinkedStyle = m.PlaceholderStyle
 	m.Cursor.SetChar(string(p[:1]))
 	v += m.Cursor.View()
 


### PR DESCRIPTION
This revision adds the missing pieces necessary for `textarea` to support a real cursor. Additionally, `Model.TextStyle` in the `cursor` package was renamed to `Model.BlinkedStyle` for clarity.