### PR TITLE
feat(v2/textarea): expose Column(), clarify 0-indexing

### DIFF
--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -595,9 +595,14 @@ func (m *Model) LineCount() int {
 	return len(m.value)
 }
 
-// Line returns the row position of the cursor.
+// Line returns the 0-indexed row position of the cursor.
 func (m Model) Line() int {
 	return m.row
+}
+
+// Column returns the 0-indexed column position of the cursor.
+func (m Model) Column() int {
+	return m.col
 }
 
 // ScrollYOffset returns the Y offset (top row) index of the current view, which


### PR DESCRIPTION
Exposing `Column()` would allow us to know the precise line:row location in the editor.