### PR TITLE
fix(viewport): clamp negative height to zero to prevent panic

### DIFF
--- a/viewport/viewport.go
+++ b/viewport/viewport.go
@@ -166,6 +166,9 @@ func (m Model) Height() int {
 
 // SetHeight sets the height of the viewport.
 func (m *Model) SetHeight(h int) {
+	if h < 0 {
+		h = 0
+	}
 	m.height = h
 }
 


### PR DESCRIPTION
## Summary
- Clamp negative height to zero in viewport to prevent panic

## Problem
During terminal resize, subtracting header/footer heights from the window height can produce negative values. Passing a negative height to the viewport caused \`slice bounds out of range\` panics.

## Fix
Add \`if h < 0 { h = 0 }\` guard in \`SetHeight()\`.

## Test plan
- [x] \`go build ./...\` passes
- [x] \`go test ./viewport/...\` passes

Closes #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)