### PR TITLE
fix(textinput): apply missing .TextStyle to virtualCursor

### DIFF
--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -690,6 +690,7 @@ func (m Model) View() string {
 	styles := m.activeStyle()
 
 	styleText := styles.Text.Inline(true).Render
+	m.virtualCursor.TextStyle = styles.Text
 
 	value := m.value[m.offset:m.offsetRight]
 	pos := max(0, m.pos-m.offset)


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features).

In `textinput.go View()` we render the virtualCursor with .SetChar() set before. 

However, we never apply the the current `styles.Text` to the `.virtualCursor.TextStyle`. This can lead to "punched out cells" if the textinput has a different background color set, then the terminal itself. When the cursor is blinking (hidden) the textinput background is also removed for the cursor char. 

This PR fixes this by setting `m.virtualCursor.TextStyle`