### PR TITLE
fix(textarea): add ctrl+left/right for word movement

### DIFF
--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -79,8 +79,8 @@ func DefaultKeyMap() KeyMap {
 	return KeyMap{
 		CharacterForward:        key.NewBinding(key.WithKeys("right", "ctrl+f"), key.WithHelp("right", "character forward")),
 		CharacterBackward:       key.NewBinding(key.WithKeys("left", "ctrl+b"), key.WithHelp("left", "character backward")),
-		WordForward:             key.NewBinding(key.WithKeys("alt+right", "alt+f"), key.WithHelp("alt+right", "word forward")),
-		WordBackward:            key.NewBinding(key.WithKeys("alt+left", "alt+b"), key.WithHelp("alt+left", "word backward")),
+		WordForward:             key.NewBinding(key.WithKeys("alt+right", "ctrl+right", "alt+f"), key.WithHelp("alt+right", "word forward")),
+		WordBackward:            key.NewBinding(key.WithKeys("alt+left", "ctrl+left", "alt+b"), key.WithHelp("alt+left", "word backward")),
 		LineNext:                key.NewBinding(key.WithKeys("down", "ctrl+n"), key.WithHelp("down", "next line")),
 		LinePrevious:            key.NewBinding(key.WithKeys("up", "ctrl+p"), key.WithHelp("up", "previous line")),
 		DeleteWordBackward:      key.NewBinding(key.WithKeys("alt+backspace", "ctrl+w"), key.WithHelp("alt+backspace", "delete word backward")),


### PR DESCRIPTION
## Summary

- Add `ctrl+left` and `ctrl+right` to textarea's default `WordBackward` and `WordForward` key bindings
- `textinput` already binds these keys for word movement, but `textarea` only has `alt+left`/`alt+right` — this fixes the inconsistency

## Test plan

- [x] Existing textarea tests pass
- [x] Verify `ctrl+left`/`ctrl+right` moves cursor by word in a textarea
- [x] Verify `alt+left`/`alt+right` still works as before