### PR TITLE
fix(filepicker): render after default-height navigation

### DIFF
--- a/filepicker/filepicker.go
+++ b/filepicker/filepicker.go
@@ -37,7 +37,7 @@ func New() Model {
 		DirAllowed:       false,
 		FileAllowed:      true,
 		AutoHeight:       true,
-		height:           0,
+		height:           1,
 		maxIdx:           0,
 		minIdx:           0,
 		selectedStack:    newStack(),

--- a/filepicker/filepicker_test.go
+++ b/filepicker/filepicker_test.go
@@ -1,0 +1,47 @@
+package filepicker
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestDefaultHeightRendersOpenedDirectory(t *testing.T) {
+	root := t.TempDir()
+	subdir := filepath.Join(root, "subdir")
+	if err := os.Mkdir(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subdir, "file.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := New()
+	m.CurrentDirectory = root
+	m = runFilepickerCmd(t, m, m.Init())
+
+	if view := m.View(); !strings.Contains(view, "subdir") {
+		t.Fatalf("expected initial view to show subdir, got %q", view)
+	}
+
+	var cmd tea.Cmd
+	m, cmd = m.Update(tea.KeyPressMsg{Code: 'l', Text: "l"})
+	m = runFilepickerCmd(t, m, cmd)
+
+	if view := m.View(); !strings.Contains(view, "file.txt") {
+		t.Fatalf("expected opened directory view to show file.txt, got %q", view)
+	}
+}
+
+func runFilepickerCmd(t *testing.T, m Model, cmd tea.Cmd) Model {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("expected command")
+	}
+
+	next, _ := m.Update(cmd())
+	return next
+}


### PR DESCRIPTION
Closes #864.

When a filepicker is used before Bubble Tea sends a `WindowSizeMsg`, it starts with `Height() == 0`. The initial view can still show the first entry, but opening a child directory resets `maxIdx` to `-1`, so `View()` filters out every entry and returns an empty string even when files exist.

This sets the default height to `1`, matching the issue workaround, so navigation keeps one visible row until `AutoHeight` applies the terminal height. The regression test opens a temp child directory with the default height and verifies that the file inside remains visible.

Validation:
- `go test ./filepicker`
- `go test ./...`
- `go build ./...`
- `go test -race ./filepicker`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run ./filepicker`
