### PR TITLE
fix(table): last row out of viewport

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -268,7 +268,7 @@ func (m *Model) UpdateViewport() {
 	// Constant runtime, independent of number of rows in a table.
 	// Limits the number of renderedRows to a maximum of 2*m.viewport.Height
 	if m.cursor >= 0 {
-		m.start = clamp(m.cursor-m.viewport.Height, 0, m.cursor)
+		m.start = clamp(m.cursor-(m.viewport.Height-1), 0, m.cursor)
 	} else {
 		m.start = 0
 	}


### PR DESCRIPTION
When a table cannot display all its rows, the viewport allows scrolling. However, the last row isn't visible.

For example for a table size of 7, the viewport height will be 5 (-2 because of the header). When setting the cursor at position 5, the 6th row should be visible, but isn't. This PR fixes this.

Because cursor is an index (starts at 0), we need to substract 1 to the viewport height to get the correct start position. Otherwise the viewport thinks it can display one more row than it can actually fit when rendering.