### PR TITLE
feat: make moveToBegin and moveToEnd public methods

### DIFF
--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -870,14 +870,14 @@ func (m Model) Width() int {
 	return m.width
 }
 
-// moveToBegin moves the cursor to the beginning of the input.
-func (m *Model) moveToBegin() {
+// MoveToBegin moves the cursor to the beginning of the input.
+func (m *Model) MoveToBegin() {
 	m.row = 0
 	m.SetCursor(0)
 }
 
-// moveToEnd moves the cursor to the end of the input.
-func (m *Model) moveToEnd() {
+// MoveToEnd moves the cursor to the end of the input.
+func (m *Model) MoveToEnd() {
 	m.row = len(m.value) - 1
 	m.SetCursor(len(m.value[m.row]))
 }
@@ -1049,9 +1049,9 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		case key.Matches(msg, m.KeyMap.WordBackward):
 			m.wordLeft()
 		case key.Matches(msg, m.KeyMap.InputBegin):
-			m.moveToBegin()
+			m.MoveToBegin()
 		case key.Matches(msg, m.KeyMap.InputEnd):
-			m.moveToEnd()
+			m.MoveToEnd()
 		case key.Matches(msg, m.KeyMap.LowercaseWordForward):
 			m.lowercaseRight()
 		case key.Matches(msg, m.KeyMap.UppercaseWordForward):


### PR DESCRIPTION
I wanted to populate the `textarea` with multiple lines and then have the cursor start on the first line but I could not figure out an easy way to do that. I noticed that the `textarea` model already has methods that allow this functionality but these methods are private. I changed them to be public. Not sure if this change would be desirable or if we already have an easier way to do this but figured I would bring it up.

Currently what happens after I populate `textarea` with `SetValue()` method (the cursor is at the end of the text): 
<img width="500" alt="default behavior" src="https://github.com/user-attachments/assets/efe19806-7f9e-4a26-8944-38bfe7e5b95d" />

With `MoveToBegin()`:
<img  width="500" alt="with MoveToBegin" src="https://github.com/user-attachments/assets/2ee611c9-8d26-4ee8-841e-74c44099e4f4" />

With `MoveToBegin()` and then followed by `MoveToEnd()`:
<img width="500" alt="with MoveTobeing first then MoveToEnd" src="https://github.com/user-attachments/assets/edbac294-1106-4203-a01f-77c247686f50" />


- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features). `Not sure it this was necessary.`