### PR TITLE
fix(table): align columns with WithWidth

### DIFF
--- a/table/resize.go
+++ b/table/resize.go
@@ -1,0 +1,106 @@
+package table
+
+func (m Model) cellFrameWidth() int {
+	return max(
+		m.styles.Header.GetHorizontalFrameSize(),
+		m.styles.Cell.GetHorizontalFrameSize(),
+	)
+}
+
+func (m Model) effectiveColumnWidths() []int {
+	widths := make([]int, len(m.cols))
+	for i, col := range m.cols {
+		widths[i] = col.Width
+	}
+	if m.tableWidth <= 0 {
+		return widths
+	}
+
+	return resizeColumnWidths(widths, m.tableWidth, m.cellFrameWidth())
+}
+
+func resizeColumnWidths(widths []int, target, frame int) []int {
+	out := append([]int(nil), widths...)
+
+	var indices []int
+	for i, w := range out {
+		if w > 0 {
+			indices = append(indices, i)
+		}
+	}
+
+	n := len(indices)
+	if n == 0 {
+		return out
+	}
+
+	sum := 0
+	for _, i := range indices {
+		sum += out[i] + frame
+	}
+	if sum == target {
+		return out
+	}
+
+	contentTarget := target - n*frame
+	if contentTarget < n {
+		contentTarget = n
+	}
+
+	contentSum := 0
+	for _, i := range indices {
+		contentSum += out[i]
+	}
+
+	switch {
+	case contentSum < contentTarget:
+		extra := contentTarget - contentSum
+		for _, i := range indices {
+			add := extra * out[i] / contentSum
+			out[i] += add
+			extra -= add
+		}
+		for j := 0; extra > 0; j++ {
+			out[indices[j%len(indices)]]++
+			extra--
+		}
+	case contentSum > contentTarget:
+		remaining := contentTarget
+		for k, i := range indices {
+			if k == len(indices)-1 {
+				out[i] = max(1, remaining)
+				break
+			}
+			w := max(1, out[i]*contentTarget/contentSum)
+			out[i] = w
+			remaining -= w
+		}
+	}
+
+	for {
+		sum = 0
+		for _, i := range indices {
+			sum += out[i] + frame
+		}
+		if sum == target {
+			break
+		}
+		if sum < target {
+			out[indices[0]]++
+			continue
+		}
+		shrunk := false
+		for _, i := range indices {
+			if out[i] > 1 {
+				out[i]--
+				shrunk = true
+				break
+			}
+		}
+		if !shrunk {
+			break
+		}
+	}
+
+	return out
+}

--- a/table/resize_test.go
+++ b/table/resize_test.go
@@ -1,0 +1,44 @@
+package table
+
+import "testing"
+
+func TestResizeColumnWidthsExpand(t *testing.T) {
+	got := resizeColumnWidths([]int{25, 16, 12}, 80, 2)
+	sum := 0
+	for _, w := range got {
+		sum += w + 2
+	}
+	if sum != 80 {
+		t.Fatalf("total width %d, want 80, widths %v", sum, got)
+	}
+}
+
+func TestResizeColumnWidthsShrink(t *testing.T) {
+	got := resizeColumnWidths([]int{25, 16, 12}, 30, 2)
+	sum := 0
+	for _, w := range got {
+		sum += w + 2
+	}
+	if sum != 30 {
+		t.Fatalf("total width %d, want 30, widths %v", sum, got)
+	}
+}
+
+func TestModelViewWidthMatchesTableWidth(t *testing.T) {
+	m := New(
+		WithWidth(80),
+		WithColumns([]Column{
+			{Title: "Name", Width: 25},
+			{Title: "Country", Width: 16},
+			{Title: "Dunk", Width: 12},
+		}),
+		WithRows([]Row{{"foo", "UK", "Yes"}}),
+	)
+
+	if got := m.naturalWidth(); got != 59 {
+		t.Fatalf("naturalWidth %d want 59", got)
+	}
+	if w := m.Width(); w != 80 {
+		t.Fatalf("Width() %d want 80", w)
+	}
+}

--- a/table/table.go
+++ b/table/table.go
@@ -26,6 +26,8 @@ type Model struct {
 	viewport viewport.Model
 	start    int
 	end      int
+
+	tableWidth int
 }
 
 // Row represents one line in the table.
