### PR TITLE
fix(textarea): prevent infinite loop in wordLeft on empty/start-of-text input

### DIFF
--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -954,7 +954,16 @@ func (m *Model) characterLeft(insideLine bool) {
 // cursor blink should be reset. If input is masked, move input to the start
 // so as not to reveal word breaks in the masked input.
 func (m *Model) wordLeft() {
+	// Skip spaces backward, stopping at the start of the text. Without this
+	// guard, characterLeft becomes a no-op at the very start of the input
+	// (row 0, col 0) while the break condition below is never satisfied,
+	// spinning the loop forever. This mirrors the end-of-text break in
+	// doWordRight.
 	for {
+		if m.row == 0 && m.col == 0 {
+			// Start of text.
+			return
+		}
 		m.characterLeft(true /* insideLine */)
 		if m.col < len(m.value[m.row]) && !unicode.IsSpace(m.value[m.row][m.col]) {
 			break

--- a/textarea/textarea_test.go
+++ b/textarea/textarea_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 	"unicode"
 
 	tea "charm.land/bubbletea/v2"
@@ -1972,6 +1973,58 @@ func TestWord(t *testing.T) {
 			t.Fatalf("Expected last word to be '%s', got '%s'", expect, word)
 		}
 	})
+}
+
+// TestWordBackwardEmptyTextareaTerminates guards against a regression where
+// wordLeft() spun forever on an empty textarea. With m.value == [][]rune{{}}
+// and the cursor at row 0, col 0, characterLeft is a no-op and the loop's
+// break condition (m.col < len(m.value[m.row])) is 0 < 0 == false, so alt+left
+// / alt+b would freeze the event loop. See charmbracelet/bubbletea#1652.
+//
+// The test runs the update on a goroutine with a timeout so a regression fails
+// the test instead of hanging the whole suite, and asserts the motion is a
+// no-op on empty input.
+func TestWordBackwardEmptyTextareaTerminates(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		key  tea.KeyPressMsg
+	}{
+		{"alt+left", tea.KeyPressMsg{Code: tea.KeyLeft, Mod: tea.ModAlt, Text: "alt+left"}},
+		{"alt+b", tea.KeyPressMsg{Code: 'b', Mod: tea.ModAlt, Text: "alt+b"}},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTextArea()
+
+			// Sanity check: the textarea starts empty with the cursor at the
+			// very start of the text.
+			if got := m.Value(); got != "" {
+				t.Fatalf("expected empty value, got %q", got)
+			}
+			if m.row != 0 || m.col != 0 {
+				t.Fatalf("expected cursor at row 0, col 0, got row %d, col %d", m.row, m.col)
+			}
+
+			done := make(chan Model, 1)
+			go func() {
+				updated, _ := m.Update(tc.key)
+				done <- updated
+			}()
+
+			select {
+			case updated := <-done:
+				// Word-backward on empty input must be a no-op.
+				if got := updated.Value(); got != "" {
+					t.Fatalf("expected value to remain empty, got %q", got)
+				}
+				if updated.row != 0 || updated.col != 0 {
+					t.Fatalf("expected cursor to stay at row 0, col 0, got row %d, col %d", updated.row, updated.col)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatalf("word backward (%s) did not terminate on empty textarea", tc.name)
+			}
+		})
+	}
 }
 
 func newDynamicTextArea(minH, maxH int) Model {


### PR DESCRIPTION
# Suggested PR

**Title:** `fix(textarea): prevent infinite loop in wordLeft on empty/start-of-text input`

**Description:**

## Summary

`textarea`'s word-backward motion (`alt+left` / `alt+b`) could spin forever and freeze the event loop when the textarea was empty or the cursor was already at the start of the text.

`wordLeft()` used an unconditional `for {}` that only exits once it finds a non-space rune:

```go
for {
    m.characterLeft(true /* insideLine */)
    if m.col < len(m.value[m.row]) && !unicode.IsSpace(m.value[m.row][m.col]) {
        break
    }
}
```

When the textarea is empty (`m.value == [][]rune{{}}`, cursor at `row=0, col=0`), `characterLeft(true)` is a no-op and the break condition `m.col < len(m.value[m.row])` evaluates to `0 < 0 == false`. The loop never terminates, hanging the program.

## Fix

Add a start-of-text guard at the top of the loop, mirroring the end-of-text break that `doWordRight()` already has. Since `characterLeft` always makes progress (moving up a row and/or left a column) until it reaches `row 0, col 0`, returning at that point guarantees termination and makes the motion a no-op on empty input.

```go
for {
    if m.row == 0 && m.col == 0 {
        // Start of text.
        return
    }
    m.characterLeft(true /* insideLine */)
    ...
}
```

## Related helpers audited

- `deleteWordLeft` / `deleteWordRight` — already guard `m.col == 0` / `len(m.value[m.row]) == 0`; safe.
- `doWordRight` (and its callers `wordRight`, `uppercaseRight`, `lowercaseRight`, `capitalizeRight`, `deleteWordRight`) — already break at end of text; safe.
- `wordLeft` was the only word-motion helper missing the boundary guard.

## Testing

Added `TestWordBackwardEmptyTextareaTerminates`, which drives an empty textarea with `alt+left` and `alt+b`. The update runs on a goroutine guarded by a 2s timeout, so a regression fails the test rather than hanging the suite, and asserts the motion is a no-op (cursor stays at `row 0, col 0`, value stays empty).

Verified the test fails against the unpatched code (times out) and passes with the fix. `go test ./...`, `go vet ./...`, and `gofmt -l .` are all clean.

Fixes charmbracelet/bubbletea#1652
