### PR TITLE
chore(links): switch bubbletea links to use main

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ applications. These components are used in production in [Glow][glow],
 A spinner, useful for indicating that some kind an operation is happening.
 There are a couple default ones, but you can also pass your own ”frames.”
 
-- [Example code, basic spinner](https://github.com/charmbracelet/bubbletea/tree/master/examples/spinner/main.go)
-- [Example code, various spinners](https://github.com/charmbracelet/bubbletea/tree/master/examples/spinners/main.go)
+- [Example code, basic spinner](https://github.com/charmbracelet/bubbletea/blob/main/examples/spinner/main.go)
+- [Example code, various spinners](https://github.com/charmbracelet/bubbletea/blob/main/examples/spinners/main.go)
 
 ## Text Input
 
@@ -35,8 +35,8 @@ A text input field, akin to an `<input type="text">` in HTML. Supports unicode,
 pasting, in-place scrolling when the value exceeds the width of the element and
 the common, and many customization options.
 
-- [Example code, one field](https://github.com/charmbracelet/bubbletea/tree/master/examples/textinput/main.go)
-- [Example code, many fields](https://github.com/charmbracelet/bubbletea/tree/master/examples/textinputs/main.go)
+- [Example code, one field](https://github.com/charmbracelet/bubbletea/blob/main/examples/textinput/main.go)
+- [Example code, many fields](https://github.com/charmbracelet/bubbletea/blob/main/examples/textinputs/main.go)
 
 ## Text Area
 
@@ -47,8 +47,8 @@ spans multiple lines. Supports unicode, pasting, vertical scrolling when the
 value exceeds the width and height of the element, and many customization
 options.
 
-- [Example code, chat input](https://github.com/charmbracelet/bubbletea/tree/master/examples/chat/main.go)
-- [Example code, story time input](https://github.com/charmbracelet/bubbletea/tree/master/examples/textarea/main.go)
+- [Example code, chat input](https://github.com/charmbracelet/bubbletea/blob/main/examples/chat/main.go)
+- [Example code, story time input](https://github.com/charmbracelet/bubbletea/blob/main/examples/textarea/main.go)
 
 ## Table
 
@@ -57,7 +57,7 @@ options.
 A component for displaying and navigating tabular data (columns and rows).
 Supports vertical scrolling and many customization options.
 
-- [Example code, countries and populations](https://github.com/charmbracelet/bubbletea/tree/master/examples/table/main.go)
+- [Example code, countries and populations](https://github.com/charmbracelet/bubbletea/blob/main/examples/table/main.go)
 
 ## Progress
 
@@ -68,8 +68,8 @@ A simple, customizable progress meter, with optional animation via
 runes can be set to whatever you'd like. The percentage readout is customizable
 and can also be omitted entirely.
 
-- [Animated example](https://github.com/charmbracelet/bubbletea/blob/master/examples/progress-animated/main.go)
-- [Static example](https://github.com/charmbracelet/bubbletea/blob/master/examples/progress-static/main.go)
+- [Animated example](https://github.com/charmbracelet/bubbletea/blob/main/examples/progress-animated/main.go)
+- [Static example](https://github.com/charmbracelet/bubbletea/blob/main/examples/progress-static/main.go)
 
 [harmonica]: https://github.com/charmbracelet/harmonica
 
@@ -82,7 +82,7 @@ Supports "dot-style" pagination (similar to what you might see on iOS) and
 numeric page numbering, but you could also just use this component for the
 logic and visualize pagination however you like.
 
-- [Example code](https://github.com/charmbracelet/bubbletea/blob/master/examples/paginator/main.go)
+- [Example code](https://github.com/charmbracelet/bubbletea/blob/main/examples/paginator/main.go)
 
 ## Viewport
 
@@ -92,7 +92,7 @@ A viewport for vertically scrolling content. Optionally includes standard
 pager keybindings and mouse wheel support. A high performance mode is available
 for applications which make use of the alternate screen buffer.
 
-- [Example code](https://github.com/charmbracelet/bubbletea/tree/master/examples/pager/main.go)
+- [Example code](https://github.com/charmbracelet/bubbletea/blob/main/examples/pager/main.go)
 
 This component is well complemented with [Reflow][reflow] for ANSI-aware
 indenting and text wrapping.
@@ -108,9 +108,9 @@ Features pagination, fuzzy filtering, auto-generated help, an activity spinner,
 and status messages, all of which can be enabled and disabled as needed.
 Extrapolated from [Glow][glow].
 
-- [Example code, default list](https://github.com/charmbracelet/bubbletea/tree/master/examples/list-default/main.go)
-- [Example code, simple list](https://github.com/charmbracelet/bubbletea/tree/master/examples/list-simple/main.go)
-- [Example code, all features](https://github.com/charmbracelet/bubbletea/tree/master/examples/list-fancy/main.go)
+- [Example code, default list](https://github.com/charmbracelet/bubbletea/blob/main/examples/list-default/main.go)
+- [Example code, simple list](https://github.com/charmbracelet/bubbletea/blob/main/examples/list-simple/main.go)
+- [Example code, all features](https://github.com/charmbracelet/bubbletea/blob/main/examples/list-fancy/main.go)
 
 ## File Picker
 
@@ -120,7 +120,7 @@ A customizable component for picking a file from the file system. Navigate
 through directories and select files, optionally limit to certain file
 extensions.
 
-- [Example code](https://github.com/charmbracelet/bubbletea/tree/master/examples/file-picker/main.go)
+- [Example code](https://github.com/charmbracelet/bubbletea/blob/main/examples/file-picker/main.go)
 
 ## Timer
 
@@ -129,7 +129,7 @@ can be customized as you like.
 
 <img src="https://stuff.charm.sh/bubbles-examples/timer.gif" width="400" alt="Timer example">
 
-- [Example code](https://github.com/charmbracelet/bubbletea/blob/master/examples/timer/main.go)
+- [Example code](https://github.com/charmbracelet/bubbletea/blob/main/examples/timer/main.go)
 
 ## Stopwatch
 
@@ -138,7 +138,7 @@ can be customized as you like.
 A simple, flexible component for counting up. The update frequency and output
 can be customized as you see fit.
 
-- [Example code](https://github.com/charmbracelet/bubbletea/blob/master/examples/stopwatch/main.go)
+- [Example code](https://github.com/charmbracelet/bubbletea/blob/main/examples/stopwatch/main.go)
 
 ## Help
 
@@ -149,7 +149,7 @@ from your keybindings. It features single and multi-line modes, which the user
 can optionally toggle between. It will truncate gracefully if the terminal is
 too wide for the content.
 
-- [Example code](https://github.com/charmbracelet/bubbletea/blob/master/examples/help/main.go)
+- [Example code](https://github.com/charmbracelet/bubbletea/blob/main/examples/help/main.go)
 
 ## Key
 
@@ -212,7 +212,7 @@ We’d love to hear your thoughts on this project. Feel free to drop us a note!
 
 ## License
 
-[MIT](https://github.com/charmbracelet/bubbletea/raw/master/LICENSE)
+[MIT](https://github.com/charmbracelet/bubbletea/raw/main/LICENSE)
 
 ---
 

--- a/list/README.md
+++ b/list/README.md
@@ -66,6 +66,6 @@ own `ItemDelegate` too ([example][customDelegate]).
 
 [kancli]: https://github.com/charmbracelet/kancli/blob/main/main.go#L45
 [itemDelegate]: https://pkg.go.dev/github.com/charmbracelet/bubbles/list#ItemDelegate
-[replacedLine]: https://github.com/charmbracelet/bubbletea/blob/master/examples/list-default/main.go#L77
-[listDefault]: https://github.com/charmbracelet/bubbletea/tree/master/examples/list-default
-[customDelegate]: https://github.com/charmbracelet/bubbletea/blob/master/examples/list-simple/main.go#L29-L50
+[replacedLine]: https://github.com/charmbracelet/bubbletea/blob/main/examples/list-default/main.go#L77
+[listDefault]: https://github.com/charmbracelet/bubbletea/tree/main/examples/list-default
+[customDelegate]: https://github.com/charmbracelet/bubbletea/blob/main/examples/list-simple/main.go#L29-L50


### PR DESCRIPTION
Cosmetic change in `README` files.

Links to `bubbletea` examples used `master` as the main branch. This resulted in a somewhat annoying message:

> Branch not found, redirected to default branch.