@@ -173,7 +175,7 @@ func WithHeight(h int) Option {
 // WithWidth sets the width of the table.
 func WithWidth(w int) Option {
 	return func(m *Model) {
-		m.viewport.SetWidth(w)
+		m.SetWidth(w)
 	}
 }
 
@@ -319,10 +321,26 @@ func (m *Model) SetColumns(c []Column) {
 	m.UpdateViewport()
 }
 
-// SetWidth sets the width of the viewport of the table.
+// SetWidth sets the total rendered width of the table.
 func (m *Model) SetWidth(w int) {
-	m.viewport.SetWidth(w)
+	m.tableWidth = w
+	if w > 0 {
+		m.viewport.SetWidth(w)
+	} else {
+		m.viewport.SetWidth(m.naturalWidth())
+	}
 	m.UpdateViewport()
+}
+
+func (m Model) naturalWidth() int {
+	frame := m.cellFrameWidth()
+	total := 0
+	for _, col := range m.cols {
+		if col.Width > 0 {
+			total += col.Width + frame
+		}
+	}
+	return total
 }
 
 // SetHeight sets the height of the viewport of the table.
@@ -416,26 +434,30 @@ func (m *Model) FromValues(value, separator string) {
 }
 
 func (m Model) headersView() string {
+	widths := m.effectiveColumnWidths()
 	s := make([]string, 0, len(m.cols))
-	for _, col := range m.cols {
-		if col.Width <= 0 {
+	for i, col := range m.cols {
+		w := widths[i]
+		if w <= 0 {
 			continue
 		}
-		style := lipgloss.NewStyle().Width(col.Width).MaxWidth(col.Width).Inline(true)
-		renderedCell := style.Render(ansi.Truncate(col.Title, col.Width, "…"))
+		style := lipgloss.NewStyle().Width(w).MaxWidth(w).Inline(true)
+		renderedCell := style.Render(ansi.Truncate(col.Title, w, "…"))
 		s = append(s, m.styles.Header.Render(renderedCell))
 	}
 	return lipgloss.JoinHorizontal(lipgloss.Top, s...)
 }
 
 func (m *Model) renderRow(r int) string {
+	widths := m.effectiveColumnWidths()
 	s := make([]string, 0, len(m.cols))
 	for i, value := range m.rows[r] {
-		if m.cols[i].Width <= 0 {
+		w := widths[i]
+		if w <= 0 {
 			continue
 		}
-		style := lipgloss.NewStyle().Width(m.cols[i].Width).MaxWidth(m.cols[i].Width).Inline(true)
-		renderedCell := m.styles.Cell.Render(style.Render(ansi.Truncate(value, m.cols[i].Width, "…")))
+		style := lipgloss.NewStyle().Width(w).MaxWidth(w).Inline(true)
+		renderedCell := m.styles.Cell.Render(style.Render(ansi.Truncate(value, w, "…")))
 		s = append(s, renderedCell)
 	}
 

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -130,6 +130,7 @@ func TestNew(t *testing.T) {
 					viewport.WithWidth(10),
 					viewport.WithHeight(20),
 				),
+				tableWidth: 10,
 			},
 		},
 		"WithFocused": {
@@ -737,7 +738,6 @@ func TestModel_View(t *testing.T) {
 					}),
 				)
 			},
-			skip: true,
 		},
 		"Modified viewport height": {
 			modelFunc: func() Model {

--- a/table/testdata/TestModel_View/Extra_padding.golden
+++ b/table/testdata/TestModel_View/Extra_padding.golden
@@ -1,14 +1,14 @@
-                                                                 
-                                                                 
-  Name                         Country of Orig…    Dunk-able     
-                                                                 
-                                                                 
                                                             
                                                             
-  Chocolate Digestives         UK                  Yes      
+  Name                      Country of Or…    Dunk-able     
                                                             
                                                             
                                                             
                                                             
-  Tim Tams                     Australia           No       
+  Chocolate Digestives      UK                Yes           
+                                                            
+                                                            
+                                                            
+                                                            
+  Tim Tams                  Australia         No            
                                                             

--- a/table/testdata/TestModel_View/Width_greater_than_columns.golden
+++ b/table/testdata/TestModel_View/Width_greater_than_columns.golden
@@ -1,7 +1,7 @@
- Name                       Country of Orig…  Dunk-able    
- Chocolate Digestives       UK                Yes                               
- Tim Tams                   Australia         No                                
- Hobnobs                    UK                Yes                               
+ Name                                   Country of Origin      Dunk-able        
+ Chocolate Digestives                   UK                     Yes              
+ Tim Tams                               Australia              No               
+ Hobnobs                                UK                     Yes              
                                                                                 
                                                                                 
                                                                                 

--- a/table/testdata/TestModel_View/Width_less_than_columns.golden
+++ b/table/testdata/TestModel_View/Width_less_than_columns.golden
@@ -1,7 +1,7 @@
- Name                     Country of Origin    Dunk-able
- Chocolate Digestives     UK                   Yes
- Tim Tams                 Australia            No
- Hobnobs                  UK                   Yes
+ Name         Countr…  Dunk-… 
+ Chocolate …  UK       Yes    
+ Tim Tams     Austra…  No     
+ Hobnobs      UK       Yes    
                               
                               
                               
@@ -9,12 +9,6 @@
                               
                               
                               
-                              
-                              
-                              
-
-
-
                               
                               
                               


### PR DESCRIPTION
## Summary

Fixes #696.

`WithWidth` previously only resized the viewport while headers and cells kept their configured column widths. That produced misaligned headers, wrapped cells, and trailing whitespace when the viewport was wider or narrower than the column sum.

This PR stores the requested table width and adjusts per-column content widths (accounting for header/cell padding) so the rendered header and rows match the target width.

## Test plan

- [x] `go test ./table/...`
- [x] Added `resize_test.go` for expand/shrink width cases
- [x] Enabled previously skipped `Width less than columns` golden test
- [x] Updated golden files for width-related scenarios

## Notes

Bordered cell/header styles that add extra frame size beyond padding are not fully addressed (existing TODO in tests).