### PR TITLE
feat(textarea): treat punctuation and symbols as word boundaries

### DIFF
--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -790,20 +790,20 @@ func (m *Model) Word() string {
 		return ""
 	}
 
-	// If cursor is on a space, return empty string
-	if unicode.IsSpace(line[col]) {
+	// If cursor is on a boundary character, return empty string.
+	if isWordBoundary(line[col]) {
 		return ""
 	}
 
-	// Find the start of the word by moving left
+	// Find the start of the word by moving left.
 	start := col
-	for start > 0 && !unicode.IsSpace(line[start-1]) {
+	for start > 0 && !isWordBoundary(line[start-1]) {
 		start--
 	}
 
-	// Find the end of the word by moving right
+	// Find the end of the word by moving right.
 	end := col
-	for end < len(line) && !unicode.IsSpace(line[end]) {
+	for end < len(line) && !isWordBoundary(line[end]) {
 		end++
 	}
 
@@ -852,6 +852,12 @@ func (m *Model) transposeLeft() {
 	}
 }
 
+// isWordBoundary reports whether the rune is a word boundary character
+// (whitespace, punctuation, or symbol).
+func isWordBoundary(r rune) bool {
+	return unicode.IsSpace(r) || unicode.IsPunct(r) || unicode.IsSymbol(r)
+}
+
 // deleteWordLeft deletes the word left to the cursor. Returns whether or not
 // the cursor blink should be reset.
 func (m *Model) deleteWordLeft() {
@@ -864,24 +870,16 @@ func (m *Model) deleteWordLeft() {
 	// call into the corresponding if clause does not apply here.
 	oldCol := m.col
 
-	m.SetCursorColumn(m.col - 1)
-	for unicode.IsSpace(m.value[m.row][m.col]) {
-		if m.col <= 0 {
-			break
-		}
-		// ignore series of whitespace before cursor
-		m.SetCursorColumn(m.col - 1)
-	}
-
-	for m.col > 0 {
-		if !unicode.IsSpace(m.value[m.row][m.col]) {
+	// If the character to the left of the cursor is a boundary character,
+	// delete consecutive boundary characters. Otherwise, delete consecutive
+	// non-boundary (word) characters.
+	if isWordBoundary(m.value[m.row][m.col-1]) {
+		for m.col > 0 && isWordBoundary(m.value[m.row][m.col-1]) {
 			m.SetCursorColumn(m.col - 1)
-		} else {
-			if m.col > 0 {
-				// keep the previous space
-				m.SetCursorColumn(m.col + 1)
-			}
-			break
+		}
+	} else {
+		for m.col > 0 && !isWordBoundary(m.value[m.row][m.col-1]) {
+			m.SetCursorColumn(m.col - 1)
 		}
 	}
 
@@ -900,16 +898,16 @@ func (m *Model) deleteWordRight() {
 
 	oldCol := m.col
 
-	for m.col < len(m.value[m.row]) && unicode.IsSpace(m.value[m.row][m.col]) {
-		// ignore series of whitespace after cursor
-		m.SetCursorColumn(m.col + 1)
-	}
-
-	for m.col < len(m.value[m.row]) {
-		if !unicode.IsSpace(m.value[m.row][m.col]) {
+	// If the character at the cursor is a boundary character, delete
+	// consecutive boundary characters. Otherwise, delete consecutive
+	// non-boundary (word) characters.
+	if isWordBoundary(m.value[m.row][m.col]) {
+		for m.col < len(m.value[m.row]) && isWordBoundary(m.value[m.row][m.col]) {
 			m.SetCursorColumn(m.col + 1)
-		} else {
-			break
+		}
+	} else {
+		for m.col < len(m.value[m.row]) && !isWordBoundary(m.value[m.row][m.col]) {
+			m.SetCursorColumn(m.col + 1)
 		}
 	}
 
@@ -956,13 +954,13 @@ func (m *Model) characterLeft(insideLine bool) {
 func (m *Model) wordLeft() {
 	for {
 		m.characterLeft(true /* insideLine */)
-		if m.col < len(m.value[m.row]) && !unicode.IsSpace(m.value[m.row][m.col]) {
+		if m.col < len(m.value[m.row]) && !isWordBoundary(m.value[m.row][m.col]) {
 			break
 		}
 	}
 
 	for m.col > 0 {
-		if unicode.IsSpace(m.value[m.row][m.col-1]) {
+		if isWordBoundary(m.value[m.row][m.col-1]) {
 			break
 		}
 		m.SetCursorColumn(m.col - 1)
@@ -978,7 +976,7 @@ func (m *Model) wordRight() {
 
 func (m *Model) doWordRight(fn func(charIdx int, pos int)) {
 	// Skip spaces forward.
-	for m.col >= len(m.value[m.row]) || unicode.IsSpace(m.value[m.row][m.col]) {
+	for m.col >= len(m.value[m.row]) || isWordBoundary(m.value[m.row][m.col]) {
 		if m.row == len(m.value)-1 && m.col == len(m.value[m.row]) {
 			// End of text.
 			break
@@ -988,7 +986,7 @@ func (m *Model) doWordRight(fn func(charIdx int, pos int)) {
 
 	charIdx := 0
 	for m.col < len(m.value[m.row]) {
-		if unicode.IsSpace(m.value[m.row][m.col]) {
+		if isWordBoundary(m.value[m.row][m.col]) {
 			break
 		}
 		fn(charIdx, m.col)

--- a/textarea/textarea_test.go
+++ b/textarea/textarea_test.go
@@ -1957,21 +1957,280 @@ func TestWord(t *testing.T) {
 	})
 
 	t.Run("delete", func(t *testing.T) {
+		// After the "navigate" subtest the text is still
+		// "Word1 Word2 Word3 Word4" and the cursor is inside Word3.
+		// Move to end first.
 		for _, k := range []tea.KeyPressMsg{
 			{Code: tea.KeyEnd, Text: "end"},
-			{Code: tea.KeyBackspace, Mod: tea.ModAlt, Text: "alt+backspace"},
-			{Code: tea.KeyBackspace, Mod: tea.ModAlt, Text: "alt+backspace"},
-			{Code: tea.KeyBackspace, Text: "backspace"},
+			// Boundary characters (spaces, punctuation) and word characters
+			// are deleted separately, so deleting " Word4" requires two
+			// alt+backspace invocations: one for "Word4" and one for the
+			// preceding space.
+			{Code: tea.KeyBackspace, Mod: tea.ModAlt, Text: "alt+backspace"}, // "Word4"
+			{Code: tea.KeyBackspace, Mod: tea.ModAlt, Text: "alt+backspace"}, // " "
+			{Code: tea.KeyBackspace, Mod: tea.ModAlt, Text: "alt+backspace"}, // "Word3"
+			{Code: tea.KeyBackspace, Mod: tea.ModAlt, Text: "alt+backspace"}, // " "
+			{Code: tea.KeyBackspace, Text: "backspace"},                      // "2"
 		} {
 			textarea, _ = textarea.Update(k)
 			textarea.View()
 		}
 
-		expect := "Word2"
+		expect := "Word"
 		if word := textarea.Word(); word != expect {
 			t.Fatalf("Expected last word to be '%s', got '%s'", expect, word)
 		}
+
+		if val := textarea.Value(); val != "Word1 Word" {
+			t.Fatalf("Expected value to be 'Word1 Word', got '%s'", val)
+		}
 	})
+}
+
+func TestIsWordBoundary(t *testing.T) {
+	tests := []struct {
+		r    rune
+		want bool
+	}{
+		// Spaces are boundaries.
+		{' ', true},
+		{'\t', true},
+		{'\n', true},
+		// ASCII punctuation.
+		{'.', true},
+		{',', true},
+		{'!', true},
+		{'(', true},
+		{')', true},
+		{'-', true},
+		{'_', true},
+		// CJK punctuation (fullwidth).
+		{'，', true},
+		{'。', true},
+		{'！', true},
+		{'？', true},
+		{'、', true},
+		{'；', true},
+		{'：', true},
+		{'"', true},
+		{'"', true},
+		{'（', true},
+		{'）', true},
+		{'【', true},
+		{'】', true},
+		{'《', true},
+		{'》', true},
+		// Symbols.
+		{'+', true},
+		{'=', true},
+		{'$', true},
+		// Letters and digits are not boundaries.
+		{'a', false},
+		{'Z', false},
+		{'0', false},
+		{'9', false},
+		// CJK ideographs are not boundaries.
+		{'中', false},
+		{'文', false},
+		{'あ', false},
+		{'漢', false},
+	}
+	for _, tt := range tests {
+		if got := isWordBoundary(tt.r); got != tt.want {
+			t.Errorf("isWordBoundary(%q) = %v, want %v", tt.r, got, tt.want)
+		}
+	}
+}
+
+func TestWordMovementWithPunctuation(t *testing.T) {
+	altLeft := tea.KeyPressMsg{Code: tea.KeyLeft, Mod: tea.ModAlt}
+	altRight := tea.KeyPressMsg{Code: tea.KeyRight, Mod: tea.ModAlt}
+
+	t.Run("ascii punctuation", func(t *testing.T) {
+		ta := newTextArea()
+		ta.SetWidth(80)
+		ta.CharLimit = 500
+		ta, _ = ta.Update(nil)
+
+		// "hello.world foo" — rune indices:
+		//  h=0 e=1 l=2 l=3 o=4 .=5 w=6 o=7 r=8 l=9 d=10 ' '=11 f=12 o=13 o=14
+		ta = sendString(ta, "hello.world foo")
+		ta.View()
+
+		// alt+left from end (col=15): skip space, land at start of "foo"
+		ta, _ = ta.Update(altLeft)
+		if ta.col != 12 {
+			t.Fatalf("after first alt+left: expected col 12, got %d", ta.col)
+		}
+		// alt+left: skip '.', land at start of "world"
+		ta, _ = ta.Update(altLeft)
+		if ta.col != 6 {
+			t.Fatalf("after second alt+left: expected col 6, got %d", ta.col)
+		}
+		// alt+left: land at start of "hello"
+		ta, _ = ta.Update(altLeft)
+		if ta.col != 0 {
+			t.Fatalf("after third alt+left: expected col 0, got %d", ta.col)
+		}
+
+		// alt+right from col=0: skip past "hello", land after 'o' (col=5)
+		ta, _ = ta.Update(altRight)
+		if ta.col != 5 {
+			t.Fatalf("after first alt+right: expected col 5, got %d", ta.col)
+		}
+		// alt+right: skip '.', past "world" (col=11)
+		ta, _ = ta.Update(altRight)
+		if ta.col != 11 {
+			t.Fatalf("after second alt+right: expected col 11, got %d", ta.col)
+		}
+	})
+
+	t.Run("CJK punctuation", func(t *testing.T) {
+		ta := newTextArea()
+		ta.SetWidth(80)
+		ta.CharLimit = 500
+		ta, _ = ta.Update(nil)
+
+		// "你好，世界" — rune indices: 你=0 好=1 ，=2 世=3 界=4
+		ta = sendString(ta, "你好，世界")
+		ta.View()
+
+		// alt+left from end (col=5): land at start of "世界" (col=3)
+		ta, _ = ta.Update(altLeft)
+		if ta.col != 3 {
+			t.Fatalf("after first alt+left: expected col 3, got %d", ta.col)
+		}
+
+		// alt+left: skip '，', land at start of "你好" (col=0)
+		ta, _ = ta.Update(altLeft)
+		if ta.col != 0 {
+			t.Fatalf("after second alt+left: expected col 0, got %d", ta.col)
+		}
+
+		// alt+right: skip past "你好" (col=2)
+		ta, _ = ta.Update(altRight)
+		if ta.col != 2 {
+			t.Fatalf("after alt+right: expected col 2, got %d", ta.col)
+		}
+
+		// alt+right: skip '，', past "世界" (col=5)
+		ta, _ = ta.Update(altRight)
+		if ta.col != 5 {
+			t.Fatalf("after second alt+right: expected col 5, got %d", ta.col)
+		}
+	})
+
+	t.Run("mixed CJK and ASCII", func(t *testing.T) {
+		ta := newTextArea()
+		ta.SetWidth(80)
+		ta.CharLimit = 500
+		ta, _ = ta.Update(nil)
+
+		// "hello，世界！end" — rune indices:
+		//  h=0 e=1 l=2 l=3 o=4 ，=5 世=6 界=7 ！=8 e=9 n=10 d=11
+		ta = sendString(ta, "hello，世界！end")
+		ta.View()
+
+		// alt+left from end (col=12): land at start of "end" (col=9)
+		ta, _ = ta.Update(altLeft)
+		if ta.col != 9 {
+			t.Fatalf("after first alt+left: expected col 9, got %d", ta.col)
+		}
+
+		// alt+left: skip '！', land at start of "世界" (col=6)
+		ta, _ = ta.Update(altLeft)
+		if ta.col != 6 {
+			t.Fatalf("after second alt+left: expected col 6, got %d", ta.col)
+		}
+
+		// alt+left: skip '，', land at start of "hello" (col=0)
+		ta, _ = ta.Update(altLeft)
+		if ta.col != 0 {
+			t.Fatalf("after third alt+left: expected col 0, got %d", ta.col)
+		}
+	})
+}
+
+func TestDeleteWordWithPunctuation(t *testing.T) {
+	altBackspace := tea.KeyPressMsg{Code: tea.KeyBackspace, Mod: tea.ModAlt}
+
+	t.Run("delete word stops at punctuation", func(t *testing.T) {
+		ta := newTextArea()
+		ta.SetWidth(80)
+		ta.CharLimit = 500
+		ta, _ = ta.Update(nil)
+
+		ta = sendString(ta, "hello.world")
+		ta.View()
+
+		// alt+backspace: should delete "world", leaving "hello."
+		ta, _ = ta.Update(altBackspace)
+		if val := ta.Value(); val != "hello." {
+			t.Fatalf("after first alt+backspace: expected \"hello.\", got %q", val)
+		}
+
+		// alt+backspace: should delete ".", leaving "hello"
+		ta, _ = ta.Update(altBackspace)
+		if val := ta.Value(); val != "hello" {
+			t.Fatalf("after second alt+backspace: expected \"hello\", got %q", val)
+		}
+	})
+
+	t.Run("delete CJK word stops at punctuation", func(t *testing.T) {
+		ta := newTextArea()
+		ta.SetWidth(80)
+		ta.CharLimit = 500
+		ta, _ = ta.Update(nil)
+
+		ta = sendString(ta, "你好，世界")
+		ta.View()
+
+		// alt+backspace: should delete "世界", leaving "你好，"
+		ta, _ = ta.Update(altBackspace)
+		if val := ta.Value(); val != "你好，" {
+			t.Fatalf("after first alt+backspace: expected \"你好，\", got %q", val)
+		}
+
+		// alt+backspace: should delete "，", leaving "你好"
+		ta, _ = ta.Update(altBackspace)
+		if val := ta.Value(); val != "你好" {
+			t.Fatalf("after second alt+backspace: expected \"你好\", got %q", val)
+		}
+	})
+}
+
+func TestWordAtCursorWithPunctuation(t *testing.T) {
+	// Word() returns the word at col-1 (the character the cursor is after).
+	tests := []struct {
+		name     string
+		input    string
+		col      int
+		expected string
+	}{
+		{"inside word", "hello.world", 3, "hello"},
+		{"on period", "hello.world", 6, ""},
+		{"inside second word", "hello.world", 8, "world"},
+		{"on CJK punct", "你好，世界", 3, ""},
+		{"inside first CJK word", "你好，世界", 1, "你好"},
+		{"inside second CJK word", "你好，世界", 4, "世界"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ta := newTextArea()
+			ta.SetWidth(80)
+			ta.CharLimit = 500
+			ta, _ = ta.Update(nil)
+
+			ta = sendString(ta, tt.input)
+			ta.View()
+
+			ta.col = tt.col
+			if word := ta.Word(); word != tt.expected {
+				t.Errorf("Word() at col %d in %q = %q, want %q", tt.col, tt.input, word, tt.expected)
+			}
+		})
+	}
 }
 
 func newDynamicTextArea(minH, maxH int) Model {


### PR DESCRIPTION
## Summary

- Word movement (`alt+f`/`alt+b`), word deletion (`alt+backspace`/`alt+d`), and `Word()` now use `unicode.IsPunct` and `unicode.IsSymbol` in addition to `unicode.IsSpace` for word boundary detection.
- This makes cursor navigation behave correctly with CJK fullwidth punctuation (e.g. `你好，世界` correctly splits into `你好` / `，` / `世界`) and ASCII punctuation (e.g. `hello.world` splits at `.`), matching bash/zsh/emacs behavior.

## Motivation

The existing word boundary logic only checked `unicode.IsSpace`, causing `alt+f`/`alt+b` to treat entire runs of CJK text + punctuation as a single "word". For CJK users this made word-level navigation essentially useless. ASCII users also benefit — `hello.world` now correctly stops at the `.` rather than jumping over the entire compound.

## Changes

- **`textarea.go`**: Added `isWordBoundary(r rune) bool` helper that combines `unicode.IsSpace`, `unicode.IsPunct`, and `unicode.IsSymbol`. Replaced all `unicode.IsSpace` calls in `wordLeft`, `wordRight`/`doWordRight`, `deleteWordLeft`, `deleteWordRight`, and `Word()` with `isWordBoundary`. The word-wrap logic (`unicode.IsSpace` at line ~1815) is intentionally **not** changed.
- **`deleteWordLeft`/`deleteWordRight`**: Simplified to delete either a run of boundary characters **or** a run of word characters (not both in one invocation), matching standard emacs/shell behavior.
- **`textarea_test.go`**: Added `TestIsWordBoundary`, `TestWordMovementWithPunctuation`, `TestDeleteWordWithPunctuation`, and `TestWordAtCursorWithPunctuation`. Updated `TestWord/delete` to reflect the new delete-word granularity.

## Test plan

- [x] `go test ./textarea/` — all tests pass
- [x] `go test ./...` — full suite passes
- [x] Verified manually with CJK input (`你好，世界`) and mixed input (`hello.world foo`)