### PR TITLE
fix(list): convert fuzzy match indexes from byte to rune offsets

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -102,7 +102,7 @@ func DefaultFilter(term string, targets []string) []Rank {
 	for i, r := range ranks {
 		result[i] = Rank{
 			Index:          r.Index,
-			MatchedIndexes: r.MatchedIndexes,
+			MatchedIndexes: runeIndexes(targets[r.Index], r.MatchedIndexes),
 		}
 	}
 	return result
@@ -116,10 +116,37 @@ func UnsortedFilter(term string, targets []string) []Rank {
 	for i, r := range ranks {
 		result[i] = Rank{
 			Index:          r.Index,
-			MatchedIndexes: r.MatchedIndexes,
+			MatchedIndexes: runeIndexes(targets[r.Index], r.MatchedIndexes),
 		}
 	}
 	return result
+}
+
+// runeIndexes converts the byte offsets that sahilm/fuzzy reports into rune
+// offsets. MatchesForItem documents its result as rune positions and
+// lipgloss.StyleRunes consumes them as such, so byte offsets would highlight
+// the wrong runes (or none) when a target contains multi-byte characters. The
+// byte offsets are ascending and always fall on rune boundaries.
+func runeIndexes(target string, byteIndexes []int) []int {
+	if len(byteIndexes) == 0 {
+		return byteIndexes
+	}
+	out := make([]int, len(byteIndexes))
+	next := 0
+	runeIndex := 0
+	for byteIndex := range target {
+		for next < len(byteIndexes) && byteIndexes[next] == byteIndex {
+			out[next] = runeIndex
+			next++
+		}
+		runeIndex++
+	}
+	// Handle any trailing offset that points just past the last rune.
+	for next < len(byteIndexes) {
+		out[next] = runeIndex
+		next++
+	}
+	return out
 }
 
 type statusMessageTimeoutMsg struct{}

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -135,3 +135,39 @@ func TestSetFilterState(t *testing.T) {
 		t.Fatalf("Error: expected view to contain '%s'", expected)
 	}
 }
+
+func TestFilterMatchedIndexesAreRunePositions(t *testing.T) {
+	// sahilm/fuzzy reports matched indexes as byte offsets, but MatchesForItem
+	// documents them as rune positions and lipgloss.StyleRunes consumes them as
+	// such. DefaultFilter and UnsortedFilter must convert byte offsets to rune
+	// offsets so multi-byte titles are highlighted correctly.
+	cases := []struct {
+		name   string
+		term   string
+		target string
+		want   []int
+	}{
+		{"ascii", "b", "abc", []int{1}},
+		{"multibyte prefix", "b", "日本b", []int{2}},
+		{"accented prefix", "x", "café x", []int{5}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, f := range []struct {
+				name   string
+				filter FilterFunc
+			}{
+				{"DefaultFilter", DefaultFilter},
+				{"UnsortedFilter", UnsortedFilter},
+			} {
+				ranks := f.filter(tc.term, []string{tc.target})
+				if len(ranks) != 1 {
+					t.Fatalf("%s: expected 1 rank, got %d", f.name, len(ranks))
+				}
+				if !reflect.DeepEqual(ranks[0].MatchedIndexes, tc.want) {
+					t.Errorf("%s: MatchedIndexes = %v, want %v", f.name, ranks[0].MatchedIndexes, tc.want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
`sahilm/fuzzy` reports `MatchedIndexes` as byte offsets, but `MatchesForItem` documents them as rune positions and `lipgloss.StyleRunes` consumes them as such - so filtering a list whose item titles contain multi-byte characters (CJK, accents, emoji) highlighted the wrong runes, or none. This converts the offsets from byte to rune positions in `DefaultFilter` and `UnsortedFilter`.

Fixes #124
