### PR TITLE
fix(textinput): use display width for cursor position with CJK characters

### DIFF
--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -921,7 +921,10 @@ func (m Model) Cursor() *tea.Cursor {
 	w := lipgloss.Width
 
 	promptWidth := w(m.promptView())
-	xOffset := m.Position() +
+	// Use display width instead of rune count for correct cursor
+	// positioning with wide characters (CJK, fullwidth, etc.)
+	displayPos := w(string(m.value[:m.pos]))
+	xOffset := displayPos +
 		promptWidth
 	if m.width > 0 {
 		xOffset = min(xOffset, m.width+promptWidth)


### PR DESCRIPTION
## Summary
- Fix cursor positioned at wrong column with CJK/wide characters in textinput

## Problem
\`textinput.Cursor()\` calculated X offset using \`m.Position()\` which returns a **rune index**. For CJK characters that occupy 2 terminal columns, this placed the cursor at the wrong position:
- Input: \`あいう\` (3 runes, 6 display columns)
- \`m.Position()\` = 3 → cursor at column 3 (wrong)
- Expected: cursor at column 6

## Fix
Use \`lipgloss.Width(string(m.value[:m.pos]))\` instead of \`m.Position()\` to compute the actual display width, matching the correct approach already used by \`textarea\`.

## Test plan
- [x] \`go build ./...\` passes
- [x] \`go test ./textinput/...\` passes

Closes #906

🤖 Generated with [Claude Code](https://claude.com/claude-code)