### PR TITLE
Fix infinite loop in textarea wordLeft navigation

### DIFF
--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -959,6 +959,9 @@ func (m *Model) wordLeft() {
 		if m.col < len(m.value[m.row]) && !unicode.IsSpace(m.value[m.row][m.col]) {
 			break
 		}
+		if m.col == 0 && m.row == 0 {
+			break
+		}
 	}
 
 	for m.col > 0 {

--- a/textarea/textarea_test.go
+++ b/textarea/textarea_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 	"unicode"
 
 	tea "charm.land/bubbletea/v2"
@@ -2429,3 +2430,24 @@ func stripString(str string) string {
 
 	return strings.Join(lines, "\n")
 }
+
+func TestWordLeftInfiniteLoopRepro(t *testing.T) {
+	m := New()
+	m.SetValue(" hello")
+	m.col = 0
+	m.row = 0
+
+	done := make(chan struct{})
+	go func() {
+		m.wordLeft()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Log("wordLeft finished")
+	case <-time.After(2 * time.Second):
+		t.Fatal("wordLeft timed out (likely infinite loop)")
+	}
+}
+


### PR DESCRIPTION
When navigating left in a textarea, if we encounter spaces at the very beginning of the input (col=0, row=0), the loop to skip spaces would run infinitely because characterLeft does nothing at the beginning and the cursor never advances.

This PR adds a boundary check to break the loop if the cursor reaches col=0, row=0.