### PR TITLE
fix(filepicker): set default height to 20 to prevent broken view

### DIFF
--- a/filepicker/filepicker.go
+++ b/filepicker/filepicker.go
@@ -37,7 +37,7 @@ func New() Model {
 		DirAllowed:       false,
 		FileAllowed:      true,
 		AutoHeight:       true,
-		height:           0,
+		height:           20,
 		maxIdx:           0,
 		minIdx:           0,
 		selectedStack:    newStack(),


### PR DESCRIPTION
## Summary
- Set default filepicker height to 20 to prevent broken initial view

## Problem
The filepicker defaults to \`height: 0\` with \`AutoHeight: true\`. Before the first \`WindowSizeMsg\` arrives, the view renders with zero height, producing empty or garbled output.

## Fix
Change default \`height\` from 0 to 20 in \`New()\`. This provides a reasonable initial view that gets overridden by the actual terminal height once \`WindowSizeMsg\` is received.

## Test plan
- [x] \`go build ./...\` passes
- [x] AutoHeight still works correctly after resize

Closes #864

🤖 Generated with [Claude Code](https://claude.com/claude-code)