### PR TITLE
feat(table): add per-column cell styling via Column.Style

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -35,6 +35,7 @@ type Row []string
 type Column struct {
 	Title string
 	Width int
+	Style *lipgloss.Style // optional per-column cell style; overrides Styles.Cell
 }
 
 // KeyMap defines keybindings. It satisfies to the help.KeyMap interface, which
@@ -434,8 +435,12 @@ func (m *Model) renderRow(r int) string {
 		if m.cols[i].Width <= 0 {
 			continue
 		}
-		style := lipgloss.NewStyle().Width(m.cols[i].Width).MaxWidth(m.cols[i].Width).Inline(true)
-		renderedCell := m.styles.Cell.Render(style.Render(ansi.Truncate(value, m.cols[i].Width, "…")))
+		sizeStyle := lipgloss.NewStyle().Width(m.cols[i].Width).MaxWidth(m.cols[i].Width).Inline(true)
+		cellStyle := m.styles.Cell
+		if m.cols[i].Style != nil {
+			cellStyle = *m.cols[i].Style
+		}
+		renderedCell := cellStyle.Render(sizeStyle.Render(ansi.Truncate(value, m.cols[i].Width, "…")))
 		s = append(s, renderedCell)
 	}
 


### PR DESCRIPTION
## Summary
- Add optional `Style *lipgloss.Style` field to `Column` struct
- Per-column style overrides default `Styles.Cell` for that column

## Usage
```go
numStyle := lipgloss.NewStyle().Padding(0, 1).
    Foreground(lipgloss.Color("212")).Align(lipgloss.Right)

cols := []table.Column{
    {Title: "Name", Width: 30},
    {Title: "Count", Width: 10, Style: &numStyle},
}
```

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./table/...` passes

Closes #689

🤖 Generated with [Claude Code](https://claude.com/claude-code)