### PR TITLE
docs: mention table width is required in v2 upgrade guide

### DIFF
--- a/UPGRADE_GUIDE_V2.md
+++ b/UPGRADE_GUIDE_V2.md
@@ -307,6 +307,8 @@ sw := stopwatch.New(stopwatch.WithInterval(500 * time.Millisecond))
 
 The table already had `SetWidth`/`SetHeight`/`Width()`/`Height()` in v1, but internally these now use viewport getter/setters.
 
+An explicit width is now required or the table body may be blank. You can pass the `WithWidth()` option to `New()` to set it.
+
 ### Textarea
 
 #### KeyMap


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] (N/A) I have created a discussion that was approved by a maintainer (for new features).

Table now requires an explicit width or the table body is rendered as blank. This is fixed in the official example in
https://github.com/charmbracelet/bubbletea/pull/1598, but it was not at all obvious from reading the upgrade guide, making for a confusing upgrade experience.

