### PR TITLE
feat(horizontal layout): add horizontal grid view for list

### DIFF
--- a/list/keys.go
+++ b/list/keys.go
@@ -8,6 +8,8 @@ type KeyMap struct {
 	// Keybindings used when browsing the list.
 	CursorUp    key.Binding
 	CursorDown  key.Binding
+	CursorLeft  key.Binding
+	CursorRight key.Binding
 	NextPage    key.Binding
 	PrevPage    key.Binding
 	GoToStart   key.Binding
@@ -41,6 +43,14 @@ func DefaultKeyMap() KeyMap {
 		CursorDown: key.NewBinding(
 			key.WithKeys("down", "j"),
 			key.WithHelp("↓/j", "down"),
+		),
+		CursorLeft: key.NewBinding(
+			key.WithKeys("left", "h"),
+			key.WithHelp("←/h", "left"),
+		),
+		CursorRight: key.NewBinding(
+			key.WithKeys("right", "l"),
+			key.WithHelp("→/l", "right"),
 		),
 		PrevPage: key.NewBinding(
 			key.WithKeys("left", "h", "pgup", "b", "u"),

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -17,6 +17,7 @@ func (i item) FilterValue() string { return string(i) }
 type itemDelegate struct{}
 
 func (d itemDelegate) Height() int                          { return 1 }
+func (d itemDelegate) Width() int                           { return 8 }
 func (d itemDelegate) Spacing() int                         { return 0 }
 func (d itemDelegate) Update(msg tea.Msg, m *Model) tea.Cmd { return nil }
 func (d itemDelegate) Render(w io.Writer, m Model, index int, listItem Item) {
@@ -134,4 +135,140 @@ func TestSetFilterState(t *testing.T) {
 	if !strings.Contains(footer, expected) {
 		t.Fatalf("Error: expected view to contain '%s'", expected)
 	}
+}
+
+func TestHorizontalEnabled(t *testing.T) {
+	items := make([]Item, 20)
+	for i := range items {
+		items[i] = item(fmt.Sprintf("item %d", i+1))
+	}
+
+	// Create a list with enough height for one row, but enough width for multiple columns
+	// Delegate height is 1, spacing 0. So 1 item height + 0 spacing = 1 row height per item.
+	// A height of 10 means 10 rows fit vertically.
+	// A width of 20, with itemDelegate width 8, spacing 0.
+	// 8 width + (0*2) spacing = 8 width per item.
+	// 20 width / 8 per item = 2.5 columns, so 2 columns fit.
+	list := New(items, itemDelegate{}, 20, 10)
+
+	// Simplify testing
+	list.SetShowPagination(false)
+	list.SetShowHelp(false)
+	list.SetShowStatusBar(false)
+	list.SetShowFilter(false)
+	list.SetShowTitle(false)
+
+	t.Run("Vertical Layout", func(t *testing.T) {
+		list.SetHorizontalEnabled(false)
+
+		// Expect 10 items per page (height 10 / itemHeight 1)
+		if list.Paginator.PerPage != 10 {
+			t.Errorf("Expected 10 items per page in vertical layout, got %d", list.Paginator.PerPage)
+		}
+		if list.Paginator.TotalPages != 2 { // 20 items / 10 per page = 2 pages
+			t.Errorf("Expected 2 total pages in vertical layout, got %d", list.Paginator.TotalPages)
+		}
+
+		// CursorDown should move to the next row (next item)
+		list.cursor = 0
+		list.CursorDown()
+		if list.cursor != 1 {
+			t.Errorf("Expected cursor to be 1 after CursorDown in vertical, got %d", list.cursor)
+		}
+
+		// CursorUp should move to the previous row (previous item)
+		list.CursorUp()
+		if list.cursor != 0 {
+			t.Errorf("Expected cursor to be 0 after CursorUp in vertical, got %d", list.cursor)
+		}
+
+		// CursorLeft/Right should not move the cursor
+		list.CursorLeft()
+		if list.cursor != 0 {
+			t.Errorf("Expected cursor to be 0 after CursorLeft in vertical, got %d", list.cursor)
+		}
+		list.CursorRight()
+		if list.cursor != 0 {
+			t.Errorf("Expected cursor to be 0 after CursorRight in vertical, got %d", list.cursor)
+		}
+	})
+
+	t.Run("Horizontal Layout", func(t *testing.T) {
+		list.SetHorizontalEnabled(true)
+
+		// Expected 2 columns per page (width 20 / itemWidth 8)
+		// Expected 10 rows per page (height 10 / itemHeight 1)
+		// PerPage = 2 columns * 10 rows = 20 items per page
+		if list.Paginator.PerPage != 20 {
+			t.Errorf("Expected 20 items per page in horizontal layout, got %d", list.Paginator.PerPage)
+		}
+		if list.Paginator.TotalPages != 1 { // 20 items / 20 per page = 1 page
+			t.Errorf("Expected 1 total page in horizontal layout, got %d", list.Paginator.TotalPages)
+		}
+
+		// CursorDown should move down by a full column width (2 items)
+		list.cursor = 0
+		list.CursorDown()
+		if list.cursor != 2 { // Moved to the item in the next "row" within the horizontal flow
+			t.Errorf("Expected cursor to be 2 after CursorDown in horizontal, got %d", list.cursor)
+		}
+
+		// CursorUp should move up by a full column width (2 items)
+		list.CursorUp()
+		if list.cursor != 0 {
+			t.Errorf("Expected cursor to be 0 after CursorUp in horizontal, got %d", list.cursor)
+		}
+
+		// CursorRight should move to the next item
+		list.CursorRight()
+		if list.cursor != 1 {
+			t.Errorf("Expected cursor to be 1 after CursorRight in horizontal, got %d", list.cursor)
+		}
+
+		// CursorLeft should move to the previous item
+		list.CursorLeft()
+		if list.cursor != 0 {
+			t.Errorf("Expected cursor to be 0 after CursorLeft in horizontal, got %d", list.cursor)
+		}
+
+		// Test moving to next page with CursorRight if infinite scrolling is enabled
+		list.InfiniteScrolling = true
+		list.SetItems(make([]Item, 30)) // More items to create multiple pages horizontally
+		list.SetSize(20, 10)            // Recalculate pagination
+
+		// Should still be 2 columns * 10 rows = 20 items per page
+		if list.Paginator.PerPage != 20 {
+			t.Errorf("Expected 20 items per page for 30 items, got %d", list.Paginator.PerPage)
+		}
+		if list.Paginator.TotalPages != 2 { // 30 items / 20 per page = 2 pages
+			t.Errorf("Expected 2 total pages for 30 items, got %d", list.Paginator.TotalPages)
+		}
+
+		list.Paginator.Page = 0
+		list.cursor = 19 // Last item on the first page
+
+		list.CursorRight() // Move past the end of the page
+		if list.Paginator.Page != 1 || list.cursor != 0 {
+			t.Errorf("Expected to move to page 1, cursor 0, but got page %d, cursor %d", list.Paginator.Page, list.cursor)
+		}
+
+		list.cursor = 9 // On the second row of the first page
+		list.Paginator.Page = 0
+
+		list.CursorDown()
+		if list.cursor != 11 { // 9 + 2 (columns)
+			t.Errorf("Expected cursor to be 11, got %d", list.cursor)
+		}
+
+		// Test moving to previous page with CursorLeft if infinite scrolling is enabled
+		list.Paginator.Page = 1
+		list.cursor = 0 // First item on the second page
+
+		list.CursorLeft() // Move before the start of the page
+		if list.Paginator.Page != 0 || list.cursor != 19 {
+			t.Errorf("Expected to move to page 0, cursor 19, but got page %d, cursor %d", list.Paginator.Page, list.cursor)
+		}
+
+		list.InfiniteScrolling = false
+	})
 }


### PR DESCRIPTION
Check #870 for reasoning.

Added horizontal grid layout to the list, you can enable it via `list.SetHorizontalEnabled(true)`. It changes how items are displayed to `rows x columns` view. It calculates how many columns fit on the screen based on new `Width()` function in the `Delegate`. Then based on that calculates how many items are on the page: `rows * columns`.

Render itself goes for each row and then each column in a loop, writes item to `string.Builder` then `lipgloss.JoinHorizontal` with string for the row which contains previous items then clears `string.Builder`, loop goes again for each column.

Added new keybindings for moving horizontally, `CursorLeft` and `CursorRight` respectively.
Also, added new test which checks for right positions of the items.

<details><summary>Test example</summary>

```
package main

import (
	"fmt"
	"io"
	"os"
	"strconv"

	"github.com/charmbracelet/bubbles/list"
	tea "github.com/charmbracelet/bubbletea"
	"github.com/charmbracelet/lipgloss"
)

type Model struct {
	SelectVertical bool
	SplitVertical  bool
	VerticalList   list.Model
	HorizontalList list.Model
}

type item string

func (i item) FilterValue() string { return string(i) }

type itemDelegate struct{}

func (d itemDelegate) Height() int                               { return 1 }
func (d itemDelegate) Width() int                                { return 8 }
func (d itemDelegate) Spacing() int                              { return 1 }
func (d itemDelegate) Update(msg tea.Msg, m *list.Model) tea.Cmd { return nil }
func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list.Item) {
	i, ok := listItem.(item)
	if !ok {
		return
	}

	var s string
	style := lipgloss.NewStyle().Width(2).AlignHorizontal(lipgloss.Bottom)

	if index == m.Index() {
		s = style.Background(lipgloss.Color("#FFBF00")).Render(string(i))
	} else {
		s = style.Render(string(i))
	}

	fmt.Fprint(w, s)
}

func initialModel() Model {
	items := make([]list.Item, 32)
	for i := range items {
		items[i] = item(strconv.Itoa(i))
	}

	list := list.New(items, itemDelegate{}, 32, 16)
	hList := list
	hList.SetHorizontalEnabled(true)

	return Model{
		SelectVertical: false,
		SplitVertical:  true,
		VerticalList:   list,
		HorizontalList: hList,
	}
}

func (m Model) Init() tea.Cmd {
	return nil
}

func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
	switch msg := msg.(type) {
	case tea.KeyMsg:
		switch msg.String() {
		case "s":
			m.SelectVertical = !m.SelectVertical
			return m, nil
		case "v":
			m.SplitVertical = !m.SplitVertical
			return m, nil
		case "ctrl+c", "q":
			return m, tea.Quit
		}
	}

	var cmd tea.Cmd

	if m.SelectVertical {
		m.VerticalList, cmd = m.VerticalList.Update(msg)
	} else {
		m.HorizontalList, cmd = m.HorizontalList.Update(msg)
	}

	return m, cmd
}

func (m Model) View() string {
	if m.SplitVertical {
		return lipgloss.JoinVertical(lipgloss.Left, m.HorizontalList.View(), m.VerticalList.View())
	} else {
		return lipgloss.JoinHorizontal(lipgloss.Left, m.HorizontalList.View(), m.VerticalList.View())
	}
}

func main() {
	p := tea.NewProgram(initialModel())

	if _, err := p.Run(); err != nil {
		fmt.Printf("Alas, there's been an error: %v", err)
		os.Exit(1)
	}
}
```
</details>

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/870a19a4-8440-4b47-b6b3-6cf2d01a082e" />

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).
