### PR TITLE
feat(viewport): expose XOffset field

### DIFF
--- a/viewport/viewport.go
+++ b/viewport/viewport.go
@@ -39,8 +39,8 @@ type Model struct {
 	// YOffset is the vertical scroll position.
 	YOffset int
 
-	// xOffset is the horizontal scroll position.
-	xOffset int
+	// XOffset is the horizontal scroll position.
+	XOffset int
 
 	// horizontalStep is the number of columns we move left or right during a
 	// default horizontal scroll.
@@ -116,10 +116,10 @@ func (m Model) ScrollPercent() float64 {
 // HorizontalScrollPercent returns the amount horizontally scrolled as a float
 // between 0 and 1.
 func (m Model) HorizontalScrollPercent() float64 {
-	if m.xOffset >= m.longestLineWidth-m.Width {
+	if m.XOffset >= m.longestLineWidth-m.Width {
 		return 1.0
 	}
-	y := float64(m.xOffset)
+	y := float64(m.XOffset)
 	h := float64(m.Width)
 	t := float64(m.longestLineWidth)
 	v := y / (t - h)
@@ -155,13 +155,13 @@ func (m Model) visibleLines() (lines []string) {
 		lines = m.lines[top:bottom]
 	}
 
-	if (m.xOffset == 0 && m.longestLineWidth <= w) || w == 0 {
+	if (m.XOffset == 0 && m.longestLineWidth <= w) || w == 0 {
 		return lines
 	}
 
 	cutLines := make([]string, len(lines))
 	for i := range lines {
-		cutLines[i] = ansi.Cut(lines[i], m.xOffset, m.xOffset+w)
+		cutLines[i] = ansi.Cut(lines[i], m.XOffset, m.XOffset+w)
 	}
 	return cutLines
 }
@@ -343,24 +343,24 @@ func (m *Model) SetHorizontalStep(n int) {
 
 // MoveLeft moves the viewport to the left by the given number of columns.
 func (m *Model) MoveLeft(cols int) {
-	m.xOffset -= cols
-	if m.xOffset < 0 {
-		m.xOffset = 0
+	m.XOffset -= cols
+	if m.XOffset < 0 {
+		m.XOffset = 0
 	}
 }
 
 // MoveRight moves viewport to the right by the given number of columns.
 func (m *Model) MoveRight(cols int) {
 	// prevents over scrolling to the right
-	if m.xOffset >= m.longestLineWidth-m.Width {
+	if m.XOffset >= m.longestLineWidth-m.Width {
 		return
 	}
-	m.xOffset += cols
+	m.XOffset += cols
 }
 
 // Resets lines indent to zero.
 func (m *Model) ResetIndent() {
-	m.xOffset = 0
+	m.XOffset = 0
 }
 
 // Update handles standard message-based viewport updates.

--- a/viewport/viewport_test.go
+++ b/viewport/viewport_test.go
@@ -91,28 +91,28 @@ func TestMoveLeft(t *testing.T) {
 		t.Parallel()
 
 		m := New(10, 10)
-		if m.xOffset != zeroPosition {
-			t.Errorf("default indent should be %d, got %d", zeroPosition, m.xOffset)
+		if m.XOffset != zeroPosition {
+			t.Errorf("default indent should be %d, got %d", zeroPosition, m.XOffset)
 		}
 
 		m.MoveLeft(m.horizontalStep)
-		if m.xOffset != zeroPosition {
-			t.Errorf("indent should be %d, got %d", zeroPosition, m.xOffset)
+		if m.XOffset != zeroPosition {
+			t.Errorf("indent should be %d, got %d", zeroPosition, m.XOffset)
 		}
 	})
 
 	t.Run("move", func(t *testing.T) {
 		t.Parallel()
 		m := New(10, 10)
-		if m.xOffset != zeroPosition {
-			t.Errorf("default indent should be %d, got %d", zeroPosition, m.xOffset)
+		if m.XOffset != zeroPosition {
+			t.Errorf("default indent should be %d, got %d", zeroPosition, m.XOffset)
 		}
 
-		m.xOffset = defaultHorizontalStep * 2
+		m.XOffset = defaultHorizontalStep * 2
 		m.MoveLeft(m.horizontalStep)
 		newIndent := defaultHorizontalStep
-		if m.xOffset != newIndent {
-			t.Errorf("indent should be %d, got %d", newIndent, m.xOffset)
+		if m.XOffset != newIndent {
+			t.Errorf("indent should be %d, got %d", newIndent, m.XOffset)
 		}
 	})
 }
@@ -127,14 +127,14 @@ func TestMoveRight(t *testing.T) {
 
 		m := New(10, 10)
 		m.SetContent("Some line that is longer than width")
-		if m.xOffset != zeroPosition {
-			t.Errorf("default indent should be %d, got %d", zeroPosition, m.xOffset)
+		if m.XOffset != zeroPosition {
+			t.Errorf("default indent should be %d, got %d", zeroPosition, m.XOffset)
 		}
 
 		m.MoveRight(m.horizontalStep)
 		newIndent := defaultHorizontalStep
-		if m.xOffset != newIndent {
-			t.Errorf("indent should be %d, got %d", newIndent, m.xOffset)
+		if m.XOffset != newIndent {
+			t.Errorf("indent should be %d, got %d", newIndent, m.XOffset)
 		}
 	})
 }
@@ -148,11 +148,11 @@ func TestResetIndent(t *testing.T) {
 		zeroPosition := 0
 
 		m := New(10, 10)
-		m.xOffset = 500
+		m.XOffset = 500
 
 		m.ResetIndent()
-		if m.xOffset != zeroPosition {
-			t.Errorf("indent should be %d, got %d", zeroPosition, m.xOffset)
+		if m.XOffset != zeroPosition {
+			t.Errorf("indent should be %d, got %d", zeroPosition, m.XOffset)
 		}
 	})
 }
@@ -196,7 +196,7 @@ func TestVisibleLines(t *testing.T) {
 
 		m := New(10, 10)
 		list := m.visibleLines()
-		m.xOffset = 5
+		m.XOffset = 5
 
 		if len(list) != 0 {
 			t.Errorf("list should be empty, got %d", len(list))
@@ -277,7 +277,7 @@ func TestVisibleLines(t *testing.T) {
 		m.MoveRight(m.horizontalStep)
 		list = m.visibleLines()
 
-		newPrefix := perceptPrefix[m.xOffset:]
+		newPrefix := perceptPrefix[m.XOffset:]
 		if !strings.HasPrefix(list[0], newPrefix) {
 			t.Errorf("first list item has to have prefix %s, get %s", newPrefix, list[0])
 		}
@@ -349,7 +349,7 @@ func TestVisibleLines(t *testing.T) {
 		}
 
 		// move left second times do not change lites if indent == 0
-		m.xOffset = 0
+		m.XOffset = 0
 		m.MoveLeft(horizontalStep)
 		list = m.visibleLines()
 		for i := range list {


### PR DESCRIPTION
I've run into a situation where I want to be able to move the viewport horizontally by a variable amount, and that amount (for example) is dictated by the width off all the content visible and to the left of my screen subtracted by my screen's width plus the viewport's `XOffset`. This allows me to do something like this:

https://github.com/user-attachments/assets/6d9caee8-dd9f-414a-936f-418a783568d7

Considering that we expose the `YOffset` it seems to make sense that we should also expose the `XOffset` as well.
