### PR TITLE
fix(stopwatch): set default Interval to 1 second as documented

### DIFF
--- a/stopwatch/stopwatch.go
+++ b/stopwatch/stopwatch.go
@@ -65,7 +65,8 @@ type Model struct {
 // New creates a new stopwatch with 1s interval.
 func New(opts ...Option) Model {
 	m := Model{
-		id: nextID(),
+		id:       nextID(),
+		Interval: time.Second,
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
New() left Interval at zero (0s) instead of 1 second as documented. Stopwatches without WithInterval() ticked as fast as possible.

Closes #862
🤖 Generated with [Claude Code](https://claude.com/claude-code)