### PR TITLE
fix(viewport): normalize method names

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -350,14 +350,17 @@ func (m *Model) SetCursor(n int) {
 // It can not go above the first row.
 func (m *Model) MoveUp(n int) {
 	m.cursor = clamp(m.cursor-n, 0, len(m.rows)-1)
+
+	offset := m.viewport.YOffset()
 	switch {
 	case m.start == 0:
-		m.viewport.SetYOffset(clamp(m.viewport.YOffset, 0, m.cursor))
+		offset = clamp(offset, 0, m.cursor)
 	case m.start < m.viewport.Height():
-		m.viewport.YOffset = (clamp(clamp(m.viewport.YOffset+n, 0, m.cursor), 0, m.viewport.Height()))
-	case m.viewport.YOffset >= 1:
-		m.viewport.YOffset = clamp(m.viewport.YOffset+n, 1, m.viewport.Height())
+		offset = clamp(clamp(offset+n, 0, m.cursor), 0, m.viewport.Height())
+	case offset >= 1:
+		offset = clamp(offset+n, 1, m.viewport.Height())
 	}
+	m.viewport.SetYOffset(offset)
 	m.UpdateViewport()
 }
 
@@ -367,15 +370,17 @@ func (m *Model) MoveDown(n int) {
 	m.cursor = clamp(m.cursor+n, 0, len(m.rows)-1)
 	m.UpdateViewport()
 
+	offset := m.viewport.YOffset()
 	switch {
-	case m.end == len(m.rows) && m.viewport.YOffset > 0:
-		m.viewport.SetYOffset(clamp(m.viewport.YOffset-n, 1, m.viewport.Height()))
-	case m.cursor > (m.end-m.start)/2 && m.viewport.YOffset > 0:
-		m.viewport.SetYOffset(clamp(m.viewport.YOffset-n, 1, m.cursor))
-	case m.viewport.YOffset > 1:
-	case m.cursor > m.viewport.YOffset+m.viewport.Height()-1:
-		m.viewport.SetYOffset(clamp(m.viewport.YOffset+1, 0, 1))
+	case m.end == len(m.rows) && offset > 0:
+		offset = clamp(offset-n, 1, m.viewport.Height())
+	case m.cursor > (m.end-m.start)/2 && offset > 0:
+		offset = clamp(offset-n, 1, m.cursor)
+	case offset > 1:
+	case m.cursor > offset+m.viewport.Height()-1:
+		offset = clamp(offset+1, 0, 1)
 	}
+	m.viewport.SetYOffset(offset)
 }
 
 // GotoTop moves the selection to the first row.

--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -943,7 +943,7 @@ func (m Model) LineInfo() LineInfo {
 // repositionView repositions the view of the viewport based on the defined
 // scrolling behavior.
 func (m *Model) repositionView() {
-	minimum := m.viewport.YOffset
+	minimum := m.viewport.YOffset()
 	maximum := minimum + m.viewport.Height() - 1
 	if row := m.cursorLineNumber(); row < minimum {
 		m.viewport.ScrollUp(minimum - row)
@@ -1268,7 +1268,7 @@ func (m Model) View() string {
 
 	// Always show at least `m.Height` lines at all times.
 	// To do this we can simply pad out a few extra new lines in the view.
-	for i := 0; i < m.height; i++ {
+	for range m.height {
 		s.WriteString(m.promptView(displayLine))
 		displayLine++
 
@@ -1446,7 +1446,7 @@ func (m Model) Cursor() *tea.Cursor {
 		baseStyle.GetBorderLeftSize()
 
 	yOffset := m.cursorLineNumber() -
-		m.viewport.YOffset +
+		m.viewport.YOffset() +
 		baseStyle.GetMarginTop() +
 		baseStyle.GetPaddingTop() +
 		baseStyle.GetBorderTopSize()
@@ -1472,7 +1472,7 @@ func (m Model) memoizedWrap(runes []rune, width int) [][]rune {
 // This accounts for soft wrapped lines.
 func (m Model) cursorLineNumber() int {
 	line := 0
-	for i := 0; i < m.row; i++ {
+	for i := range m.row {
 		// Calculate the number of lines that the current line will be split
 		// into.
 		line += len(m.memoizedWrap(m.value[i], m.width))

--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -946,9 +946,9 @@ func (m *Model) repositionView() {
 	minimum := m.viewport.YOffset
 	maximum := minimum + m.viewport.Height() - 1
 	if row := m.cursorLineNumber(); row < minimum {
-		m.viewport.LineUp(minimum - row)
+		m.viewport.ScrollUp(minimum - row)
 	} else if row > maximum {
-		m.viewport.LineDown(row - maximum)
+		m.viewport.ScrollDown(row - maximum)
 	}
 }
 

--- a/textarea/textarea_test.go
+++ b/textarea/textarea_test.go
@@ -43,7 +43,7 @@ func TestVerticalScrolling(t *testing.T) {
 		"the text area.",
 	}
 	for _, line := range lines {
-		textarea.viewport.LineDown(1)
+		textarea.viewport.ScrollDown(1)
 		view = textarea.View()
 		if !strings.Contains(view, line) {
 			t.Log(view)

--- a/viewport/viewport.go
+++ b/viewport/viewport.go
@@ -514,7 +514,7 @@ func (m *Model) ScrollDown(n int) {
 	m.hiIdx = m.findNearedtMatch()
 }
 
-// ScrollUp moves the view down by the given number of lines. Returns the new
+// ScrollUp moves the view up by the given number of lines. Returns the new
 // lines to show.
 func (m *Model) ScrollUp(n int) {
 	if m.AtTop() || n == 0 || len(m.lines) == 0 {

--- a/viewport/viewport_test.go
+++ b/viewport/viewport_test.go
@@ -99,7 +99,7 @@ func TestMoveLeft(t *testing.T) {
 			t.Errorf("default indent should be %d, got %d", zeroPosition, m.xOffset)
 		}
 
-		m.MoveLeft(m.horizontalStep)
+		m.ScrollLeft(m.horizontalStep)
 		if m.xOffset != zeroPosition {
 			t.Errorf("indent should be %d, got %d", zeroPosition, m.xOffset)
 		}
@@ -108,12 +108,13 @@ func TestMoveLeft(t *testing.T) {
 	t.Run("move", func(t *testing.T) {
 		t.Parallel()
 		m := New(WithHeight(10), WithWidth(10))
+		m.longestLineWidth = 100
 		if m.xOffset != zeroPosition {
 			t.Errorf("default indent should be %d, got %d", zeroPosition, m.xOffset)
 		}
 
 		m.xOffset = defaultHorizontalStep * 2
-		m.MoveLeft(m.horizontalStep)
+		m.ScrollLeft(m.horizontalStep)
 		newIndent := defaultHorizontalStep
 		if m.xOffset != newIndent {
 			t.Errorf("indent should be %d, got %d", newIndent, m.xOffset)
@@ -135,7 +136,7 @@ func TestMoveRight(t *testing.T) {
 			t.Errorf("default indent should be %d, got %d", zeroPosition, m.xOffset)
 		}
 
-		m.MoveRight(m.horizontalStep)
+		m.ScrollRight(m.horizontalStep)
 		newIndent := defaultHorizontalStep
 		if m.xOffset != newIndent {
 			t.Errorf("indent should be %d, got %d", newIndent, m.xOffset)
@@ -154,7 +155,7 @@ func TestResetIndent(t *testing.T) {
 		m := New(WithHeight(10), WithWidth(10))
 		m.xOffset = 500
 
-		m.ResetIndent()
+		m.SetXOffset(0)
 		if m.xOffset != zeroPosition {
 			t.Errorf("indent should be %d, got %d", zeroPosition, m.xOffset)
 		}
@@ -233,7 +234,7 @@ func TestVisibleLines(t *testing.T) {
 
 		m := New(WithHeight(numberOfLines), WithWidth(10))
 		m.SetContent(strings.Join(defaultList, "\n"))
-		m.YOffset = 5
+		m.SetYOffset(5)
 
 		list := m.visibleLines()
 		if len(list) != numberOfLines {
@@ -246,7 +247,7 @@ func TestVisibleLines(t *testing.T) {
 
 		lastItemIdx := numberOfLines - 1
 		// we trim line if it doesn't fit to width of the viewport
-		shouldGet := defaultList[m.YOffset+lastItemIdx][:m.Width()]
+		shouldGet := defaultList[m.YOffset()+lastItemIdx][:m.Width()]
 		if list[lastItemIdx] != shouldGet {
 			t.Errorf(`%dth list item should be '%s', got '%s'`, lastItemIdx, shouldGet, list[lastItemIdx])
 		}
@@ -258,7 +259,7 @@ func TestVisibleLines(t *testing.T) {
 
 		m := New(WithHeight(numberOfLines), WithWidth(10))
 		m.lines = defaultList
-		m.YOffset = 7
+		m.SetYOffset(7)
 
 		// default list
 		list := m.visibleLines()
@@ -278,7 +279,7 @@ func TestVisibleLines(t *testing.T) {
 		}
 
 		// move right
-		m.MoveRight(m.horizontalStep)
+		m.ScrollRight(m.horizontalStep)
 		list = m.visibleLines()
 
 		newPrefix := perceptPrefix[m.xOffset:]
@@ -291,7 +292,7 @@ func TestVisibleLines(t *testing.T) {
 		}
 
 		// move left
-		m.MoveLeft(m.horizontalStep)
+		m.ScrollLeft(m.horizontalStep)
 		list = m.visibleLines()
 		if !strings.HasPrefix(list[0], perceptPrefix) {
 			t.Errorf("first list item has to have prefix %s", perceptPrefix)
@@ -333,7 +334,7 @@ func TestVisibleLines(t *testing.T) {
 		}
 
 		// move right
-		m.MoveRight(horizontalStep)
+		m.ScrollRight(horizontalStep)
 		list = m.visibleLines()
 
 		for i := range list {
@@ -344,7 +345,7 @@ func TestVisibleLines(t *testing.T) {
 		}
 
 		// move left
-		m.MoveLeft(horizontalStep)
+		m.ScrollLeft(horizontalStep)
 		list = m.visibleLines()
 		for i := range list {
 			if list[i] != initList[i] {
@@ -354,7 +355,7 @@ func TestVisibleLines(t *testing.T) {
 
 		// move left second times do not change lites if indent == 0
 		m.xOffset = 0
-		m.MoveLeft(horizontalStep)
+		m.ScrollLeft(horizontalStep)
 		list = m.visibleLines()
 		for i := range list {
 			if list[i] != initList[i] {
@@ -374,7 +375,7 @@ func TestRightOverscroll(t *testing.T) {
 		m.SetContent(content)
 
 		for i := 0; i < 10; i++ {
-			m.MoveRight(m.horizontalStep)
+			m.ScrollRight(m.horizontalStep)
 		}
 
 		visibleLines := m.visibleLines()


### PR DESCRIPTION
this ports #763 to v2, removes the deprecated methods, and also normalize YOffset so it works the same as XOffset.

It also adds the `YOffset` and `XOffset` methods to get their respective values.