### PR TITLE
fix(table): Use ansi.Truncate instead of runewidth.Truncate

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -6,7 +6,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/mattn/go-runewidth"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/key"
@@ -419,7 +419,7 @@ func (m Model) headersView() string {
 			continue
 		}
 		style := lipgloss.NewStyle().Width(col.Width).MaxWidth(col.Width).Inline(true)
-		renderedCell := style.Render(runewidth.Truncate(col.Title, col.Width, "…"))
+		renderedCell := style.Render(ansi.Truncate(col.Title, col.Width, "…"))
 		s = append(s, m.styles.Header.Render(renderedCell))
 	}
 	return lipgloss.JoinHorizontal(lipgloss.Top, s...)
@@ -432,7 +432,7 @@ func (m *Model) renderRow(r int) string {
 			continue
 		}
 		style := lipgloss.NewStyle().Width(m.cols[i].Width).MaxWidth(m.cols[i].Width).Inline(true)
-		renderedCell := m.styles.Cell.Render(style.Render(runewidth.Truncate(value, m.cols[i].Width, "…")))
+		renderedCell := m.styles.Cell.Render(style.Render(ansi.Truncate(value, m.cols[i].Width, "…")))
 		s = append(s, renderedCell)
 	}
 

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -258,6 +258,21 @@ func TestModel_RenderRow(t *testing.T) {
 	}
 }
 
+func TestModel_RenderRow_AnsiWidth(t *testing.T) {
+	value := "\x1b[31mABCDEFGH\x1b[0m"
+	table := &Model{
+		rows:   []Row{{value}},
+		cols:   []Column{{Title: "col1", Width: 8}},
+		styles: Styles{Cell: lipgloss.NewStyle()},
+	}
+
+	got := ansi.Strip(table.renderRow(0))
+	want := "ABCDEFGH"
+	if got != want {
+		t.Fatalf("\n\nWant: \n%s\n\nGot:  \n%s\n", want, got)
+	}
+}
+
 func TestTableAlignment(t *testing.T) {
 	t.Run("No border", func(t *testing.T) {
 		biscuits := New(


### PR DESCRIPTION
`runewidth.Truncate` does not consider terminal escape characters - this means that if a table cell contains funky characters, then it will be incorrectly truncated.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).

Minimal reproducer:

```go
package main

import (
	"fmt"

	"github.com/charmbracelet/bubbles/table"
	"github.com/charmbracelet/lipgloss"
)

func main() {
	cols := []table.Column{{Title: "Name", Width: 7}}
	value := lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Render("ABCDEFGH")
	rows := []table.Row{{value}}

	t := table.New(
		table.WithColumns(cols),
		table.WithRows(rows),
	)

	fmt.Println(t.View())
}
```

Before:

<img width="496" height="94" alt="image" src="https://github.com/user-attachments/assets/9442d211-cadb-462a-b9de-5a2fd0baed67" />

After:

<img width="496" height="94" alt="image" src="https://github.com/user-attachments/assets/3685932d-55fa-443e-8c75-a1715c398c6e" />

