### PR TITLE
fix textinput: render full placeholder text

### DIFF
--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -745,8 +745,7 @@ func (m Model) placeholderView() string {
 		render = styles.Placeholder.Render
 	)
 
-	p := make([]rune, m.Width()+1)
-	copy(p, []rune(m.Placeholder))
+	p := []rune(m.Placeholder)
 
 	m.virtualCursor.TextStyle = styles.Placeholder
 	m.virtualCursor.SetChar(string(p[:1]))


### PR DESCRIPTION
Good day,

I noticed this bug where the placeholder only shows the first character when Width() is small or unset.

The issue is in the placeholderView() function - it allocates a rune slice with size m.Width()+1, which truncates the placeholder text when Width() is 0 or not set.

## Fix

Allocate the full placeholder text directly instead of truncating it based on Width().

## Testing

This fix should allow the full placeholder text ("Nickname", "Email", "Password") to display properly regardless of the Width() setting.

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly, RoomWithOutRoof