### PR TITLE
feat(help): add FullColumnGap style for column spacing

### DIFF
--- a/help/help.go
+++ b/help/help.go
@@ -40,6 +40,10 @@ type Styles struct {
 	FullKey       lipgloss.Style
 	FullDesc      lipgloss.Style
 	FullSeparator lipgloss.Style
+
+	// FullColumnGap is the style applied to the gap between the key column
+	// and the description column within each group in the full help view.
+	FullColumnGap lipgloss.Style
 }
 
 // DefaultStyles returns a set of default styles for the help bubble. Light or
@@ -208,10 +212,11 @@ func (m Model) FullHelpView(groups [][]key.Binding) string {
 		}
 
 		// Column
+		gap := m.Styles.FullColumnGap.Render(" ")
 		col := lipgloss.JoinHorizontal(lipgloss.Top,
 			sep,
 			m.Styles.FullKey.Render(strings.Join(keys, "\n")),
-			" ",
+			gap,
 			m.Styles.FullDesc.Render(strings.Join(descriptions, "\n")),
 		)
 		w := lipgloss.Width(col)


### PR DESCRIPTION
## Summary
- Add `FullColumnGap` field to `help.Styles` for styling the gap between key and description columns in the full help view
- The hardcoded `" "` space is now rendered through this style, allowing consumers to customize color, padding, or content of the gap
- Backwards compatible: the zero-value `lipgloss.Style` renders the space unchanged

Closes #572

## Test plan
- [x] Existing tests pass (`go test ./help/`)
- [ ] Verify the full help view renders correctly with default (zero-value) style
- [ ] Verify custom FullColumnGap style is applied when set