### PR TITLE
fix(textinput): allow full placeholder display when width is 0

### DIFF
--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -751,11 +751,6 @@ func (m Model) placeholderView() string {
 	m.virtualCursor.SetChar(string(p[:1]))
 	v += m.virtualCursor.View()
 
-	// If the entire placeholder is already set and no padding is needed, finish
-	if m.Width() < 1 && len(p) <= 1 {
-		return styles.Prompt.Render(m.Prompt) + v
-	}
-
 	// If Width is set then size placeholder accordingly
 	if m.Width() > 0 {
 		// available width is width - len + cursor offset of 1

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -745,8 +745,7 @@ func (m Model) placeholderView() string {
 		render = styles.Placeholder.Render
 	)
 
-	p := make([]rune, m.Width()+1)
-	copy(p, []rune(m.Placeholder))
+	p := []rune(m.Placeholder)
 
 	m.virtualCursor.TextStyle = styles.Placeholder
 	m.virtualCursor.SetChar(string(p[:1]))


### PR DESCRIPTION
Good day,

## Summary
This PR fixes issue #950: textinput v2: 0 Width breaks placeholders

## Problem
When `Width = 0` is set on a textinput model with a placeholder, only the first character of the placeholder was displayed.

The bug was caused by an erroneous early return check in `placeholderView()`:
```go
if m.Width() < 1 && len(p) <= 1 {
    return styles.Prompt.Render(m.Prompt) + v
}
```

This check incorrectly truncated the placeholder to just 1 character when Width is 0 and placeholder length > 1.

## Solution
Removed the incorrect early return. The comment in the code already states "if there is no width, the placeholder can be any length", which is the correct behavior for Width = 0.

Now when Width is 0, the full placeholder is displayed as expected.

## Testing
- Manual test with Width=0 and multi-char placeholder shows full placeholder text

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly, RoomWithOutRoof