### PR TITLE
fix(textarea): reposition view after SetValue

### DIFF
--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -482,6 +482,7 @@ func (m *Model) SetValue(s string) {
 	m.Reset()
 	m.InsertString(s)
 	m.recalculateHeight()
+	m.repositionView()
 }
 
 // InsertString inserts a string at the cursor position.

--- a/textarea/textarea_test.go
+++ b/textarea/textarea_test.go
@@ -143,6 +143,22 @@ func TestSetValue(t *testing.T) {
 	}
 }
 
+func TestSetValueViewportReposition(t *testing.T) {
+	ta := newTextArea()
+	ta.SetHeight(3)
+	ta.SetWidth(40)
+
+	// Insert more lines than the viewport height so the cursor ends below the visible area.
+	lines := strings.Join([]string{"line1", "line2", "line3", "line4", "line5"}, "\n")
+	ta.SetValue(lines)
+
+	// Cursor must be visible: ScrollYOffset must be high enough that the last row is in view.
+	if ta.ScrollYOffset()+ta.Height()-1 < ta.LineCount()-1 {
+		t.Fatalf("cursor out of view after SetValue: yOffset=%d height=%d lines=%d",
+			ta.ScrollYOffset(), ta.Height(), ta.LineCount())
+	}
+}
+
 func TestInsertString(t *testing.T) {
 	textarea := newTextArea()
 


### PR DESCRIPTION
## Problem

When `SetValue` is called with content taller than the textarea viewport, the viewport is not scrolled to show the cursor position. The cursor ends up on the last line of the content, but `repositionView()` was never called to adjust the scroll offset.

## Fix

Call `m.repositionView()` at the end of `SetValue`, consistent with how other content-insertion paths work.

## Test

Added `TestSetValueViewportReposition` which sets a 3-line viewport, calls `SetValue` with 5 lines, and asserts the cursor line is within the visible range.

Fixes #231