### PR TITLE
feat(textarea): add pointer selection

### DIFF
--- a/textarea/selection.go
+++ b/textarea/selection.go
@@ -1,0 +1,257 @@
+package textarea
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/rivo/uniseg"
+)
+
+// Position is a location in the textarea's logical buffer: Row indexes a
+// logical (unwrapped) line, Col indexes a rune within that line. Col may
+// equal the line length, meaning "just past the last rune".
+type Position struct {
+	Row int
+	Col int
+}
+
+// before reports whether p sorts before q in the buffer.
+func (p Position) before(q Position) bool {
+	if p.Row != q.Row {
+		return p.Row < q.Row
+	}
+	return p.Col < q.Col
+}
+
+// gutterWidth returns the number of columns rendered to the left of the text
+// content: the prompt, plus the line-number column when enabled. Mouse
+// coordinates are offset by this much before being mapped to a column.
+func (m Model) gutterWidth() int {
+	w := m.promptWidth
+	if m.ShowLineNumbers {
+		// lineNumberView renders line numbers as " %*v " where the width is
+		// the digit count of MaxHeight, so the column is digits plus the two
+		// surrounding spaces.
+		w += len(strconv.Itoa(m.MaxHeight)) + 2
+	}
+	return w
+}
+
+// runeIndexForColumn returns the index of the rune occupying the given display
+// column within runes, accounting for double-width runes. A column past the
+// end of the line yields len(runes).
+func runeIndexForColumn(runes []rune, col int) int {
+	if col <= 0 {
+		return 0
+	}
+	w := 0
+	for i, r := range runes {
+		rWidth := uniseg.StringWidth(string(r))
+		// Land on a rune when the target column falls anywhere within it, so
+		// clicking the right half of a wide rune selects that rune.
+		if w+rWidth > col {
+			return i
+		}
+		w += rWidth
+	}
+	return len(runes)
+}
+
+// PositionAt maps coordinates within the textarea's rendered area to a buffer
+// position. Coordinates are relative to the textarea itself: (0, 0) is its
+// top-left cell, including the prompt/line-number gutter. Callers that render
+// the textarea at an offset must subtract that offset first.
+//
+// Coordinates outside the content resolve to the nearest position: above the
+// first line yields the start of the buffer, below the last yields its end,
+// and a column past a line's text yields the end of that line.
+func (m Model) PositionAt(x, y int) Position {
+	if len(m.value) == 0 {
+		return Position{}
+	}
+
+	targetLine := y + m.viewport.YOffset()
+	if targetLine < 0 {
+		return Position{}
+	}
+
+	contentX := x - m.gutterWidth()
+	if contentX < 0 {
+		contentX = 0
+	}
+
+	display := 0
+	for row, line := range m.value {
+		wrapped := m.memoizedWrap(line, m.width)
+		if len(wrapped) == 0 {
+			// An empty logical line still occupies one display row.
+			wrapped = [][]rune{{}}
+		}
+		base := 0
+		for _, wrappedLine := range wrapped {
+			if display == targetLine {
+				col := base + runeIndexForColumn(wrappedLine, contentX)
+				return Position{Row: row, Col: clamp(col, 0, len(line))}
+			}
+			base += len(wrappedLine)
+			display++
+		}
+	}
+
+	// Past the last display row: clamp to the end of the buffer.
+	lastRow := len(m.value) - 1
+	return Position{Row: lastRow, Col: len(m.value[lastRow])}
+}
+
+// BeginSelection starts a selection at the given textarea-relative
+// coordinates, discarding any previous selection, and moves the cursor there.
+// Pair it with [Model.ExtendSelection] as the pointer moves and
+// [Model.EndSelection] when the drag finishes.
+//
+// See [Model.PositionAt] for the coordinate convention.
+func (m *Model) BeginSelection(x, y int) {
+	pos := m.PositionAt(x, y)
+	m.selectFrom(pos, pos)
+	m.selecting = true
+	m.moveCursorTo(pos)
+}
+
+// ExtendSelection extends an in-progress selection to the given
+// textarea-relative coordinates and moves the cursor there. It is a no-op
+// unless [Model.BeginSelection] started a drag.
+func (m *Model) ExtendSelection(x, y int) {
+	if !m.selecting {
+		return
+	}
+	pos := m.PositionAt(x, y)
+	m.selHead = pos
+	m.hasSelection = true
+	m.moveCursorTo(pos)
+}
+
+// EndSelection completes an in-progress drag. The selection itself is
+// retained so it can be read with [Model.SelectedText]; a zero-width
+// selection (a plain click) is discarded.
+func (m *Model) EndSelection() {
+	m.selecting = false
+	if m.selAnchor == m.selHead {
+		m.ClearSelection()
+	}
+}
+
+// SelectAll selects the entire buffer.
+func (m *Model) SelectAll() {
+	if len(m.value) == 0 {
+		return
+	}
+	lastRow := len(m.value) - 1
+	m.selectFrom(
+		Position{Row: 0, Col: 0},
+		Position{Row: lastRow, Col: len(m.value[lastRow])},
+	)
+	m.selecting = false
+}
+
+// ClearSelection removes the current selection, if any.
+func (m *Model) ClearSelection() {
+	m.hasSelection = false
+	m.selecting = false
+	m.selAnchor = Position{}
+	m.selHead = Position{}
+}
+
+// HasSelection reports whether a non-empty selection is active.
+func (m Model) HasSelection() bool {
+	return m.hasSelection && m.selAnchor != m.selHead
+}
+
+// Selection returns the selected range, normalized so start sorts before end,
+// and whether a non-empty selection is active.
+func (m Model) Selection() (start, end Position, ok bool) {
+	if !m.HasSelection() {
+		return Position{}, Position{}, false
+	}
+	start, end = m.selAnchor, m.selHead
+	if end.before(start) {
+		start, end = end, start
+	}
+	return start, end, true
+}
+
+// SelectedText returns the selected text, with logical lines joined by "\n".
+// It returns the empty string when nothing is selected.
+func (m Model) SelectedText() string {
+	start, end, ok := m.Selection()
+	if !ok {
+		return ""
+	}
+
+	if start.Row == end.Row {
+		line := m.value[start.Row]
+		return string(line[clamp(start.Col, 0, len(line)):clamp(end.Col, 0, len(line))])
+	}
+
+	var b strings.Builder
+	for row := start.Row; row <= end.Row; row++ {
+		line := m.value[row]
+		switch row {
+		case start.Row:
+			b.WriteString(string(line[clamp(start.Col, 0, len(line)):]))
+		case end.Row:
+			b.WriteString(string(line[:clamp(end.Col, 0, len(line))]))
+		default:
+			b.WriteString(string(line))
+		}
+		if row < end.Row {
+			b.WriteRune('\n')
+		}
+	}
+	return b.String()
+}
+
+// selectFrom sets the selection anchor and head.
+func (m *Model) selectFrom(anchor, head Position) {
+	m.selAnchor = anchor
+	m.selHead = head
+	m.hasSelection = true
+}
+
+// moveCursorTo places the cursor at the given buffer position, clamped to the
+// buffer's bounds.
+func (m *Model) moveCursorTo(pos Position) {
+	if len(m.value) == 0 {
+		return
+	}
+	row := clamp(pos.Row, 0, len(m.value)-1)
+	m.row = row
+	m.col = clamp(pos.Col, 0, len(m.value[row]))
+}
+
+// selectionSpanFor returns the half-open rune range [from, to) of the given
+// logical row that is selected, restricted to the wrapped segment covering
+// [base, base+length). ok is false when the segment holds no selected runes.
+func (m Model) selectionSpanFor(row, base, length int) (from, to int, ok bool) {
+	start, end, active := m.Selection()
+	if !active || row < start.Row || row > end.Row {
+		return 0, 0, false
+	}
+
+	lineLen := len(m.value[row])
+
+	// Selected range within this logical row.
+	rowFrom, rowTo := 0, lineLen
+	if row == start.Row {
+		rowFrom = clamp(start.Col, 0, lineLen)
+	}
+	if row == end.Row {
+		rowTo = clamp(end.Col, 0, lineLen)
+	}
+
+	// Intersect with the wrapped segment.
+	from = max(rowFrom, base)
+	to = min(rowTo, base+length)
+	if from >= to {
+		return 0, 0, false
+	}
+	return from - base, to - base, true
+}

