### PR TITLE
feat:  add an optional modtime section to the filepicker

### DIFF
--- a/filepicker/filepicker.go
+++ b/filepicker/filepicker.go
@@ -17,6 +17,9 @@ import (
 	"github.com/dustin/go-humanize"
 )
 
+// DefaultModTimeLayout is the default layout used to format modification time for a given file.
+const DefaultModTimeLayout = "Jan _2 15:04"
+
 var lastID int64
 
 func nextID() int {
@@ -34,6 +37,7 @@ func New() Model {
 		ShowPermissions:  true,
 		ShowSize:         true,
 		ShowHidden:       false,
+		ModTimeLayout:    DefaultModTimeLayout,
 		DirAllowed:       false,
 		FileAllowed:      true,
 		AutoHeight:       true,
@@ -103,6 +107,7 @@ type Styles struct {
 	Selected         lipgloss.Style
 	DisabledSelected lipgloss.Style
 	FileSize         lipgloss.Style
+	ModTime          lipgloss.Style
 	EmptyDirectory   lipgloss.Style
 }
 
@@ -125,6 +130,7 @@ func DefaultStylesWithRenderer(r *lipgloss.Renderer) Styles {
 		Permission:       r.NewStyle().Foreground(lipgloss.Color("244")),
 		Selected:         r.NewStyle().Foreground(lipgloss.Color("212")).Bold(true),
 		FileSize:         r.NewStyle().Foreground(lipgloss.Color("240")).Width(fileSizeWidth).Align(lipgloss.Right),
+		ModTime:          r.NewStyle().Foreground(lipgloss.Color("240")),
 		EmptyDirectory:   r.NewStyle().Foreground(lipgloss.Color("240")).PaddingLeft(paddingLeft).SetString("Bummer. No Files Found."),
 	}
 }
@@ -147,6 +153,8 @@ type Model struct {
 	files           []os.DirEntry
 	ShowPermissions bool
 	ShowSize        bool
+	ShowModTime     bool
+	ModTimeLayout   string
 	ShowHidden      bool
 	DirAllowed      bool
 	FileAllowed     bool
@@ -400,6 +408,9 @@ func (m Model) View() string {
 			if m.ShowSize {
 				selected += fmt.Sprintf("%"+strconv.Itoa(m.Styles.FileSize.GetWidth())+"s", size)
 			}
+			if m.ShowModTime {
+				selected += " " + info.ModTime().Format(m.ModTimeLayout)
+			}
 			selected += " " + name
 			if isSymlink {
 				selected += " → " + symlinkPath
@@ -432,6 +443,9 @@ func (m Model) View() string {
 		}
 		if m.ShowSize {
 			s.WriteString(m.Styles.FileSize.Render(size))
+		}
+		if m.ShowModTime {
+			s.WriteString(" " + m.Styles.ModTime.Render(info.ModTime().Format(m.ModTimeLayout)))
 		}
 		s.WriteString(" " + fileName)
 		s.WriteRune('\n')


### PR DESCRIPTION
### Describe your changes

Add an optional modtime section to the filepicker. This makes the filepicker looks like a bit more `ls -l`. 

For backward compatibility this is disabled by default.

The default modification time layout format is similar to the one in `ls -l`. This is configurable using standard time.Format() supported layouts.

### Related issue/discussion: 

Fixes:  #780 Add modification time to the filepicker  

### Checklist before requesting a review

- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my code

### If this is a feature

- [X] I have created a discussion
- [X] A project maintainer has approved this feature request. Link to comment: https://github.com/charmbracelet/bubbles/discussions/792#discussioncomment-13587355
