### PR TITLE
fix(table): Use ansi.Truncate instead of runewidth.Truncate

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -9,7 +9,7 @@ import (
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
-	"github.com/mattn/go-runewidth"
+	"github.com/charmbracelet/x/ansi"
 )
 
 // Model defines a state for the table widget.
@@ -422,7 +422,7 @@ func (m Model) headersView() string {
 			continue
 		}
 		style := lipgloss.NewStyle().Width(col.Width).MaxWidth(col.Width).Inline(true)
-		renderedCell := style.Render(runewidth.Truncate(col.Title, col.Width, "…"))
+		renderedCell := style.Render(ansi.Truncate(col.Title, col.Width, "…"))
 		s = append(s, m.styles.Header.Render(renderedCell))
 	}
 	return lipgloss.JoinHorizontal(lipgloss.Top, s...)
@@ -435,7 +435,7 @@ func (m *Model) renderRow(r int) string {
 			continue
 		}
 		style := lipgloss.NewStyle().Width(m.cols[i].Width).MaxWidth(m.cols[i].Width).Inline(true)
-		renderedCell := m.styles.Cell.Render(style.Render(runewidth.Truncate(value, m.cols[i].Width, "…")))
+		renderedCell := m.styles.Cell.Render(style.Render(ansi.Truncate(value, m.cols[i].Width, "…")))
 		s = append(s, renderedCell)
 	}
 

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -288,6 +288,21 @@ func TestModel_RenderRow(t *testing.T) {
 	}
 }
 
+func TestModel_RenderRow_AnsiWidth(t *testing.T) {
+	value := "\x1b[31mABCDEFGH\x1b[0m"
+	table := &Model{
+		rows:   []Row{{value}},
+		cols:   []Column{{Title: "col1", Width: 8}},
+		styles: Styles{Cell: lipgloss.NewStyle()},
+	}
+
+	got := ansi.Strip(table.renderRow(0))
+	want := "ABCDEFGH"
+	if got != want {
+		t.Fatalf("\n\nWant: \n%s\n\nGot:  \n%s\n", want, got)
+	}
+}
+
 func TestTableAlignment(t *testing.T) {
 	t.Run("No border", func(t *testing.T) {
 		biscuits := New(


### PR DESCRIPTION
Originally from https://github.com/charmbracelet/bubbles/pull/883, retargeted against `v2-exp` as suggested by @andreynering.

`runewidth.Truncate` does not consider terminal escape characters - this means that if a table cell contains funky characters, then it will be incorrectly truncated.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).

Minimal reproducer:

```go
package main

import (
	"fmt"

	"charm.land/bubbles/v2/table"
	"charm.land/lipgloss/v2"
)

func main() {
	cols := []table.Column{{Title: "Name", Width: 7}}
	value := lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Render("ABCDEFGH")
	rows := []table.Row{{value}}

	t := table.New(
		table.WithColumns(cols),
		table.WithWidth(20),
		table.WithRows(rows),
	)

	fmt.Println(t.View())
}

```

Before:

<img width="341" height="94" alt="image" src="https://github.com/user-attachments/assets/3418b9d4-fefe-4ae8-9473-cc0f10edf402" />

After:

<img width="341" height="94" alt="image" src="https://github.com/user-attachments/assets/1879c00e-b111-403b-9a4f-d42256abb40c" />