--- a/textarea/selection_test.go
+++ b/textarea/selection_test.go
@@ -1,0 +1,294 @@
+package textarea
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// newSelectionTextarea returns a focused textarea with a known geometry and
+// no prompt, so tests can reason about columns directly.
+func newSelectionTextarea(t *testing.T, value string) Model {
+	t.Helper()
+	ta := New()
+	ta.Prompt = ""
+	ta.ShowLineNumbers = false
+	ta.SetWidth(20)
+	ta.SetHeight(6)
+	ta.Focus()
+	ta.SetValue(value)
+	return ta
+}
+
+func TestPositionAt(t *testing.T) {
+	t.Parallel()
+
+	ta := newSelectionTextarea(t, "hello\nworld")
+
+	tests := []struct {
+		name string
+		x, y int
+		want Position
+	}{
+		{"origin", 0, 0, Position{Row: 0, Col: 0}},
+		{"mid first line", 3, 0, Position{Row: 0, Col: 3}},
+		{"start second line", 0, 1, Position{Row: 1, Col: 0}},
+		{"mid second line", 2, 1, Position{Row: 1, Col: 2}},
+		{"past end of line clamps to line end", 40, 0, Position{Row: 0, Col: 5}},
+		{"negative y clamps to buffer start", 0, -3, Position{Row: 0, Col: 0}},
+		{"below last line clamps to buffer end", 0, 50, Position{Row: 1, Col: 5}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ta.PositionAt(tt.x, tt.y); got != tt.want {
+				t.Errorf("PositionAt(%d, %d) = %+v, want %+v", tt.x, tt.y, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPositionAtAccountsForGutter asserts that the prompt and line-number
+// columns are subtracted before mapping a click to a text column. Without
+// this, every click lands N columns to the right of where the user aimed.
+func TestPositionAtAccountsForGutter(t *testing.T) {
+	t.Parallel()
+
+	ta := New()
+	ta.Prompt = "> " // 2 columns
+	ta.ShowLineNumbers = false
+	ta.SetWidth(20)
+	ta.SetHeight(3)
+	ta.Focus()
+	ta.SetValue("hello")
+
+	// Clicking the first text cell is x=2 because the prompt occupies 0..1.
+	if got := ta.PositionAt(2, 0); got != (Position{Row: 0, Col: 0}) {
+		t.Errorf("first text cell = %+v, want row 0 col 0", got)
+	}
+	if got := ta.PositionAt(5, 0); got != (Position{Row: 0, Col: 3}) {
+		t.Errorf("fourth text cell = %+v, want row 0 col 3", got)
+	}
+	// A click inside the gutter clamps to the start of the line rather than
+	// producing a negative column.
+	if got := ta.PositionAt(0, 0); got != (Position{Row: 0, Col: 0}) {
+		t.Errorf("click in gutter = %+v, want row 0 col 0", got)
+	}
+}
+
+func TestSelectedTextSingleLine(t *testing.T) {
+	t.Parallel()
+
+	ta := newSelectionTextarea(t, "hello world")
+	ta.BeginSelection(0, 0)
+	ta.ExtendSelection(5, 0)
+	ta.EndSelection()
+
+	if !ta.HasSelection() {
+		t.Fatal("expected an active selection")
+	}
+	if got, want := ta.SelectedText(), "hello"; got != want {
+		t.Errorf("SelectedText() = %q, want %q", got, want)
+	}
+}
+
+func TestSelectedTextAcrossLines(t *testing.T) {
+	t.Parallel()
+
+	ta := newSelectionTextarea(t, "one\ntwo\nthree")
+	// From the "e" of "one" through the "t" of "three".
+	ta.BeginSelection(2, 0)
+	ta.ExtendSelection(1, 2)
+	ta.EndSelection()
+
+	if got, want := ta.SelectedText(), "e\ntwo\nt"; got != want {
+		t.Errorf("SelectedText() = %q, want %q", got, want)
+	}
+}
+
+// TestSelectedTextBackwardDrag asserts a right-to-left / bottom-to-top drag
+// yields the same text as the equivalent forward drag: the range is
+// normalized rather than returned inverted (which would slice out of order).
+func TestSelectedTextBackwardDrag(t *testing.T) {
+	t.Parallel()
+
+	forward := newSelectionTextarea(t, "one\ntwo\nthree")
+	forward.BeginSelection(2, 0)
+	forward.ExtendSelection(1, 2)
+	forward.EndSelection()
+
+	backward := newSelectionTextarea(t, "one\ntwo\nthree")
+	backward.BeginSelection(1, 2)
+	backward.ExtendSelection(2, 0)
+	backward.EndSelection()
+
+	if got, want := backward.SelectedText(), forward.SelectedText(); got != want {
+		t.Errorf("backward drag = %q, want %q (same as forward)", got, want)
+	}
+	if got, want := backward.SelectedText(), "e\ntwo\nt"; got != want {
+		t.Errorf("SelectedText() = %q, want %q", got, want)
+	}
+}
+
+// TestClickWithoutDragMakesNoSelection asserts a plain click (press and
+// release with no movement) does not leave a zero-width selection behind,
+// which would otherwise make HasSelection true with empty text.
+func TestClickWithoutDragMakesNoSelection(t *testing.T) {
+	t.Parallel()
+
+	ta := newSelectionTextarea(t, "hello world")
+	ta.BeginSelection(3, 0)
+	ta.EndSelection()
+
+	if ta.HasSelection() {
+		t.Error("a click without a drag must not leave a selection")
+	}
+	if got := ta.SelectedText(); got != "" {
+		t.Errorf("SelectedText() = %q, want empty", got)
+	}
+}
+
+// TestExtendSelectionRequiresBegin asserts stray motion events (a drag that
+// started outside the textarea) do not spontaneously create a selection.
+func TestExtendSelectionRequiresBegin(t *testing.T) {
+	t.Parallel()
+
+	ta := newSelectionTextarea(t, "hello world")
+	ta.ExtendSelection(5, 0)
+
+	if ta.HasSelection() {
+		t.Error("ExtendSelection without BeginSelection must not select")
+	}
+}
+
+func TestClearSelection(t *testing.T) {
+	t.Parallel()
+
+	ta := newSelectionTextarea(t, "hello world")
+	ta.BeginSelection(0, 0)
+	ta.ExtendSelection(5, 0)
+	ta.EndSelection()
+	if !ta.HasSelection() {
+		t.Fatal("expected a selection to clear")
+	}
+
+	ta.ClearSelection()
+	if ta.HasSelection() {
+		t.Error("HasSelection() = true after ClearSelection()")
+	}
+	if got := ta.SelectedText(); got != "" {
+		t.Errorf("SelectedText() = %q, want empty", got)
+	}
+}
+
+func TestSelectAll(t *testing.T) {
+	t.Parallel()
+
+	ta := newSelectionTextarea(t, "one\ntwo")
+	ta.SelectAll()
+
+	if got, want := ta.SelectedText(), "one\ntwo"; got != want {
+		t.Errorf("SelectedText() = %q, want %q", got, want)
+	}
+}
+
+// TestKeyPressClearsSelection asserts a pointer selection does not survive
+// keyboard input, which would leave a highlight pointing at stale offsets
+// after the buffer or cursor moved.
+func TestKeyPressClearsSelection(t *testing.T) {
+	t.Parallel()
+
+	ta := newSelectionTextarea(t, "hello world")
+	ta.BeginSelection(0, 0)
+	ta.ExtendSelection(5, 0)
+	ta.EndSelection()
+	if !ta.HasSelection() {
+		t.Fatal("expected a selection before typing")
+	}
+
+	ta, _ = ta.Update(keyPress('x'))
+
+	if ta.HasSelection() {
+		t.Error("selection must be cleared by keyboard input")
+	}
+}
+
+// TestSelectionRendersWithSelectionStyle asserts selected runes are painted
+// with the Selection style and unselected ones are not, so the highlight is
+// visually distinct from the terminal's native selection.
+func TestSelectionRendersWithSelectionStyle(t *testing.T) {
+	t.Parallel()
+
+	ta := newSelectionTextarea(t, "hello world")
+
+	plain := ta.View()
+
+	ta.BeginSelection(0, 0)
+	ta.ExtendSelection(5, 0)
+	ta.EndSelection()
+	selected := ta.View()
+
+	if plain == selected {
+		t.Fatal("view must change when a selection is active")
+	}
+
+	// The text itself is unchanged — only styling differs.
+	if got, want := strings.TrimSpace(ansi.Strip(selected)), strings.TrimSpace(ansi.Strip(plain)); got != want {
+		t.Errorf("stripped view changed: got %q, want %q", got, want)
+	}
+}
+
+// TestSelectionSurvivesSoftWrap asserts selection offsets are mapped through
+// the wrapped layout, not the logical line: clicking the second visual row of
+// a wrapped line must select from that row, not from the middle of row one.
+func TestSelectionSurvivesSoftWrap(t *testing.T) {
+	t.Parallel()
+
+	ta := New()
+	ta.Prompt = ""
+	ta.ShowLineNumbers = false
+	ta.SetWidth(10)
+	ta.SetHeight(6)
+	ta.Focus()
+	// Wider than the 10-column width, so it soft wraps.
+	ta.SetValue("aaaaabbbbbccccc")
+
+	// The second visual row starts at rune offset 10.
+	pos := ta.PositionAt(0, 1)
+	if pos.Row != 0 {
+		t.Fatalf("soft wrap must stay on logical row 0, got row %d", pos.Row)
+	}
+	if pos.Col != 10 {
+		t.Errorf("second visual row starts at col 10, got %d", pos.Col)
+	}
+
+	ta.BeginSelection(0, 1)
+	ta.ExtendSelection(5, 1)
+	ta.EndSelection()
+
+	if got, want := ta.SelectedText(), "ccccc"; got != want {
+		t.Errorf("SelectedText() = %q, want %q", got, want)
+	}
+}
+
+// TestSelectionEmptyBuffer asserts the selection API is safe on an empty
+// textarea rather than panicking on an out-of-range row.
+func TestSelectionEmptyBuffer(t *testing.T) {
+	t.Parallel()
+
+	ta := newSelectionTextarea(t, "")
+	ta.BeginSelection(0, 0)
+	ta.ExtendSelection(5, 3)
+	ta.EndSelection()
+	ta.SelectAll()
+
+	if ta.HasSelection() {
+		t.Error("empty buffer must not report a selection")
+	}
+	if got := ta.SelectedText(); got != "" {
+		t.Errorf("SelectedText() = %q, want empty", got)
+	}
+	_ = ta.View() // must not panic
+}

--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -197,6 +197,10 @@ type StyleState struct {
 	EndOfBuffer      lipgloss.Style
 	Placeholder      lipgloss.Style
 	Prompt           lipgloss.Style
+
+	// Selection styles text covered by an active selection. See
+	// [Model.BeginSelection].
+	Selection lipgloss.Style
 }
 
 func (s StyleState) computedCursorLine() lipgloss.Style {
@@ -228,6 +232,10 @@ func (s StyleState) computedPrompt() lipgloss.Style {
 
 func (s StyleState) computedText() lipgloss.Style {
 	return s.Text.Inherit(s.Base).Inline(true)
+}
+
+func (s StyleState) computedSelection() lipgloss.Style {
+	return s.Selection.Inherit(s.Text).Inherit(s.Base).Inline(true)
 }
 
 // line is the input to the text wrapping function. This is stored in a struct
@@ -352,6 +360,19 @@ type Model struct {
 
 	// rune sanitizer for input.
 	rsan runeutil.Sanitizer
+
+	// Selection anchor and head. The anchor is where the selection began;
+	// the head follows the pointer. Either may sort before the other — use
+	// [Model.Selection] for a normalized range.
+	selAnchor Position
+	selHead   Position
+
+	// hasSelection reports whether a selection has been set at all.
+	// [Model.HasSelection] additionally requires it to be non-empty.
+	hasSelection bool
+
+	// selecting reports whether a drag is currently in progress.
+	selecting bool
 }
 
 // New creates a new model with default settings.
@@ -403,6 +424,7 @@ func DefaultStyles(isDark bool) Styles {
 		LineNumber:       lipgloss.NewStyle().Foreground(lightDark(lipgloss.Color("249"), lipgloss.Color("7"))),
 		Placeholder:      lipgloss.NewStyle().Foreground(lipgloss.Color("240")),
 		Prompt:           lipgloss.NewStyle().Foreground(lipgloss.Color("7")),
+		Selection:        lipgloss.NewStyle().Background(lightDark(lipgloss.Color("253"), lipgloss.Color("8"))),
 		Text:             lipgloss.NewStyle(),
 	}
 	s.Blurred = StyleState{
@@ -413,6 +435,7 @@ func DefaultStyles(isDark bool) Styles {
 		LineNumber:       lipgloss.NewStyle().Foreground(lightDark(lipgloss.Color("249"), lipgloss.Color("7"))),
 		Placeholder:      lipgloss.NewStyle().Foreground(lipgloss.Color("240")),
 		Prompt:           lipgloss.NewStyle().Foreground(lipgloss.Color("7")),
+		Selection:        lipgloss.NewStyle().Background(lightDark(lipgloss.Color("253"), lipgloss.Color("8"))),
 		Text:             lipgloss.NewStyle().Foreground(lightDark(lipgloss.Color("245"), lipgloss.Color("7"))),
 	}
 	s.Cursor = CursorStyle{
@@ -1221,8 +1244,13 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.PasteMsg:
+		m.ClearSelection()
 		m.insertRunesFromUserInput([]rune(msg.Content))
 	case tea.KeyPressMsg:
+		// Any keyboard input invalidates a pointer selection: the buffer or
+		// the cursor is about to move out from under it.
+		m.ClearSelection()
+
 		switch {
 		case key.Matches(msg, m.KeyMap.DeleteAfterCursor):
 			m.col = clamp(m.col, 0, len(m.value[m.row]))
@@ -1375,6 +1403,11 @@ func (m *Model) view() string {
 			style = styles.computedText()
 		}
 
+		// wrappedBase is the index, within the logical line, of the first rune
+		// of the current wrapped segment. It is what maps a segment back onto
+		// selection coordinates.
+		wrappedBase := 0
+
 		for wl, wrappedLine := range wrappedLines {
 			prompt := m.promptView(displayLine)
 			s.WriteString(style.Render(prompt))
@@ -1410,7 +1443,14 @@ func (m *Model) view() string {
 				wrappedLine = []rune(strings.TrimSuffix(string(wrappedLine), " "))
 				padding -= m.width - strwidth
 			}
-			if m.row == l && lineInfo.RowOffset == wl {
+			// A selection covering this segment takes precedence over the
+			// inline cursor: during a drag the highlight is the meaningful
+			// affordance, and mixing the two would double-style the same cell.
+			if selFrom, selTo, selected := m.selectionSpanFor(l, wrappedBase, len(wrappedLine)); selected {
+				s.WriteString(style.Render(string(wrappedLine[:selFrom])))
+				s.WriteString(styles.computedSelection().Render(string(wrappedLine[selFrom:selTo])))
+				s.WriteString(style.Render(string(wrappedLine[selTo:])))
+			} else if m.row == l && lineInfo.RowOffset == wl {
 				s.WriteString(style.Render(string(wrappedLine[:lineInfo.ColumnOffset])))
 				if m.col >= len(line) && lineInfo.CharOffset >= m.width {
 					m.virtualCursor.SetChar(" ")
@@ -1423,6 +1463,7 @@ func (m *Model) view() string {
 			} else {
 				s.WriteString(style.Render(string(wrappedLine)))
 			}
+			wrappedBase += len(wrappedLine)
 			s.WriteString(style.Render(strings.Repeat(" ", max(0, padding))))
 			s.WriteRune('\n')
 			newLines++


### PR DESCRIPTION
The textarea has no selection concept and handles no mouse input, so an app embedding it cannot offer "drag to select just the input text" — a drag falls through to the terminal's own selection, which also grabs whatever UI is drawn around the textarea.

Add a pointer selection model:

  - BeginSelection / ExtendSelection / EndSelection drive a drag.
  - SelectAll, ClearSelection, HasSelection, Selection, SelectedText round out the API.
  - PositionAt maps textarea-relative coordinates to a buffer position.
  - StyleState gains a Selection style so the highlight is visually distinct from the terminal's native selection.

Coordinates are textarea-relative rather than absolute, and the drag is driven by explicit calls rather than by consuming tea.MouseMsg in Update. A component does not know where its parent drew it, so it cannot resolve absolute mouse coordinates on its own; making the caller pass local coordinates keeps that translation where the layout is known. This also matches how an app already routes clicks to a positioned child.

Mapping accounts for the prompt and line-number gutter and for soft wrapping, so clicking the second visual row of a wrapped line selects from that row rather than from the middle of the first. Out-of-range coordinates clamp to the nearest position instead of erroring.

A selection takes precedence over the inline cursor when rendering the segment that contains it, so the same cell is not styled twice. Any keyboard input clears the selection, since the buffer or cursor is about to move out from under the stored offsets.

Selecting does not modify the buffer: this covers select-and-copy, which is what an embedding app needs to read via SelectedText. Typing over a selection to replace it is deliberately left out.

Refs charmbracelet/bubbles#1027

- [ ] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
