### PR TITLE
fix(table): ensure cursor row is visible after SetCursor

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -346,9 +346,14 @@ func (m Model) Cursor() int {
 	return m.cursor
 }
 
-// SetCursor sets the cursor position in the table.
+// SetCursor sets the cursor position in the table and ensures the cursor
+// row is visible within the viewport.
 func (m *Model) SetCursor(n int) {
 	m.cursor = clamp(n, 0, len(m.rows)-1)
+	// Reset the viewport offset so the cursor row is always visible.
+	// Without this, jumping to a distant row (e.g. SetCursor(cursor+9))
+	// can leave the highlighted row outside the visible area.
+	m.viewport.SetYOffset(0)
 	m.UpdateViewport()
 }
 


### PR DESCRIPTION
## Summary
- Fix highlighted table row jumping out of visible viewport after \`SetCursor()\`

## Problem
\`SetCursor(n)\` updated the cursor position and called \`UpdateViewport()\`, but did not reset \`YOffset\`. When jumping to a distant row (e.g. \`SetCursor(cursor+9)\`), the highlighted row moved outside the viewport.

## Steps to Reproduce
```go
// In bubbletea example table
case "tab":
    m.table.SetCursor(m.table.Cursor() + 9) // Row jumps out of view
```

## Fix
Reset \`viewport.YOffset\` to 0 before \`UpdateViewport()\`, forcing the viewport to recalculate around the new cursor position.

## Test plan
- [x] \`go build ./...\` passes
- [x] \`go test ./table/...\` passes

Closes #733

🤖 Generated with [Claude Code](https://claude.com/claude-code)