### PR TITLE
fix(table): prevent Cell foreground from overriding Selected style

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -429,22 +429,25 @@ func (m Model) headersView() string {
 }
 
 func (m *Model) renderRow(r int) string {
+	isSelected := r == m.cursor
 	s := make([]string, 0, len(m.cols))
 	for i, value := range m.rows[r] {
 		if m.cols[i].Width <= 0 {
 			continue
 		}
-		style := lipgloss.NewStyle().Width(m.cols[i].Width).MaxWidth(m.cols[i].Width).Inline(true)
-		renderedCell := m.styles.Cell.Render(style.Render(ansi.Truncate(value, m.cols[i].Width, "…")))
+		sizeStyle := lipgloss.NewStyle().Width(m.cols[i].Width).MaxWidth(m.cols[i].Width).Inline(true)
+		cellStyle := m.styles.Cell
+		renderedCell := cellStyle.Render(sizeStyle.Render(ansi.Truncate(value, m.cols[i].Width, "…")))
 		s = append(s, renderedCell)
 	}
 
 	row := lipgloss.JoinHorizontal(lipgloss.Top, s...)
 
-	if r == m.cursor {
-		return m.styles.Selected.Render(row)
+	if isSelected {
+		// Strip existing ANSI styles from the row before applying Selected
+		// so that Cell foreground colors don't override the selection style.
+		return m.styles.Selected.Render(ansi.Strip(row))
 	}
-
 	return row
 }
 


### PR DESCRIPTION
## Summary
- Fix selected row style being overridden by Cell foreground color in tables

## Problem
When \`Styles.Cell\` has a \`Foreground\` color set, the ANSI escape codes persist inside the rendered row string. When \`Styles.Selected.Render(row)\` wraps it, the inner Cell colors override the Selected style, making the highlighted row look identical to unselected rows.

## Fix
Strip existing ANSI styles from the row with \`ansi.Strip()\` before applying the Selected style. This ensures selection highlighting is always visible.

## Test plan
- [x] \`go build ./...\` passes
- [x] \`go test ./table/...\` passes (golden files match)

Closes #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)