### PR TITLE
feat(textinput,textarea): add shift+backspace support

### DIFF
--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -88,7 +88,7 @@ func DefaultKeyMap() KeyMap {
 		DeleteAfterCursor:       key.NewBinding(key.WithKeys("ctrl+k"), key.WithHelp("ctrl+k", "delete after cursor")),
 		DeleteBeforeCursor:      key.NewBinding(key.WithKeys("ctrl+u"), key.WithHelp("ctrl+u", "delete before cursor")),
 		InsertNewline:           key.NewBinding(key.WithKeys("enter", "ctrl+m"), key.WithHelp("enter", "insert newline")),
-		DeleteCharacterBackward: key.NewBinding(key.WithKeys("backspace", "ctrl+h"), key.WithHelp("backspace", "delete character backward")),
+		DeleteCharacterBackward: key.NewBinding(key.WithKeys("backspace", "shift+backspace", "ctrl+h"), key.WithHelp("backspace", "delete character backward")),
 		DeleteCharacterForward:  key.NewBinding(key.WithKeys("delete", "ctrl+d"), key.WithHelp("delete", "delete character forward")),
 		LineStart:               key.NewBinding(key.WithKeys("home", "ctrl+a"), key.WithHelp("home", "line start")),
 		LineEnd:                 key.NewBinding(key.WithKeys("end", "ctrl+e"), key.WithHelp("end", "line end")),

--- a/textarea/textarea_test.go
+++ b/textarea/textarea_test.go
@@ -2390,6 +2390,17 @@ func TestDynamicHeight_ShrinksWhenScrolledNoMaxContent(t *testing.T) {
 	}
 }
 
+func TestShiftBackspaceDeletesCharacterBackward(t *testing.T) {
+	ta := newTextArea()
+	ta.SetValue("abc")
+
+	ta, _ = ta.Update(tea.KeyPressMsg{Code: tea.KeyBackspace, Mod: tea.ModShift})
+
+	if got, want := ta.Value(), "ab"; got != want {
+		t.Errorf("after shift+backspace got %q, want %q", got, want)
+	}
+}
+
 func newTextArea() Model {
 	textarea := New()
 

--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -75,7 +75,7 @@ func DefaultKeyMap() KeyMap {
 		DeleteWordForward:       key.NewBinding(key.WithKeys("alt+delete", "alt+d")),
 		DeleteAfterCursor:       key.NewBinding(key.WithKeys("ctrl+k")),
 		DeleteBeforeCursor:      key.NewBinding(key.WithKeys("ctrl+u")),
-		DeleteCharacterBackward: key.NewBinding(key.WithKeys("backspace", "ctrl+h")),
+		DeleteCharacterBackward: key.NewBinding(key.WithKeys("backspace", "shift+backspace", "ctrl+h")),
 		DeleteCharacterForward:  key.NewBinding(key.WithKeys("delete", "ctrl+d")),
 		LineStart:               key.NewBinding(key.WithKeys("home", "ctrl+a")),
 		LineEnd:                 key.NewBinding(key.WithKeys("end", "ctrl+e")),

--- a/textinput/textinput_test.go
+++ b/textinput/textinput_test.go
@@ -107,6 +107,18 @@ func ExampleValidateFunc() {
 	}
 }
 
+func TestShiftBackspaceDeletesCharacterBackward(t *testing.T) {
+	ti := New()
+	ti.Focus()
+	ti.SetValue("abc")
+
+	ti, _ = ti.Update(tea.KeyPressMsg{Code: tea.KeyBackspace, Mod: tea.ModShift})
+
+	if got, want := ti.Value(), "ab"; got != want {
+		t.Errorf("after shift+backspace got %q, want %q", got, want)
+	}
+}
+
 func keyPress(key rune) tea.Msg {
 	return tea.KeyPressMsg{Code: key, Text: string(key)}
 }


### PR DESCRIPTION
Aliases `shift+backspace` to the existing `DeleteCharacterBackward` binding in both `textinput` and `textarea`. On keyboard protocols that distinguish modifiers (e.g. the kitty keyboard protocol), `shift+backspace` arrives as a separate key, so users in those environments can't delete a character backward while holding shift. Most other editors treat the two identically.

Discussion: #971

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
