### PR TITLE
docs: fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Build Status](https://github.com/charmbracelet/bubbles/workflows/build/badge.svg)](https://github.com/charmbracelet/bubbles/actions)
 [![Go ReportCard](https://goreportcard.com/badge/charmbracelet/bubbles)](https://goreportcard.com/report/charmbracelet/bubbles)
 
-Primatives for [Bubble Tea](https://github.com/charmbracelet/bubbletea)
+Primitives for [Bubble Tea](https://github.com/charmbracelet/bubbletea)
 applications. These components are used in production in [Crush][crush], and [many other applications][otherstuff].
 
 > [!TIP]


### PR DESCRIPTION
## Summary

Fix a typo in the README introduction.

## Related issue

N/A. This is a trivial docs-only fix.

## Guideline alignment

No `CONTRIBUTING.md` or pull request template was present in the repository root or `.github` directory when this PR was prepared.

## Validation/testing

Not run. This is a documentation-only change.
