### PR TITLE
v2: feat(textarea): add VisibleYOffset and ScrollPosition methods

### DIFF
--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -591,9 +591,21 @@ func (m *Model) LineCount() int {
 	return len(m.value)
 }
 
-// Line returns the line position.
+// Line returns the row position of the cursor.
 func (m Model) Line() int {
 	return m.row
+}
+
+// ScrollYOffset returns the Y offset (top row) index of the current view, which
+// can be used to calculate the current scroll position.
+func (m Model) ScrollYOffset() int {
+	return m.viewport.YOffset()
+}
+
+// ScrollPercent returns the amount of the textarea that is currently scrolled
+// through, clamped between 0 and 1.
+func (m Model) ScrollPercent() float64 {
+	return m.viewport.ScrollPercent()
 }
 
 // CursorDown moves the cursor down by one line.


### PR DESCRIPTION
### Describe your changes

- Added `VisibleYOffset()` method to textarea component, which can be used to properly calculate scrolling position of the underlying viewport.
  - Can't use `LineCount()` and `Line()`, because then the scroll position is based off the cursor position, which isn't typical for scrollbars.
  - I decided against `YOffset()` as that could be confused with the position of the cursor.
- Added `ScrollPercent()` for similar reasons as to why it's within `viewport` as well, for those who want the scroll position as a percentage.

With either of the above, a proper scrollbar can be achieved, like so:

![](https://cdn.liam.sh/share/2025/08/WindowsTerminal_PjI2aIg480.gif)

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request.
