### PR TITLE
fix(stopwatch): initialize Interval field with default 1s

### DIFF
--- a/stopwatch/stopwatch.go
+++ b/stopwatch/stopwatch.go
@@ -65,7 +65,8 @@ type Model struct {
 // New creates a new stopwatch with 1s interval.
 func New(opts ...Option) Model {
 	m := Model{
-		id: nextID(),
+		id:       nextID(),
+		Interval: time.Second,
 	}
 
 	for _, opt := range opts {

--- a/stopwatch/stopwatch_test.go
+++ b/stopwatch/stopwatch_test.go
@@ -1,0 +1,23 @@
+package stopwatch
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("default interval is 1s", func(t *testing.T) {
+		m := New()
+		if m.Interval != time.Second {
+			t.Errorf("expected default interval %v, got %v", time.Second, m.Interval)
+		}
+	})
+
+	t.Run("custom interval via WithInterval", func(t *testing.T) {
+		custom := 500 * time.Millisecond
+		m := New(WithInterval(custom))
+		if m.Interval != custom {
+			t.Errorf("expected custom interval %v, got %v", custom, m.Interval)
+		}
+	})
+}


### PR DESCRIPTION
Fixes #862

Description:
The New() function was documented to default to a 1s interval, but it was initializing with a 0 duration

Changes:

Initialized Interval to time.Second in the New function.

Took the liberty to create stopwatch_test.go to verify the default value and ensure WithInterval still works correctly.

This is my first-ever contribution to open source!  So please let me know if there are any style adjustments or changes you'd like me to make.

- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [X] I have created a discussion that was approved by a maintainer (for new features).
