### PR TITLE
fix(table): clamp cursor to 0 when SetRows is called with empty slice

### DIFF
--- a/table/cursor_shrink_test.go
+++ b/table/cursor_shrink_test.go
@@ -1,0 +1,42 @@
+package table
+
+import (
+	"testing"
+)
+
+func TestSetRows_CursorClampsToZeroOnEmpty(t *testing.T) {
+	cols := []Column{{Title: "Name", Width: 10}}
+	rows := []Row{{"a"}, {"b"}, {"c"}}
+	tbl := New(WithColumns(cols), WithRows(rows), WithHeight(5))
+
+	// Move to last row
+	tbl.GotoBottom()
+	if tbl.Cursor() != 2 {
+		t.Fatalf("expected cursor at 2, got %d", tbl.Cursor())
+	}
+
+	// Replace with empty rows
+	tbl.SetRows([]Row{})
+
+	got := tbl.Cursor()
+	if got < 0 {
+		t.Fatalf("SetRows(empty): Cursor() = %d, want >= 0 (got negative cursor on empty table)", got)
+	}
+}
+
+func TestSetRows_CursorClampsOnShrink(t *testing.T) {
+	cols := []Column{{Title: "Name", Width: 10}}
+	rows := []Row{{"a"}, {"b"}, {"c"}}
+	tbl := New(WithColumns(cols), WithRows(rows), WithHeight(5))
+
+	// Move to last row (index 2)
+	tbl.GotoBottom()
+
+	// Shrink to 1 row
+	tbl.SetRows([]Row{{"x"}})
+
+	got := tbl.Cursor()
+	if got != 0 {
+		t.Fatalf("SetRows(fewer rows): Cursor() = %d, want 0", got)
+	}
+}

--- a/table/table.go
+++ b/table/table.go
@@ -306,7 +306,9 @@ func (m Model) Columns() []Column {
 func (m *Model) SetRows(r []Row) {
 	m.rows = r
 
-	if m.cursor > len(m.rows)-1 {
+	if len(m.rows) == 0 {
+		m.cursor = 0
+	} else if m.cursor > len(m.rows)-1 {
 		m.cursor = len(m.rows) - 1
 	}
 


### PR DESCRIPTION
When SetRows is called with an empty rows slice, the guard added in #783
still runs the assignment on line 310:

    if m.cursor > len(m.rows)-1 {
        m.cursor = len(m.rows) - 1  // len == 0, so this is -1
    }

Because len(m.rows)-1 is -1 when the slice is empty, any cursor position
(including 0) satisfies the condition and gets set to -1. After that,
Cursor() returns -1 indefinitely until new rows are loaded.

The fix adds an explicit empty-slice guard that resets cursor to 0, which
matches the initial state of a freshly constructed table. The existing
shrink-to-fewer-rows path is unchanged.

Before this change, TestSetRows_CursorClampsToZeroOnEmpty failed:

    cursor_shrink_test.go:23: SetRows(empty): Cursor() = -1, want >= 0

After: both new tests pass and the full table suite stays green.