### PR TITLE
fix(textarea): stop wordLeft from spinning on an empty buffer

### DIFF
--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -921,7 +921,14 @@ func (m *Model) characterLeft(insideLine bool) {
 // cursor blink should be reset. If input is masked, move input to the start
 // so as not to reveal word breaks in the masked input.
 func (m *Model) wordLeft() {
+	// Skip spaces backward. characterLeft is a no-op at the very beginning
+	// of the buffer (row=0, col=0), so without an explicit check the loop
+	// spins forever on an empty textarea or one whose content is all
+	// trailing whitespace. See #1652 (filed against bubbletea, lives here).
 	for {
+		if m.row == 0 && m.col == 0 {
+			return
+		}
 		m.characterLeft(true /* insideLine */)
 		if m.col < len(m.value[m.row]) && !unicode.IsSpace(m.value[m.row][m.col]) {
 			break

--- a/textarea/textarea_test.go
+++ b/textarea/textarea_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 	"unicode"
 
 	tea "charm.land/bubbletea/v2"
@@ -1972,6 +1973,28 @@ func TestWord(t *testing.T) {
 			t.Fatalf("Expected last word to be '%s', got '%s'", expect, word)
 		}
 	})
+}
+
+func TestWordLeftOnEmptyDoesNotHang(t *testing.T) {
+	// Regression test for charmbracelet/bubbletea#1652. Pressing alt+left
+	// (the WordBackward binding) on an empty textarea used to spin
+	// wordLeft's "skip spaces backward" loop forever because characterLeft
+	// is a no-op at (0,0) and the break condition can never become true.
+	textarea := newTextArea()
+	textarea.SetHeight(3)
+	textarea.SetWidth(20)
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyLeft, Mod: tea.ModAlt, Text: "alt+left"})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("wordLeft never returned on an empty textarea (would have hung the event loop)")
+	}
 }
 
 func newTextArea() Model {


### PR DESCRIPTION
Filed against bubbletea but lives here: charmbracelet/bubbletea#1652.

\`textarea.wordLeft\` (the \`alt+left\` / \`alt+b\` binding) has an unconditional \`for\` loop whose only exit is landing on a non-space rune. When the textarea is empty (or all trailing whitespace) \`characterLeft\` is a no-op at \`(0, 0)\` and the break condition \`col < len(value[row])\` is \`0 < 0\`, so the loop spins forever and freezes the Bubble Tea event loop. \`doWordRight\` already has the same kind of guard for the end-of-text case.

Added an explicit beginning-of-text check at the top of the loop. If we're already at \`(0, 0)\`, return early.

## Test plan

\`\`\`
go test ./textarea/...
\`\`\`

Added \`TestWordLeftOnEmptyDoesNotHang\` which dispatches \`alt+left\` on an empty textarea inside a goroutine and fails if the call doesn't return within 2 seconds — without the fix the test hangs until the test framework times out.