### PR TITLE
(v2) Add focus status to textarea's setPromptFunc

### DIFF
--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -287,7 +287,7 @@ type Model struct {
 
 	// If promptFunc is set, it replaces Prompt as a generator for
 	// prompt strings at the beginning of each line.
-	promptFunc func(line int) string
+	promptFunc func(line int, focused bool) string
 
 	// promptWidth is the width of the prompt.
 	promptWidth int
@@ -1052,7 +1052,7 @@ func (m *Model) SetWidth(w int) {
 // promptWidth, it will be padded to the left. If it returns a prompt that is
 // longer, display artifacts may occur; the caller is responsible for computing
 // an adequate promptWidth.
-func (m *Model) SetPromptFunc(promptWidth int, fn func(lineIndex int) string) {
+func (m *Model) SetPromptFunc(promptWidth int, fn func(lineIndex int, focused bool) string) {
 	m.promptFunc = fn
 	m.promptWidth = promptWidth
 }
@@ -1320,7 +1320,7 @@ func (m Model) promptView(displayLine int) (prompt string) {
 	if m.promptFunc == nil {
 		return prompt
 	}
-	prompt = m.promptFunc(displayLine)
+	prompt = m.promptFunc(displayLine, m.focus)
 	width := lipgloss.Width(prompt)
 	if width < m.promptWidth {
 		prompt = fmt.Sprintf("%*s%s", m.promptWidth-width, "", prompt)


### PR DESCRIPTION
This gives focus status to the prompt. We may want to reexamine this and add more metadata.

```go
// Before
func (m *Model) SetPromptFunc(promptWidth int, fn func(lineIndex int) string)

// After
func (m *Model) SetPromptFunc(promptWidth int, fn func(lineIndex int, focused bool) string)
```