### PR TITLE
fix: enforce path !empty check no matter file/dir allow states

### DIFF
--- a/filepicker/filepicker.go
+++ b/filepicker/filepicker.go
@@ -496,7 +496,7 @@ func (m Model) didSelectFile(msg tea.Msg) (bool, string) {
 			}
 		}
 
-		if (!isDir && m.FileAllowed) || (isDir && m.DirAllowed) && m.Path != "" {
+		if ((!isDir && m.FileAllowed) || (isDir && m.DirAllowed)) && m.Path != "" {
 			return true, m.Path
 		}
 


### PR DESCRIPTION
### Describe your changes

This PR corrects didSelectFile()'s logical precendence. Currently, `m.Path`'s nil check is included in the truth value of `isDir && m.DirAllowed` rather than being a separate truth value. This is due to Go considering logical AND to have a higher precedence than logical OR ([source](https://go.dev/ref/spec#Operator_precedence)).

### Related issue/discussion: N/A

### Tests/Steps To Reproduce

You can recreate this issue without any Bubble Tea infrastructure. Here is a trivial example:

```go
func main() {
	path := ""
	fmt.Printf("%v <-- Current\n", true || false && path != "")
	fmt.Printf("%v <-- After This PR\n", (true || false) && path != "")
}
```

Will result in:
```
$ go run main.go 
true <-- Current
false <-- After This PR
```


### Checklist before requesting a review

- [x] I have read `CONTRIBUTING.md`
- [x] I have performed a self-review of my code