### PR TITLE
Add ability to hide the no items content

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -150,6 +150,7 @@ type Model struct {
 	showStatusBar    bool
 	showPagination   bool
 	showHelp         bool
+	showNoItems      bool
 	filteringEnabled bool
 
 	itemNameSingular string
@@ -229,6 +230,7 @@ func New(items []Item, delegate ItemDelegate, width, height int) Model {
 		showStatusBar:         true,
 		showPagination:        true,
 		showHelp:              true,
+		showNoItems:           true,
 		itemNameSingular:      "item",
 		itemNamePlural:        "items",
 		filteringEnabled:      true,
@@ -276,6 +278,12 @@ func (m Model) FilteringEnabled() bool {
 // SetShowTitle shows or hides the title bar.
 func (m *Model) SetShowTitle(v bool) {
 	m.showTitle = v
+	m.updatePagination()
+}
+
+// SetShowNoItems shows or hides the no item message.
+func (m *Model) SetShowNoItems(v bool) {
+	m.showNoItems = v
 	m.updatePagination()
 }
 
@@ -1219,7 +1227,11 @@ func (m Model) populatedView() string {
 		if m.filterState == Filtering {
 			return ""
 		}
-		return m.Styles.NoItems.Render("No " + m.itemNamePlural + ".")
+		if m.showNoItems {
+			return m.Styles.NoItems.Render("No " + m.itemNamePlural + ".")
+		} else {
+			return ""
+		}
 	}
 
 	if len(items) > 0 {


### PR DESCRIPTION
- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

Adds the ability to hide the no items message. This is nice to have as when  This prevents 

Below, I'm showing what it looks like when setting `SetShowNoItems` with the [list-fancy](https://github.com/charmbracelet/bubbletea/blob/main/examples/list-fancy/main.go) example.

<details>
<summary>SetShowNoItems(false)</summary>

<img width="676" height="271" alt="image" src="https://github.com/user-attachments/assets/12495b28-2ff3-4a60-9220-2d5261ebe64a" />

</details>

<details>
<summary>SetShowNoItems(true)</summary>

1. This is the default (to keep existing behaviour unchanged), so someone doesn't need to set this when upgrading

<img width="676" height="271" alt="image" src="https://github.com/user-attachments/assets/21c48054-dda3-4eaf-9094-ad2d44b74e9c" />

As you can see, the no items message is duplicated in the status bar and content sections.

</details>
