### PR TITLE
fix(textarea): remove double rendering in placeholder view

### DIFF
--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -1554,7 +1554,7 @@ func (m Model) placeholderView() string {
 	}
 
 	m.viewport.SetContent(s.String())
-	return styles.Base.Render(m.viewport.View())
+	return m.viewport.View()
 }
 
 // Blink returns the blink command for the virtual cursor.

--- a/textarea/textarea_test.go
+++ b/textarea/textarea_test.go
@@ -1889,6 +1889,23 @@ func TestView(t *testing.T) {
 				cursorRow: 7,
 			},
 		},
+		{
+			name: "empty textarea with placeholder and styled border",
+			modelFunc: func(m Model) Model {
+				m.SetHeight(2)
+				m.SetWidth(20)
+				m.Placeholder = "line 1"
+				m.styles.Focused.Base = lipgloss.NewStyle().Border(lipgloss.NormalBorder())
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`┌────────────────────┐
+				    │>   1 line 1        │
+				    │>                   │
+				    └────────────────────┘
+				`),
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
The placeholder view was being wrapped with styles.Base.Render() which added an extra border, causing double borders when using custom styled borders with placeholders.

before repair (bubbletea/examples/split-editors.go):
<img width="1485" height="426" alt="image" src="https://github.com/user-attachments/assets/4b1158df-0ea4-403c-a506-a0941339d9fe" />

after repair:
<img width="1484" height="427" alt="image" src="https://github.com/user-attachments/assets/fbd64969-4f87-4cb5-9ce4-9d866fc6e865" />

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).