### PR TITLE
textarea: reset viewport when auto-resized wrapped content fully fits

### DIFF
--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -1031,6 +1031,13 @@ func (m Model) LineInfo() LineInfo {
 // repositionView repositions the view of the viewport based on the defined
 // scrolling behavior.
 func (m *Model) repositionView() {
+	// Hosts sometimes auto-resize the textarea to exactly fit the current
+	// number of soft-wrapped rows. When that happens, an old viewport offset can
+	// hide the first wrapped row even though the entire buffer now fits.
+	if m.totalLineCount() <= m.viewport.Height() {
+		m.viewport.GotoTop()
+		return
+	}
 	minimum := m.viewport.YOffset()
 	maximum := minimum + m.viewport.Height() - 1
 	if row := m.cursorLineNumber(); row < minimum {
@@ -1038,6 +1045,19 @@ func (m *Model) repositionView() {
 	} else if row > maximum {
 		m.viewport.ScrollDown(row - maximum)
 	}
+}
+
+func (m Model) totalLineCount() int {
+	total := 0
+	for i := range m.value {
+		wrapped := m.memoizedWrap(m.value[i], m.width)
+		if len(wrapped) == 0 {
+			total++
+			continue
+		}
+		total += len(wrapped)
+	}
+	return total
 }
 
 // Width returns the width of the textarea.

--- a/textarea/textarea_test.go
+++ b/textarea/textarea_test.go
@@ -120,6 +120,40 @@ func TestValueSoftWrap(t *testing.T) {
 	}
 }
 
+func TestAutoResizeKeepsFirstSoftWrappedRowVisible(t *testing.T) {
+	textarea := newTextArea()
+	textarea.Prompt = ""
+	textarea.ShowLineNumbers = false
+	textarea.SetWidth(24)
+	textarea.SetHeight(1)
+	textarea.CharLimit = 200
+
+	textarea, _ = textarea.Update(nil)
+
+	input := "this is a long active line that should wrap to the next row while typing"
+	for _, k := range input {
+		textarea, _ = textarea.Update(keyPress(k))
+		textarea.SetHeight(softWrappedLineCount(textarea))
+		textarea.View()
+	}
+
+	if got := textarea.viewport.YOffset(); got != 0 {
+		t.Fatalf("expected viewport offset 0 after autoresize, got %d", got)
+	}
+
+	view := stripString(textarea.View())
+	if !strings.Contains(view, "this is a long active") {
+		t.Fatalf("expected first wrapped row to stay visible, got %q", view)
+	}
+	if !strings.Contains(view, "typing") {
+		t.Fatalf("expected last wrapped row to be visible, got %q", view)
+	}
+}
+
+func softWrappedLineCount(m Model) int {
+	return m.totalLineCount()
+}
+
 func TestSetValue(t *testing.T) {
 	textarea := newTextArea()
 	textarea.SetValue(strings.Join([]string{"Foo", "Bar", "Baz"}, "\n"))


### PR DESCRIPTION
## Summary

- **Bug**: When a host app auto-resizes `textarea` height to match the current number of soft-wrapped rows (e.g. after each keypress), a stale `viewport.YOffset` can hide the first wrapped row — even though the entire buffer now fits within the visible area.
- **Fix**: In `repositionView()`, if the total soft-wrapped line count fits within the viewport height, snap the viewport to top before applying cursor-following logic.
- **Test**: Adds a keypress-driven autoresize regression test that simulates the real failure mode: type a long line one character at a time, auto-resize height after each keypress, and assert the first wrapped row remains visible.

## Repro

1. Create a `textarea` with a constrained width and height of 1
2. Type a long line one keypress at a time
3. After each keypress, set the textarea height to the current soft-wrapped row count
4. Observe the first wrapped row disappears even though the content fully fits

## Test plan

- [x] New test `TestAutoResizeKeepsFirstSoftWrappedRowVisible` passes
- [x] All existing `textarea` tests pass
- [x] Full module `go test ./...` passes