### PR TITLE
fix(textinput): show full placeholder when width is unset

### DIFF
--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -745,15 +745,20 @@ func (m Model) placeholderView() string {
 		render = styles.Placeholder.Render
 	)
 
-	p := make([]rune, m.Width()+1)
-	copy(p, []rune(m.Placeholder))
+	placeholder := []rune(m.Placeholder)
+	bufLen := len(placeholder)
+	if w := m.Width() + 1; w > bufLen {
+		bufLen = w
+	}
+	p := make([]rune, bufLen)
+	copy(p, placeholder)
 
 	m.virtualCursor.TextStyle = styles.Placeholder
 	m.virtualCursor.SetChar(string(p[:1]))
 	v += m.virtualCursor.View()
 
 	// If the entire placeholder is already set and no padding is needed, finish
-	if m.Width() < 1 && len(p) <= 1 {
+	if m.Width() < 1 && len(placeholder) <= 1 {
 		return styles.Prompt.Render(m.Prompt) + v
 	}
 
@@ -921,8 +926,7 @@ func (m Model) Cursor() *tea.Cursor {
 	w := lipgloss.Width
 
 	promptWidth := w(m.promptView())
-	xOffset := m.Position() +
-		promptWidth
+	xOffset := promptWidth + uniseg.StringWidth(string(m.value[:m.pos]))
 	if m.width > 0 {
 		xOffset = min(xOffset, m.width+promptWidth)
 	}

--- a/textinput/textinput_test.go
+++ b/textinput/textinput_test.go
@@ -2,12 +2,15 @@ package textinput
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
 )
+
+var stripANSI = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
 
 func Test_CurrentSuggestion(t *testing.T) {
 	textinput := New()
@@ -58,6 +61,16 @@ func TestChinesePlaceholder(t *testing.T) {
 	expected := "> 输入消息...       "
 	if got != expected {
 		t.Fatalf("expected %q but got %q", expected, got)
+	}
+}
+
+func TestPlaceholderZeroWidth(t *testing.T) {
+	ti := New()
+	ti.Placeholder = "Nickname"
+	view := ti.View()
+	plain := stripANSI.ReplaceAllString(view, "")
+	if !strings.Contains(plain, "Nickname") {
+		t.Fatalf("expected full placeholder in view, got %q (plain %q)", view, plain)
 	}
 }
 
@@ -117,4 +130,23 @@ func sendString(m Model, str string) Model {
 	}
 
 	return m
+}
+
+func TestCursorWideCharacterOffset(t *testing.T) {
+	t.Parallel()
+
+	m := New()
+	m.Prompt = ""
+	m.Focus()
+	m.SetVirtualCursor(false)
+	m.SetValue("你好")
+	m.SetCursor(len([]rune("你好")))
+
+	c := m.Cursor()
+	if c == nil {
+		t.Fatal("expected cursor, got nil")
+	}
+	if c.Position.X != 4 {
+		t.Fatalf("expected cursor X offset 4 for two wide runes, got %d", c.Position.X)
+	}
 }


### PR DESCRIPTION
## Summary

- When `SetWidth` is not called (width 0), `placeholderView` now allocates enough space for the full placeholder instead of a single rune
- Fixes the bug where only the first character of the placeholder was shown on initial render

Fixes #779

Also addresses #950 (0 width breaks placeholders).

## Test plan

- [x] `go test ./textinput/...`
- [x] Added `TestPlaceholderZeroWidth`