### PR TITLE
feat(filepicker): add HighlightedDirEntry method

### DIFF
--- a/filepicker/filepicker.go
+++ b/filepicker/filepicker.go
@@ -527,3 +527,13 @@ func (m Model) HighlightedPath() string {
 	}
 	return filepath.Join(m.CurrentDirectory, m.files[m.selected].Name())
 }
+
+// HighlightedDirEntry returns the currently highlighted DirEntry without
+// selecting it. This is useful for previewing file information before the
+// user confirms a selection. Returns nil if no entry is highlighted.
+func (m Model) HighlightedDirEntry() os.DirEntry {
+	if len(m.files) == 0 || m.selected < 0 || m.selected >= len(m.files) {
+		return nil
+	}
+	return m.files[m.selected]
+}


### PR DESCRIPTION
## Summary
- Add `HighlightedDirEntry()` method that returns the currently highlighted `os.DirEntry` without selecting it
- Complements the existing `HighlightedPath()` by giving access to the full `DirEntry` interface (type, info, name)
- Useful for building file preview panes or showing metadata before the user confirms selection

Closes #580

## Test plan
- [x] Package builds successfully (`go build ./filepicker/`)
- [ ] Verify the method returns the correct entry when navigating the file picker
- [ ] Verify it returns nil when the file list is empty