### PR TITLE
fix(textarea): count runes, not display width, for CharLimit

### DIFF
--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -616,7 +616,7 @@ func (m Model) Value() string {
 func (m *Model) Length() int {
 	var l int
 	for _, row := range m.value {
-		l += uniseg.StringWidth(string(row))
+		l += len(row)
 	}
 	// We add len(m.value) to include the newline characters.
 	return l + len(m.value) - 1

--- a/textarea/textarea_test.go
+++ b/textarea/textarea_test.go
@@ -2390,6 +2390,25 @@ func TestDynamicHeight_ShrinksWhenScrolledNoMaxContent(t *testing.T) {
 	}
 }
 
+func TestCharLimitWideRunes(t *testing.T) {
+	m := newTextArea()
+	m.Prompt = ""
+	m.ShowLineNumbers = false
+	m.CharLimit = 5
+
+	// Five East Asian wide runes, each two cells wide. CharLimit counts
+	// characters, not display cells, so all five should be accepted (this
+	// matches textinput, which limits by rune count).
+	m = sendString(m, "你好世界龍")
+
+	if got := len([]rune(m.Value())); got != 5 {
+		t.Errorf("CharLimit=5 admitted %d wide characters, want 5", got)
+	}
+	if got := m.Length(); got != 5 {
+		t.Errorf("Length() = %d for five characters, want 5", got)
+	}
+}
+
 func newTextArea() Model {
 	textarea := New()
 


### PR DESCRIPTION
`Length()` sums `uniseg.StringWidth` per row, so `CharLimit` is enforced by display width rather than character count. Wide runes (CJK, emoji) take two cells, so a textarea with `CharLimit=N` stops accepting input at about `N/2` characters. This contradicts the godoc on both `Length()` ("the number of characters currently in the text input") and `CharLimit` ("the maximum number of characters"), and disagrees with `textinput`, which enforces the same limit by rune count.

Repro: with `CharLimit = 5`, typing five wide runes one at a time leaves only three in the textarea, while five ASCII characters are accepted. `textinput` with the same limit accepts all five wide runes.

The fix counts runes (`len(row)`, where `row` is `[]rune`), matching the godoc and `textinput`. `uniseg` is still used for rendering, and the existing ASCII `CharLimit` tests are unchanged (width equals rune count for ASCII). Added `TestCharLimitWideRunes` covering the wide-rune case.