### PR TITLE
Fix placeholder for 0 width textinputs

### DIFF
--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -745,8 +745,14 @@ func (m Model) placeholderView() string {
 		render = styles.Placeholder.Render
 	)
 
-	p := make([]rune, m.Width()+1)
-	copy(p, []rune(m.Placeholder))
+	var p []rune
+	rawHolder := []rune(m.Placeholder)
+	if m.Width() <= 0 {
+		p = make([]rune, len(rawHolder))	
+	} else {
+		p = make([]rune, m.Width() + 1)
+	}
+	copy(p, rawHolder)
 
 	m.virtualCursor.TextStyle = styles.Placeholder
 	m.virtualCursor.SetChar(string(p[:1]))


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features). (n/a)

Fixes #950

The issue is that the placeholder arr (`p`) was made using width + 1. Width = 0 (and, technically, width < 0) are valid widths indicating unlimited width. There is even a comment later in the view that makes it sound like this is the intentional behaviour:

> if there is no width, the placeholder can be any length

However, if w = 0, then the p will be 1 rune in length rather than unlimited