### PR TITLE
feat(table): additional help keys

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -13,8 +13,11 @@ import (
 
 // Model defines a state for the table widget.
 type Model struct {
-	KeyMap KeyMap
-	Help   help.Model
+	KeyMap                  KeyMap
+	additionalShortHelpKeys []key.Binding
+	additionalFullHelpKeys  [][]key.Binding
+
+	Help help.Model
 
 	cols   []Column
 	rows   []Row
@@ -198,6 +201,22 @@ func WithKeyMap(km KeyMap) Option {
 	}
 }
 
+// WithAdditionalShortHelpKeys adds additional keys to the short help.
+// you need to handle the keys itself!
+func WithAdditionalShortHelpKeys(kbs []key.Binding) Option {
+	return func(m *Model) {
+		m.additionalShortHelpKeys = kbs
+	}
+}
+
+// WithAdditionalFullHelpKeys adds additional keys to the full help.
+// you need to handle the keys itself!
+func WithAdditionalFullHelpKeys(kbs [][]key.Binding) Option {
+	return func(m *Model) {
+		m.additionalFullHelpKeys = kbs
+	}
+}
+
 // Update is the Bubble Tea update loop.
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	if !m.focus {
@@ -256,7 +275,18 @@ func (m Model) View() string {
 // Note that this view is not rendered by default and you must call it
 // manually in your application, where applicable.
 func (m Model) HelpView() string {
-	return m.Help.View(m.KeyMap)
+	if m.Help.ShowAll {
+		var kbs [][]key.Binding
+		kbs = append(kbs, m.KeyMap.FullHelp()...)
+		kbs = append(kbs, m.additionalFullHelpKeys...)
+		return m.Help.FullHelpView(kbs)
+	}
+
+	var kbs []key.Binding
+	kbs = append(kbs, m.KeyMap.ShortHelp()...)
+	kbs = append(kbs, m.additionalShortHelpKeys...)
+
+	return m.Help.ShortHelpView(kbs)
 }
 
 // UpdateViewport updates the list content based on the previously defined

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -1,6 +1,8 @@
 package table
 
 import (
+	"github.com/charmbracelet/bubbles/key"
+	"strings"
 	"testing"
 
 	"github.com/charmbracelet/lipgloss"
@@ -156,4 +158,47 @@ func TestTableAlignment(t *testing.T) {
 		got := ansi.Strip(baseStyle.Render(biscuits.View()))
 		golden.RequireEqual(t, []byte(got))
 	})
+}
+
+func TestAdditionalKeys(t *testing.T) {
+	biscuits := New(
+		WithHeight(5),
+		WithColumns([]Column{
+			{Title: "Name", Width: 25},
+			{Title: "Country of Origin", Width: 16},
+			{Title: "Dunk-able", Width: 12},
+		}),
+		WithRows([]Row{
+			{"Chocolate Digestives", "UK", "Yes"},
+			{"Tim Tams", "Australia", "No"},
+			{"Hobnobs", "UK", "Yes"},
+		}),
+		WithAdditionalShortHelpKeys([]key.Binding{
+			key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "shortkey")),
+		}),
+		WithAdditionalFullHelpKeys([][]key.Binding{
+			{
+				key.NewBinding(key.WithKeys("f"), key.WithHelp("s", "fullkey")),
+			},
+		}),
+	)
+
+	// short help
+	if !strings.Contains(biscuits.HelpView(), "shortkey") {
+		t.Fatalf("Error: short help view to contain '%s'", "shortkey")
+	}
+	if strings.Contains(biscuits.HelpView(), "fullkey") {
+		t.Fatalf("Error: short help should not contain '%s'", "fullkey")
+	}
+
+	// full help
+	biscuits.Help.ShowAll = true
+	if strings.Contains(biscuits.HelpView(), "shortkey") {
+		t.Fatalf("Error: full help should not contain '%s'", "shortkey")
+	}
+
+	if !strings.Contains(biscuits.HelpView(), "fullkey") {
+		t.Fatalf("Error: short help view to contain '%s'", "fullkey")
+	}
+
 }


### PR DESCRIPTION
adds additional keys to the `table` component:

```go
// additional short help keys
	tbl := table.New(
		table.WithAdditionalShortHelpKeys([]key.Binding{
			key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "shortkey")),
		}),
	)

        tbl.HelpView()
```

```go
// additional full help keys
	tbl := table.New(
		table.WithAdditionalFullHelpKeys([][]key.Binding{
			{
				key.NewBinding(key.WithKeys("f"), key.WithHelp("s", "fullkey")),
			},
		}),
	)
        tbl.Help.ShowAll = true

        tbl.HelpView()
```

> note: the handling of those keys must be done in your userland code!