### PR TITLE
fix(textinput): account for scroll offset in hardware Cursor() X position

### DIFF
--- a/textinput/textinput.go
+++ b/textinput/textinput.go
@@ -921,7 +921,7 @@ func (m Model) Cursor() *tea.Cursor {
 	w := lipgloss.Width
 
 	promptWidth := w(m.promptView())
-	xOffset := m.Position() +
+	xOffset := max(0, m.pos-m.offset) +
 		promptWidth
 	if m.width > 0 {
 		xOffset = min(xOffset, m.width+promptWidth)

--- a/textinput/textinput_test.go
+++ b/textinput/textinput_test.go
@@ -118,3 +118,27 @@ func sendString(m Model, str string) Model {
 
 	return m
 }
+
+func TestCursorXAccountsForScrollOffset(t *testing.T) {
+	m := New()
+	m.Focus()
+	m.SetVirtualCursor(false)
+	m.CharLimit = 200
+	m.SetWidth(20)
+
+	text := strings.Repeat("a", 30)
+	m.SetValue(text)
+	m.SetCursor(15)
+
+	cur := m.Cursor()
+	if cur == nil {
+		t.Fatal("Cursor() returned nil")
+	}
+
+	// With 30 chars in a width-20 viewport, offset=10 and visible column=5.
+	// Hardware cursor X must include the prompt ("> ", width 2).
+	const wantX = 7
+	if cur.X != wantX {
+		t.Errorf("Cursor().X = %d, want %d (scroll-adjusted visible column + prompt width)", cur.X, wantX)
+	}
+}


### PR DESCRIPTION
## Summary

Fix `textinput.Model.Cursor()` to use the scroll-adjusted visible column (`m.pos - m.offset`) instead of the absolute cursor position (`m.Position()`), matching how `View()` already renders the cursor.

Fixes #1001

## Motivation

When input text is wider than the configured width, the textinput scrolls horizontally. `View()` correctly uses `m.pos - m.offset` for the visible cursor column, but `Cursor()` used the absolute position. This caused the hardware cursor (used with `SetVirtualCursor(false)`) to appear at the wrong column when the input was scrolled.

## Changes

- **`textinput/textinput.go`**: In `Cursor()`, replace `m.Position()` with `max(0, m.pos-m.offset)` when computing `xOffset`.
- **`textinput/textinput_test.go`**: Add `TestCursorXAccountsForScrollOffset` — sets a 30-character value in a width-20 input with the cursor at position 15 (offset=10, visible column=5) and asserts `Cursor().X == 7` (visible column + prompt width).

## Tests

```
go test ./textinput/... -v -run TestCursorXAccountsForScrollOffset  # PASS
go test ./...                                                      # PASS (all packages)
```

## Notes

- The existing `min(xOffset, m.width+promptWidth)` clamp is unchanged.
- When text does not overflow (`offset == 0`), behavior is identical to before.
- Reviewed with composer-2.5 sub-agent: APPROVED.