### PR TITLE
fix(viewport): prevent panic when height is negative or zero

### DIFF
--- a/viewport/viewport.go
+++ b/viewport/viewport.go
@@ -147,6 +147,9 @@ func (m Model) visibleLines() (lines []string) {
 	if len(m.lines) > 0 {
 		top := max(0, m.YOffset)
 		bottom := clamp(m.YOffset+h, top, len(m.lines))
+		if top >= bottom {
+			return nil
+		}
 		lines = m.lines[top:bottom]
 	}
 

--- a/viewport/viewport_test.go
+++ b/viewport/viewport_test.go
@@ -201,6 +201,38 @@ func TestVisibleLines(t *testing.T) {
 		}
 	})
 
+	t.Run("negative height should not panic", func(t *testing.T) {
+		t.Parallel()
+
+		m := New(10, 10)
+		m.SetContent(strings.Join(defaultList, "\n"))
+		m.YOffset = 5
+		m.Height = -4
+
+		// This should not panic
+		list := m.visibleLines()
+
+		if list != nil {
+			t.Errorf("list should be nil with negative height, got %d items", len(list))
+		}
+	})
+
+	t.Run("zero height should not panic", func(t *testing.T) {
+		t.Parallel()
+
+		m := New(10, 10)
+		m.SetContent(strings.Join(defaultList, "\n"))
+		m.YOffset = 5
+		m.Height = 0
+
+		// This should not panic
+		list := m.visibleLines()
+
+		if list != nil {
+			t.Errorf("list should be nil with zero height, got %d items", len(list))
+		}
+	})
+
 	t.Run("empty list: with indent", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
 ## Summary

  - Add guard in `visibleLines()` to prevent slice bounds panic when `top >= bottom`
  - Add tests for negative and zero height scenarios

  ## Details

  When viewport height becomes negative (e.g., during terminal resize with other components), `visibleLines()` panics with
  "slice bounds out of range [N:M]" where N > M.

  This happens because:
  1. `h = Height - Style.GetVerticalFrameSize()` becomes negative
  2. `bottom = clamp(YOffset + h, top, len(lines))` becomes less than `top`
  3. `lines[top:bottom]` panics

  Fixes #879
