### PR TITLE
fix(filepicker): allow selecting directories with DirAllowed

### DIFF
--- a/filepicker/filepicker.go
+++ b/filepicker/filepicker.go
@@ -353,6 +353,14 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 				break
 			}
 
+			// When DirAllowed is true and the user pressed Select on a
+			// directory, select it without navigating into it. The user
+			// can still navigate into directories using Open-only keys
+			// (e.g. "l" or "right").
+			if isDir && m.DirAllowed && key.Matches(msg, m.KeyMap.Select) {
+				break
+			}
+
 			m.CurrentDirectory = filepath.Join(m.CurrentDirectory, f.Name())
 			m.pushView(m.selected, m.minIdx, m.maxIdx)
 			m.selected = 0
@@ -495,7 +503,7 @@ func (m Model) didSelectFile(msg tea.Msg) (bool, string) {
 			}
 		}
 
-		if (!isDir && m.FileAllowed) || (isDir && m.DirAllowed) && m.Path != "" {
+		if ((!isDir && m.FileAllowed) || (isDir && m.DirAllowed)) && m.Path != "" {
 			return true, m.Path
 		}
 


### PR DESCRIPTION
## Summary
- When `DirAllowed` is true, pressing Enter on a directory now selects it instead of navigating into it. Navigation into directories still works via Open-only keys (`l`, right arrow).
- Fix operator precedence bug in `didSelectFile` where `(isDir && m.DirAllowed) && m.Path != ""` was evaluated incorrectly due to missing outer parentheses, preventing directory selections from being reported via `DidSelectFile`.

Closes #659

## Test plan
- [x] Package builds successfully (`go build ./filepicker/`)
- [ ] Verify that with `DirAllowed: true`, pressing Enter on a directory sets `Path` and `DidSelectFile` returns true
- [ ] Verify that pressing `l` or right arrow on a directory still navigates into it
- [ ] Verify that with `DirAllowed: false`, existing behavior is unchanged