### PR TITLE
fix(textinput): show full placeholder when Width is not set

### DIFF
--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -745,15 +745,16 @@ func (m Model) placeholderView() string {
 		render = styles.Placeholder.Render
 	)
 
-	p := make([]rune, m.Width()+1)
-	copy(p, []rune(m.Placeholder))
+	placeholderRunes := []rune(m.Placeholder)
+	p := make([]rune, max(m.Width()+1, len(placeholderRunes)))
+	copy(p, placeholderRunes)
 
 	m.virtualCursor.TextStyle = styles.Placeholder
 	m.virtualCursor.SetChar(string(p[:1]))
 	v += m.virtualCursor.View()
 
 	// If the entire placeholder is already set and no padding is needed, finish
-	if m.Width() < 1 && len(p) <= 1 {
+	if m.Width() < 1 && len(placeholderRunes) <= 1 {
 		return styles.Prompt.Render(m.Prompt) + v
 	}
 

--- a/textinput/textinput_test.go
+++ b/textinput/textinput_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/x/ansi"
 	tea "charm.land/bubbletea/v2"
 )
 
@@ -58,6 +59,20 @@ func TestChinesePlaceholder(t *testing.T) {
 	expected := "> 输入消息...       "
 	if got != expected {
 		t.Fatalf("expected %q but got %q", expected, got)
+	}
+}
+
+func TestPlaceholderFullRenderWithoutWidth(t *testing.T) {
+	// Regression test for https://github.com/charmbracelet/bubbles/issues/779:
+	// when Width is 0 (default), only the first character of the placeholder was shown.
+	ti := New()
+	ti.Placeholder = "Nickname"
+
+	// Strip ANSI escape codes before checking, since the cursor and the rest
+	// of the placeholder are styled separately.
+	plain := ansi.Strip(ti.View())
+	if !strings.Contains(plain, "Nickname") {
+		t.Fatalf("expected placeholder %q to appear in full, got: %q", "Nickname", plain)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #779: when `Width` is `0` (the default), only the first character of the placeholder was displayed.

## Root cause

`placeholderView` allocated `make([]rune, m.Width()+1)` — a 1-element slice when `Width` is 0. After `copy`, only one rune was transferred. The subsequent guard `m.Width() < 1 && len(p) <= 1` then triggered an early return, rendering only that single character.

## Changes

- `textinput.go`: allocate `max(m.Width()+1, len(placeholderRunes))` so the full placeholder always fits; update the early-return condition to check `len(placeholderRunes) <= 1` instead of `len(p) <= 1`.

## Testing

- New regression test `TestPlaceholderFullRenderWithoutWidth` verifies the full placeholder appears when `Width` is not set.
- All existing tests pass.

Fixes #779