### PR TITLE
fix: render textarea placeholder base style once

### DIFF
--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -1590,7 +1590,7 @@ func (m Model) placeholderView() string {
 	}
 
 	m.viewport.SetContent(s.String())
-	return styles.Base.Render(m.viewport.View())
+	return m.viewport.View()
 }
 
 // Blink returns the blink command for the virtual cursor.

--- a/textarea/textarea_test.go
+++ b/textarea/textarea_test.go
@@ -1918,6 +1918,29 @@ func TestView(t *testing.T) {
 	}
 }
 
+func TestPlaceholderWithBaseBorderAppliesBaseStyleOnce(t *testing.T) {
+	t.Parallel()
+
+	textarea := newTextArea()
+	textarea.Prompt = ""
+	textarea.ShowLineNumbers = false
+	textarea.SetWidth(20)
+	textarea.SetHeight(3)
+
+	styles := textarea.Styles()
+	styles.Focused.Base = lipgloss.NewStyle().Border(lipgloss.NormalBorder()).Padding(0, 1)
+	styles.Blurred.Base = styles.Focused.Base
+	styles.Focused.CursorLine = lipgloss.NewStyle()
+	textarea.SetStyles(styles)
+
+	view := stripString(textarea.View())
+	for _, border := range []string{"┌", "┐", "└", "┘"} {
+		if got := strings.Count(view, border); got != 1 {
+			t.Fatalf("expected placeholder view to render border %q once, got %d:\n%s", border, got, view)
+		}
+	}
+}
+
 func TestWord(t *testing.T) {
 	textarea := newTextArea()
 


### PR DESCRIPTION
## Summary
- make the textarea placeholder path return the raw viewport output so `Base` is applied only by `View()`
- keep placeholder rendering consistent with the normal text rendering path
- add a regression test that catches doubled borders when `Base` has a border

## Test plan
- go test ./textarea
- go test ./...
- git diff --check

Fixes charmbracelet/bubbletea#1643
