### PR TITLE
fix(list): adjust cursor position on RemoveItem

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -439,6 +439,13 @@ func (m *Model) InsertItem(index int, item Item) tea.Cmd {
 // this will be a no-op. O(n) complexity, which probably won't matter in the
 // case of a TUI.
 func (m *Model) RemoveItem(index int) {
+	if index < 0 || index >= len(m.items) {
+		return
+	}
+
+	itemsBefore := len(m.VisibleItems())
+	currentIndex := m.Index()
+
 	m.items = removeItemFromSlice(m.items, index)
 	if m.filterState != Unfiltered {
 		m.filteredItems = removeFilterMatchFromSlice(m.filteredItems, index)
@@ -446,6 +453,24 @@ func (m *Model) RemoveItem(index int) {
 			m.resetFiltering()
 		}
 	}
+
+	itemsAfter := len(m.VisibleItems())
+
+	// Adjust cursor when the removed item was at or before the current
+	// position, so that the selection doesn't silently shift to the next item.
+	if itemsAfter < itemsBefore && currentIndex > 0 && index <= currentIndex {
+		currentIndex--
+	}
+
+	// Clamp the index to the new bounds.
+	if itemsAfter > 0 {
+		currentIndex = clamp(currentIndex, 0, itemsAfter-1)
+	} else {
+		currentIndex = 0
+	}
+
+	m.Paginator.Page = currentIndex / max(1, m.Paginator.PerPage)
+	m.cursor = currentIndex % max(1, m.Paginator.PerPage)
 	m.updatePagination()
 }
 


### PR DESCRIPTION
## Summary
- Fix `RemoveItem` to properly adjust the cursor when the removed item is at or before the current selection, preventing the selection from silently shifting to the next item
- Add early bounds check for out-of-range indices (negative or >= len)
- Clamp cursor to valid bounds after removal to prevent out-of-range panics

Closes #632

## Test plan
- [x] Existing tests pass (`go test ./list/`)
- [ ] Remove item before cursor: cursor should move back by one to stay on the same logical item
- [ ] Remove item at cursor (last item): cursor should move to the previous item
- [ ] Remove item after cursor: cursor should stay unchanged
- [ ] Remove all items: no panic, cursor resets to 0