### PR TITLE
Textarea: Fix Duplicate Base Style Application

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module charm.land/bubbles/v2
+module github.com/hnimtadd/bubbles/v2
 
 go 1.25.0
 

--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -1588,9 +1588,7 @@ func (m Model) placeholderView() string {
 		// terminate with new line
 		s.WriteRune('\n')
 	}
-
-	m.viewport.SetContent(s.String())
-	return styles.Base.Render(m.viewport.View())
+	return s.String()
 }
 
 // Blink returns the blink command for the virtual cursor.

--- a/textarea/textarea_test.go
+++ b/textarea/textarea_test.go
@@ -1063,6 +1063,31 @@ func TestView(t *testing.T) {
 			},
 		},
 		{
+			name: "placeholder with style",
+			modelFunc: func(m Model) Model {
+				s := m.Styles()
+				s.Focused.Base = lipgloss.NewStyle().Border(lipgloss.NormalBorder())
+				m.SetStyles(s)
+				m.Focus()
+
+				m.SetWidth(12)
+
+				return m
+			},
+			want: want{
+				view: heredoc.Doc(`
+					┌──────────┐
+					│>   1 Hell│
+					│>     o,  │
+					│>     Worl│
+					│>     d!  │
+					│>         │
+					│>         │
+					└──────────┘
+				`),
+			},
+		},
+		{
 			name: "set width with style max width minus one",
 			modelFunc: func(m Model) Model {
 				s := m.Styles()


### PR DESCRIPTION
Thanks for maintaining bubbletea! I've identified and fixed a styling bug in the textarea component.

## Issue
The textarea applies the Base style twice when displaying placeholder text, causing visual duplication of borders and backgrounds. This inconsistency doesn't occur with normal text rendering.

## Root Cause
The `view()` method handles placeholder and text content rendering separately, leading to the Base style being applied at different stages of the rendering pipeline.

## Proposed Solution
Unify the style application flow:
1. Compute either the placeholder view or text buffer view (without applying Base style)
2. Apply the Base style exactly once to the final viewport content

This ensures consistent styling regardless of whether the textarea displays placeholder or actual text.

## How to Reproduce
1. Checkout bubbletea at [commit fdcd0cf](https://github.com/charmbracelet/bubbletea/commit/fdcd0cfd598195e7043c18ab1bc65dcae03588f5)
2. Run `examples/split-editors`: `go run main.go`
3. Observe the duplicate borders on the textarea with placeholder active

## Verify the Fix
Test the fix with:
```bash
go mod edit -replace charm.land/bubbles/v2=github.com/hnimtadd/bubbles/v2@v2.1.1-fix-textarea
go mod tidy
cd examples/split-editors && go run main.go
```
The duplicate borders now disappear.

I will attach the image before and after the fix here.

Before:
<img width="1479" height="923" alt="image" src="https://github.com/user-attachments/assets/dc3eab72-5ac4-4bcd-b543-f827ef04dc07" />
After:
<img width="1464" height="901" alt="image" src="https://github.com/user-attachments/assets/906d9ecb-054e-4879-a54d-afd5434ac8a9" />


## Next Steps
I have a working fix ready and would be happy to submit with this PR. Does this approach align with your design philosophy?