### PR TITLE
fix(textinput): apply virtual cursor TextStyle on render

### DIFF
--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -697,6 +697,7 @@ func (m Model) View() string {
 
 	if pos < len(value) { //nolint:nestif
 		char := m.echoTransform(string(value[pos]))
+		m.virtualCursor.TextStyle = styles.Text
 		m.virtualCursor.SetChar(char)
 		v += m.virtualCursor.View()                            // cursor and text under it
 		v += styleText(m.echoTransform(string(value[pos+1:]))) // text after cursor
@@ -710,10 +711,12 @@ func (m Model) View() string {
 				v += m.virtualCursor.View()
 				v += m.completionView(1)
 			} else {
+				m.virtualCursor.TextStyle = styles.Text
 				m.virtualCursor.SetChar(" ")
 				v += m.virtualCursor.View()
 			}
 		} else {
+			m.virtualCursor.TextStyle = styles.Text
 			m.virtualCursor.SetChar(" ")
 			v += m.virtualCursor.View()
 		}


### PR DESCRIPTION
This fixes an issue where the style of a blinked-off virtual cursor might not match the text background color of a textinput, if one is set.

Before:

https://github.com/user-attachments/assets/75a277ae-266b-4208-b042-bb71a4862142

After:

https://github.com/user-attachments/assets/cd888d26-4b65-4d04-85b1-7809fcaf1c0c





- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
