### PR TITLE
docs: fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Build Status](https://github.com/charmbracelet/bubbles/workflows/build/badge.svg)](https://github.com/charmbracelet/bubbles/actions)
 [![Go ReportCard](https://goreportcard.com/badge/charmbracelet/bubbles)](https://goreportcard.com/report/charmbracelet/bubbles)
 
-Primatives for [Bubble Tea](https://github.com/charmbracelet/bubbletea)
+Primitives for [Bubble Tea](https://github.com/charmbracelet/bubbletea)
 applications. These components are used in production in [Crush][crush], and [many other applications][otherstuff].
 
 > [!TIP]


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

## Summary
- Fix a spelling typo in the README intro.

## Related issue
- N/A (doc wording fix)

## Guideline alignment
- https://github.com/charmbracelet/bubbles/contribute

## Validation/testing
- Not run (docs change only)
