### PR TITLE
docs: fix README typo in spinner section

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ applications. These components are used in production in [Crush][crush], and [ma
 
 <img src="https://stuff.charm.sh/bubbles-examples/spinner.gif" width="400" alt="Spinner Example">
 
-A spinner, useful for indicating that some kind an operation is happening.
+A spinner, useful for indicating that some kind of operation is happening.
 There are a couple default ones, but you can also pass your own ”frames.”
 
 - [Example code, basic spinner](https://github.com/charmbracelet/bubbletea/blob/main/examples/spinner/main.go)


### PR DESCRIPTION
## Summary
Fix a spelling typo in the README intro: "some kind an operation" → "some kind of operation."

## Related issue
Closes #907

## Validation/testing
Docs change only — no tests needed.
