### PR TITLE
fix(textinput): use display width for cursor position with CJK characters

### DIFF
--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -921,8 +921,8 @@ func (m Model) Cursor() *tea.Cursor {
 	w := lipgloss.Width
 
 	promptWidth := w(m.promptView())
-	xOffset := m.Position() +
-		promptWidth
+	displayWidth := uniseg.StringWidth(string(m.value[m.offset:m.pos]))
+	xOffset := displayWidth + promptWidth
 	if m.width > 0 {
 		xOffset = min(xOffset, m.width+promptWidth)
 	}

--- a/textinput/textinput_test.go
+++ b/textinput/textinput_test.go
@@ -107,6 +107,76 @@ func ExampleValidateFunc() {
 	}
 }
 
+func TestCursorPositionWithCJKCharacters(t *testing.T) {
+	t.Parallel()
+
+	ti := New()
+	ti.SetVirtualCursor(false)
+	ti.Focus()
+	ti.Prompt = "> "
+
+	// Type CJK characters that are 2 cells wide each.
+	ti = sendString(ti, "你好")
+
+	cur := ti.Cursor()
+	if cur == nil {
+		t.Fatal("expected non-nil cursor")
+	}
+
+	promptWidth := 2 // "> " is 2 columns
+	// "你好" = 2 CJK characters, each 2 cells wide = 4 columns total.
+	expectedX := promptWidth + 4
+	if cur.X != expectedX {
+		t.Fatalf("expected cursor X=%d but got X=%d", expectedX, cur.X)
+	}
+}
+
+func TestCursorPositionWithMixedASCIIAndCJK(t *testing.T) {
+	t.Parallel()
+
+	ti := New()
+	ti.SetVirtualCursor(false)
+	ti.Focus()
+	ti.Prompt = ""
+
+	// Type mixed ASCII and CJK characters.
+	ti = sendString(ti, "ab你c")
+
+	cur := ti.Cursor()
+	if cur == nil {
+		t.Fatal("expected non-nil cursor")
+	}
+
+	// "ab" = 2 columns, "你" = 2 columns, "c" = 1 column => 5 total.
+	expectedX := 5
+	if cur.X != expectedX {
+		t.Fatalf("expected cursor X=%d but got X=%d", expectedX, cur.X)
+	}
+}
+
+func TestCursorPositionCJKWithOffset(t *testing.T) {
+	t.Parallel()
+
+	ti := New()
+	ti.SetVirtualCursor(false)
+	ti.Focus()
+	ti.Prompt = ""
+	ti.SetWidth(6) // narrow width to force scrolling
+
+	// Type enough CJK characters to overflow the width.
+	ti = sendString(ti, "你好世界")
+
+	cur := ti.Cursor()
+	if cur == nil {
+		t.Fatal("expected non-nil cursor")
+	}
+
+	// Cursor X should not exceed width.
+	if cur.X > ti.Width() {
+		t.Fatalf("cursor X=%d exceeds width=%d", cur.X, ti.Width())
+	}
+}
+
 func keyPress(key rune) tea.Msg {
 	return tea.KeyPressMsg{Code: key, Text: string(key)}
 }


### PR DESCRIPTION
## Summary

`Cursor()` used `m.Position()` (rune index) to compute the X offset. This is incorrect for wide characters (e.g. CJK) that occupy 2 terminal columns per rune, causing the real cursor to be placed to the left of where it should be.

Fix: replace `m.Position()` with `uniseg.StringWidth(string(m.value[m.offset:m.pos]))` to compute the actual display width of the visible text before the cursor.

## Test plan

- Added `TestCursorPositionWithCJKCharacters` — pure CJK input
- Added `TestCursorPositionWithMixedASCIIAndCJK` — mixed ASCII + CJK
- Added `TestCursorPositionCJKWithOffset` — narrow width forcing scroll, cursor stays within bounds