### PR TITLE
fix(list): RemoveItem correctly updates the filtered list when a filter is active

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -441,7 +441,19 @@ func (m *Model) InsertItem(index int, item Item) tea.Cmd {
 func (m *Model) RemoveItem(index int) {
 	m.items = removeItemFromSlice(m.items, index)
 	if m.filterState != Unfiltered {
-		m.filteredItems = removeFilterMatchFromSlice(m.filteredItems, index)
+		// Rebuild filtered list: drop the entry matching the removed global
+		// index and shift down all subsequent global indices by one.
+		filtered := m.filteredItems[:0]
+		for _, fi := range m.filteredItems {
+			if fi.index == index {
+				continue
+			}
+			if fi.index > index {
+				fi.index--
+			}
+			filtered = append(filtered, fi)
+		}
+		m.filteredItems = filtered
 		if len(m.filteredItems) == 0 {
 			m.resetFiltering()
 		}
@@ -1297,15 +1309,6 @@ func removeItemFromSlice(i []Item, index int) []Item {
 	}
 	copy(i[index:], i[index+1:])
 	i[len(i)-1] = nil
-	return i[:len(i)-1]
-}
-
-func removeFilterMatchFromSlice(i []filteredItem, index int) []filteredItem {
-	if index >= len(i) {
-		return i // noop
-	}
-	copy(i[index:], i[index+1:])
-	i[len(i)-1] = filteredItem{}
 	return i[:len(i)-1]
 }
 

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -99,6 +99,29 @@ func TestSetFilterText(t *testing.T) {
 	}
 }
 
+func TestRemoveItemWithFilter(t *testing.T) {
+	items := []Item{item("foo"), item("bar"), item("baz")}
+	l := New(items, itemDelegate{}, 10, 10)
+	l.SetFilterText("ba")
+	l.SetFilterState(FilterApplied)
+
+	// filtered list contains ["bar", "baz"] at global indices 1 and 2.
+	// Remove "foo" (global index 0) — filtered list should be unchanged.
+	l.RemoveItem(0)
+	visible := l.VisibleItems()
+	if !reflect.DeepEqual(visible, []Item{item("bar"), item("baz")}) {
+		t.Fatalf("after removing unfiltered item: got %v, want [bar baz]", visible)
+	}
+
+	// The global list is now ["bar", "baz"]. Remove "bar" (global index 0).
+	// Filtered list should shrink to ["baz"].
+	l.RemoveItem(0)
+	visible = l.VisibleItems()
+	if !reflect.DeepEqual(visible, []Item{item("baz")}) {
+		t.Fatalf("after removing filtered item: got %v, want [baz]", visible)
+	}
+}
+
 func TestSetFilterState(t *testing.T) {
 	tc := []Item{item("foo"), item("bar"), item("baz")}
 


### PR DESCRIPTION
Fixes #632.

## Problem

`RemoveItem(index)` used the same `index` for two different purposes:
- removing from `m.items` (where `index` is the global item position) ✓
- removing from `m.filteredItems` (where `index` was treated as a position in the filtered slice) ✗

When a filter was applied, those two indices no longer correspond. Depending on the relative lengths, either the wrong filtered entry was removed, or a removal in the global list was not reflected in the filtered view.

## Fix

Instead of removing by positional index from `filteredItems`, iterate over the slice and:
- skip the `filteredItem` whose `.index` field matches the global `index` being removed.
- decrement `.index` for every subsequent entry (since they now point one position further than their actual global slot).

The orphaned `removeFilterMatchFromSlice` helper is deleted.