### PR TITLE
Fix: infinite loop in wordLeft when at buffer start

### DIFF
--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -954,6 +954,11 @@ func (m *Model) characterLeft(insideLine bool) {
 // cursor blink should be reset. If input is masked, move input to the start
 // so as not to reveal word breaks in the masked input.
 func (m *Model) wordLeft() {
+	// If we're already at the start, do nothing and return
+	if m.row == 0 && m.col == 0 {
+		return
+	}
+
 	for {
 		m.characterLeft(true /* insideLine */)
 		if m.col < len(m.value[m.row]) && !unicode.IsSpace(m.value[m.row][m.col]) {


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).

This PR fixes a critical hang in the textarea component. Previously, calling wordLeft() (triggered by Alt+b or Alt+Left) while the cursor was at the beginning of an empty or space-filled buffer would result in an infinite loop.

**The Issue**
In the current implementation of wordLeft():
1. The first for loop calls m.characterLeft(true).
2. If the cursor is at (0,0), characterLeft does not change the cursor position.
3. The loop condition !unicode.IsSpace(...) is never met because the cursor never moves to a new character.
4. The loop runs indefinitely, pinning the CPU and freezing the TUI.

**The Fix**
Added a boundary check at the start of wordLeft() and a delta check inside the loop to ensure that if the cursor fails to move, the loop terminates immediately.