### PR TITLE
fix(table): Selected row styling not applying to cells.

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -426,17 +426,44 @@ func (m *Model) renderRow(r int) string {
 			continue
 		}
 		style := lipgloss.NewStyle().Width(m.cols[i].Width).MaxWidth(m.cols[i].Width).Inline(true)
-		renderedCell := m.styles.Cell.Render(style.Render(runewidth.Truncate(value, m.cols[i].Width, "…")))
+		cellContent := style.Render(runewidth.Truncate(value, m.cols[i].Width, "…"))
+		cellStyle := m.styles.Cell
+		if r == m.cursor {
+			// borrows necessary selected row styling
+			cellStyle = m.getSelRowCellStyle()
+		}
+		renderedCell := cellStyle.Render(cellContent)
 		s = append(s, renderedCell)
 	}
 
 	row := lipgloss.JoinHorizontal(lipgloss.Top, s...)
 
 	if r == m.cursor {
-		return m.styles.Selected.Render(row)
+		// if not unset, these styles will break cell styling
+		return m.styles.Selected.
+			UnsetUnderline().
+			UnsetUnderlineSpaces().
+			UnsetStrikethrough().
+			UnsetStrikethroughSpaces().
+			Render(row)
 	}
 
 	return row
+}
+
+func (m Model) getSelRowCellStyle() lipgloss.Style {
+	s := m.styles.Selected
+	return m.styles.Cell.Foreground(s.GetForeground()).
+		Background(s.GetBackground()).
+		Italic(s.GetItalic()).
+		Bold(s.GetBold()).
+		Blink(s.GetBlink()).
+		Reverse(s.GetReverse()).
+		Faint(s.GetFaint()).
+		Underline(s.GetUnderline()).
+		UnderlineSpaces(s.GetUnderlineSpaces()).
+		Strikethrough(s.GetStrikethrough()).
+		StrikethroughSpaces(s.GetStrikethroughSpaces())
 }
 
 func clamp(v, low, high int) int {


### PR DESCRIPTION
Selected row styling not applying to individual cells.
- Fixes #729
- Now applies necessary selected row styling to the individual cells.

```go
s := table.DefaultStyles()
	s.Header = s.Header.
		BorderStyle(lipgloss.NormalBorder()).
		BorderForeground(lipgloss.Color("240")).
		BorderBottom(true).
		Bold(false)
	s.Selected = s.Selected.
		Foreground(lipgloss.Color("229")).
		Background(lipgloss.Color("57")).
		Bold(true).
		Italic(true).
		Underline(true)
	s.Cell = s.Cell.
		Foreground(lipgloss.Color("57"))
	t.SetStyles(s)
```

Before:
<img src="https://github.com/user-attachments/assets/a6661f0c-87a9-41b1-a533-99d3b26c3a47" width="720" alt="Before">
After:
<img src="https://github.com/user-attachments/assets/067983b4-6276-4d96-a996-a345d8b7b5e8" width="350" alt="Before">

You can experiment further...

