### PR TITLE
feat(textarea): let user choose word or rune wrap

### DIFF
--- a/textarea/textarea_test.go
+++ b/textarea/textarea_test.go
@@ -606,7 +606,7 @@ func TestView(t *testing.T) {
 			},
 		},
 		{
-			name: "softwrap",
+			name: "softwrap-word",
 			modelFunc: func(m Model) Model {
 				m.ShowLineNumbers = false
 				m.Prompt = ""
@@ -628,6 +628,31 @@ func TestView(t *testing.T) {
 				`),
 				cursorRow: 2,
 				cursorCol: 3,
+			},
+		},
+		{
+			name: "softwrap-rune",
+			modelFunc: func(m Model) Model {
+				m.ShowLineNumbers = false
+				m.Prompt = ""
+				m.SetWidth(5)
+				m.SetWrapMode(RuneWrap)
+
+				input := "foobarbaz"
+				m = sendString(m, input)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					fooba
+					rbaz
+
+
+
+				`),
+				cursorRow: 1,
+				cursorCol: 4,
 			},
 		},
 		{


### PR DESCRIPTION
This PR provides an alternative to word wrap that just calls `ansi.Hardwrap`. It makes `textarea` act more like a typical code editor.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features): #846
