### PR TITLE
feat(cursor): export BlinkCanceledMsg type

### DIFF
--- a/cursor/cursor.go
+++ b/cursor/cursor.go
@@ -31,8 +31,8 @@ type BlinkMsg struct {
 	tag int
 }
 
-// blinkCanceled is sent when a blink operation is canceled.
-type blinkCanceled struct{}
+// BlinkCanceledMsg is sent when a blink operation is canceled.
+type BlinkCanceledMsg struct{}
 
 // blinkCtx manages cursor blinking.
 type blinkCtx struct {
@@ -151,7 +151,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		}
 		return m, cmd
 
-	case blinkCanceled: // no-op
+	case BlinkCanceledMsg: // no-op
 		return m, nil
 	}
 	return m, nil
@@ -201,7 +201,7 @@ func (m *Model) Blink() tea.Cmd {
 		if ctx.Err() == context.DeadlineExceeded {
 			return blinkMsg
 		}
-		return blinkCanceled{}
+		return BlinkCanceledMsg{}
 	}
 }
 

--- a/cursor/cursor_test.go
+++ b/cursor/cursor_test.go
@@ -16,7 +16,7 @@ import (
 //		if ctx.Err() == context.DeadlineExceeded {
 //			return BlinkMsg{id: m.id, tag: m.blinkTag}
 //		}
-//		return blinkCanceled{}
+//		return BlinkCanceledMsg{}
 //	}
 //
 // A race on “m.blinkTag” will occur if:


### PR DESCRIPTION
## Summary
- Rename the unexported `blinkCanceled` type to `BlinkCanceledMsg` so that consumers can handle blink cancellation events in their own `Update` functions
- This is useful when embedding the cursor model and needing to distinguish between blink messages and cancellation signals

Closes #834

## Test plan
- [x] Existing tests pass (`go test ./cursor/`)
- [ ] Verify consumers can now match on `cursor.BlinkCanceledMsg` in their Update functions