### PR TITLE
ci: test on oldstable and stable go versions, automerge dependabot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,11 +6,9 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: ['1.23', '1.24']
+        go-version: [stable, oldstable]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    env:
-      GO111MODULE: "on"
     steps:
       - name: Install Go
         uses: actions/setup-go@v5
@@ -28,3 +26,22 @@ jobs:
 
       - name: Test
         run: go test ./...
+
+  dependabot:
+    needs: [test]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    if: ${{ github.actor == 'dependabot[bot]' && github.event_name == 'pull_request'}}
+    steps:
+      - id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --squash --auto "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
- stable and oldstable are the latest and previous versions, so we don't need to update this when a new release is out
- auto-merge dependabot PRs like we do on other projects