### PR TITLE
fix(filepicker): don't blank the view when height is unset

### DIFF
--- a/filepicker/filepicker.go
+++ b/filepicker/filepicker.go
@@ -228,8 +228,18 @@ func (m Model) readDir(path string, showHidden bool) tea.Cmd {
 func (m *Model) SetHeight(h int) {
 	m.height = h
 	if m.maxIdx > m.height-1 {
-		m.maxIdx = m.minIdx + m.height - 1
+		m.maxIdx = m.bottomIdx(m.minIdx)
 	}
+}
+
+// bottomIdx returns the index of the last visible entry for a viewport whose
+// first visible entry is top. If the height has not been set yet, one entry is
+// shown so that the view is never blank.
+func (m Model) bottomIdx(top int) int {
+	if m.height < 1 {
+		return top
+	}
+	return top + m.height - 1
 }
 
 // Height returns the height of the file picker.
@@ -250,21 +260,21 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			break
 		}
 		m.files = msg.entries
-		m.maxIdx = max(m.maxIdx, m.Height()-1)
+		m.maxIdx = max(m.maxIdx, m.bottomIdx(m.minIdx))
 	case tea.WindowSizeMsg:
 		if m.AutoHeight {
 			m.SetHeight(msg.Height - marginBottom)
 		}
-		m.maxIdx = m.Height() - 1
+		m.maxIdx = m.bottomIdx(m.minIdx)
 	case tea.KeyPressMsg:
 		switch {
 		case key.Matches(msg, m.KeyMap.GoToTop):
 			m.selected = 0
 			m.minIdx = 0
-			m.maxIdx = m.Height() - 1
+			m.maxIdx = m.bottomIdx(0)
 		case key.Matches(msg, m.KeyMap.GoToLast):
 			m.selected = len(m.files) - 1
-			m.minIdx = len(m.files) - m.Height()
+			m.minIdx = max(len(m.files)-m.Height(), 0)
 			m.maxIdx = len(m.files) - 1
 		case key.Matches(msg, m.KeyMap.Down):
 			m.selected++
@@ -294,7 +304,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 			if m.maxIdx >= len(m.files) {
 				m.maxIdx = len(m.files) - 1
-				m.minIdx = m.maxIdx - m.Height()
+				m.minIdx = max(m.maxIdx-m.Height(), 0)
 			}
 		case key.Matches(msg, m.KeyMap.PageUp):
 			m.selected -= m.Height()
@@ -315,7 +325,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			} else {
 				m.selected = 0
 				m.minIdx = 0
-				m.maxIdx = m.Height() - 1
+				m.maxIdx = m.bottomIdx(0)
 			}
 			return m, m.readDir(m.CurrentDirectory, m.ShowHidden)
 		case key.Matches(msg, m.KeyMap.Open):
@@ -357,7 +367,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			m.pushView(m.selected, m.minIdx, m.maxIdx)
 			m.selected = 0
 			m.minIdx = 0
-			m.maxIdx = m.Height() - 1
+			m.maxIdx = m.bottomIdx(0)
 			return m, m.readDir(m.CurrentDirectory, m.ShowHidden)
 		}
 	}
@@ -495,7 +505,7 @@ func (m Model) didSelectFile(msg tea.Msg) (bool, string) {
 			}
 		}
 
-		if (!isDir && m.FileAllowed) || (isDir && m.DirAllowed) && m.Path != "" {
+		if ((!isDir && m.FileAllowed) || (isDir && m.DirAllowed)) && m.Path != "" {
 			return true, m.Path
 		}
 

--- a/filepicker/filepicker_test.go
+++ b/filepicker/filepicker_test.go
@@ -1,0 +1,86 @@
+package filepicker
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// newTestDir creates a directory containing a subdirectory with a file in it.
+func newTestDir(tb testing.TB) string {
+	tb.Helper()
+	root := tb.TempDir()
+	sub := filepath.Join(root, "subdir")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		tb.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "file.go"), []byte("package main"), 0o644); err != nil {
+		tb.Fatal(err)
+	}
+	return root
+}
+
+// update sends msg to the model and runs the returned command, if any, feeding
+// its message back into the model.
+func update(tb testing.TB, m Model, msg tea.Msg) Model {
+	tb.Helper()
+	m, cmd := m.Update(msg)
+	if cmd != nil {
+		m, _ = m.Update(cmd())
+	}
+	return m
+}
+
+// TestNavigateWithoutWindowSize asserts that a file picker which never receives
+// a tea.WindowSizeMsg still renders its entries after entering a directory.
+func TestNavigateWithoutWindowSize(t *testing.T) {
+	m := New()
+	m.CurrentDirectory = newTestDir(t)
+
+	m = update(t, m, m.Init()())
+	if got := m.View(); !strings.Contains(got, "subdir") {
+		t.Fatalf("expected view to contain %q, got %q", "subdir", got)
+	}
+
+	m = update(t, m, tea.KeyPressMsg{Code: 'l', Text: "l"})
+	if !strings.HasSuffix(m.CurrentDirectory, "subdir") {
+		t.Fatalf("expected to descend into subdir, got %q", m.CurrentDirectory)
+	}
+	if m.maxIdx < m.minIdx {
+		t.Fatalf("maxIdx (%d) must not be less than minIdx (%d)", m.maxIdx, m.minIdx)
+	}
+	if got := m.View(); !strings.Contains(got, "file.go") {
+		t.Fatalf("expected view to contain %q, got %q", "file.go", got)
+	}
+}
+
+// TestDidSelectFileRequiresPath asserts that a selection is only reported once
+// a path has actually been selected.
+func TestDidSelectFileRequiresPath(t *testing.T) {
+	m := New()
+	m.CurrentDirectory = filepath.Join(newTestDir(t), "subdir")
+	m.AllowedTypes = []string{".txt"}
+
+	m = update(t, m, m.Init()())
+
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	if didSelect, path := m.DidSelectFile(enter); didSelect {
+		t.Fatalf("expected no selection for a disallowed type, got %q", path)
+	}
+	if didSelect, path := m.DidSelectDisabledFile(enter); didSelect {
+		t.Fatalf("expected no disabled selection before a path is set, got %q", path)
+	}
+
+	m.AllowedTypes = []string{".go"}
+	m = update(t, m, enter)
+	didSelect, path := m.DidSelectFile(enter)
+	if !didSelect {
+		t.Fatal("expected file.go to be selected")
+	}
+	if !strings.HasSuffix(path, "file.go") {
+		t.Fatalf("expected path to end in file.go, got %q", path)
+	}
+}


### PR DESCRIPTION
## What?

Added `bottomIdx(top)`, which returns the last visible index for a viewport starting at `top` and falls back to `top` when `height < 1`.

Fixed operator order in `didSelectFile`. 

Added a test to cover both changes

## Why?

Fixes #905 