### PR TITLE
Add ability to customize the list status message location

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -143,6 +143,14 @@ func (f FilterState) String() string {
 	}[f]
 }
 
+// The location to render the status message
+type StatusMessageLocation int
+
+const (
+	InTitle StatusMessageLocation = iota
+	InStatusBar
+)
+
 // Model contains the state of this component.
 type Model struct {
 	showTitle        bool
@@ -189,8 +197,9 @@ type Model struct {
 	// 1 second.
 	StatusMessageLifetime time.Duration
 
-	statusMessage      string
-	statusMessageTimer *time.Timer
+	statusMessage         string
+	StatusMessageLocation StatusMessageLocation
+	statusMessageTimer    *time.Timer
 
 	// The master set of items we're working with.
 	items []Item
@@ -1118,7 +1127,7 @@ func (m Model) titleView() string {
 		view += m.Styles.Title.Render(m.Title)
 
 		// Status message
-		if m.filterState != Filtering {
+		if m.filterState != Filtering && m.StatusMessageLocation == InTitle {
 			view += "  " + m.statusMessage
 			view = ansi.Truncate(view, m.width-spinnerWidth, ellipsis)
 		}
@@ -1182,6 +1191,10 @@ func (m Model) statusView() string {
 	if numFiltered > 0 {
 		status += m.Styles.DividerDot.String()
 		status += m.Styles.StatusBarFilterCount.Render(fmt.Sprintf("%d filtered", numFiltered))
+	}
+	if m.StatusMessageLocation == InStatusBar && m.statusMessage != "" {
+		status += m.Styles.DividerDot.String()
+		status += m.statusMessage
 	}
 
 	return m.Styles.StatusBar.Render(status)


### PR DESCRIPTION
- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

Adds an option to configure the location of the status message (either between the title (default), or in the status bar). 

Intuitively, when implementing my own list I believed that the status message would be shown in the status bar and was confused when my list wasn't showing the message because I had hidden the tittle. I believe this customization allows the use of status message without requiring the title be shown. 

<details>
<summary>l.StatusMessageLocation = list.InStatusBar</summary>

https://github.com/user-attachments/assets/d563b6d5-45b8-40b0-ad45-2a099bd77376

</details>

<details>
<summary>l.StatusMessageLocation = list.InTitle</summary>

This is the default behaviour that matches the current behaviour.

https://github.com/user-attachments/assets/e64cc285-f52c-4c8d-b3e6-f20bfda5e6bd

</details>