### PR TITLE
stopwatch: default Interval to 1s in New() to match the documented default

### DIFF
--- a/stopwatch/stopwatch.go
+++ b/stopwatch/stopwatch.go
@@ -65,7 +65,8 @@ type Model struct {
 // New creates a new stopwatch with 1s interval.
 func New(opts ...Option) Model {
 	m := Model{
-		id: nextID(),
+		id:       nextID(),
+		Interval: time.Second,
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
Closes #862.

`stopwatch.New()` left `Interval` at the zero-value `time.Duration`, so calling `Init()` immediately and never ticking, even though both the field doc and the `New` comment say it defaults to 1 second. Initialise it in `New` so the documented default is what actually runs.