### PR TITLE
fix(list): Correct 

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -199,6 +199,9 @@ type Model struct {
 func New(items []Item, delegate ItemDelegate, width, height int) Model {
 	styles := DefaultStyles()
 
+	// Ensure help text does not exceed list width
+	styles.HelpStyle = styles.HelpStyle.Width(width)
+
 	sp := spinner.New()
 	sp.Spinner = spinner.Line
 	sp.Style = styles.Spinner


### PR DESCRIPTION
## Changes
- Adds `Width()` to `HelpStyle` to ensure the help text rendering does not exceed list's width

## Testing Notes
- Tested workaround with bubbles list by doing `myList.Styles.HelpStyle = myList.Styles.HelpStyle.Width(48)` which confirmed the help text as root cause for the behavior

[re: discord help thread](https://discord.com/channels/1032368467246075914/1296689096307245079)

Fixes #744