### PR TITLE
feat(filepicker): add ShowModTime to display file modification time

### DIFF
--- a/filepicker/filepicker.go
+++ b/filepicker/filepicker.go
@@ -141,6 +141,7 @@ type Model struct {
 	files           []os.DirEntry
 	ShowPermissions bool
 	ShowSize        bool
+	ShowModTime     bool
 	ShowHidden      bool
 	DirAllowed      bool
 	FileAllowed     bool
@@ -399,6 +400,9 @@ func (m Model) View() string {
 			if m.ShowSize {
 				selected += fmt.Sprintf("%"+strconv.Itoa(m.Styles.FileSize.GetWidth())+"s", size)
 			}
+			if m.ShowModTime {
+				selected += " " + info.ModTime().Format("Jan 02 15:04")
+			}
 			selected += " " + name
 			if isSymlink {
 				selected += " → " + symlinkPath
@@ -431,6 +435,9 @@ func (m Model) View() string {
 		}
 		if m.ShowSize {
 			s.WriteString(m.Styles.FileSize.Render(size))
+		}
+		if m.ShowModTime {
+			s.WriteString(" " + info.ModTime().Format("Jan 02 15:04"))
 		}
 		s.WriteString(" " + fileName)
 		s.WriteRune('\n')


### PR DESCRIPTION
## Summary
- Add \`ShowModTime\` option to display file modification timestamps in the filepicker

## Problem
The filepicker shows permissions and size but not modification time. Users often need to identify recent files by date.

## Fix
New \`ShowModTime bool\` field on the filepicker Model. When enabled, displays modification time in \`Jan 02 15:04\` format between the size and filename columns.

```go
fp := filepicker.New()
fp.ShowModTime = true
```

## Test plan
- [x] \`go build ./...\` passes
- [x] Renders correctly for both selected and unselected entries

Closes #805

🤖 Generated with [Claude Code](https://claude.com/claude-code)