### PR TITLE
feat: textarea selection

### DIFF
--- a/textarea/selection.go
+++ b/textarea/selection.go
@@ -1,0 +1,248 @@
+package textarea
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// Position is a location in the textarea's logical buffer: Row indexes a
+// logical (unwrapped) line, Col indexes a rune within that line. Col may
+// equal the line length, meaning "just past the last rune".
+type Position struct {
+	Row int
+	Col int
+}
+
+// before reports whether p sorts before q in the buffer.
+func (p Position) before(q Position) bool {
+	if p.Row != q.Row {
+		return p.Row < q.Row
+	}
+	return p.Col < q.Col
+}
+
+// gutterWidth returns the number of columns rendered to the left of the text
+// content: the prompt, plus the line-number column when enabled. Mouse
+// coordinates are offset by this much before being mapped to a column.
+func (m Model) gutterWidth() int {
+	w := m.promptWidth
+	if m.ShowLineNumbers {
+		w += len(strconv.Itoa(m.MaxHeight)) + 2
+	}
+	return w
+}
+
+// runeIndexForColumn returns the index of the rune occupying the given display
+// column within runes, accounting for double-width runes. A column past the
+// end of the line yields len(runes).
+func runeIndexForColumn(runes []rune, col int) int {
+	if col <= 0 {
+		return 0
+	}
+	w := 0
+	for i, r := range runes {
+		rWidth := ansi.StringWidth(string(r))
+		if w+rWidth > col {
+			return i
+		}
+		w += rWidth
+	}
+	return len(runes)
+}
+
+// PositionAt maps coordinates within the textarea's rendered area to a buffer
+// position. Coordinates are relative to the textarea itself: (0, 0) is its
+// top-left cell, including the prompt/line-number gutter. Callers that render
+// the textarea at an offset must subtract that offset first.
+//
+// Coordinates outside the content resolve to the nearest position: above the
+// first line yields the start of the buffer, below the last yields its end,
+// and a column past a line's text yields the end of that line.
+func (m Model) PositionAt(x, y int) Position {
+	if len(m.value) == 0 {
+		return Position{}
+	}
+
+	targetLine := y + m.viewport.YOffset()
+	if targetLine < 0 {
+		return Position{}
+	}
+
+	contentX := x - m.gutterWidth()
+	if contentX < 0 {
+		contentX = 0
+	}
+
+	display := 0
+	for row, line := range m.value {
+		wrapped := m.memoizedWrap(line, m.width)
+		if len(wrapped) == 0 {
+			wrapped = [][]rune{{}}
+		}
+		base := 0
+		for _, wrappedLine := range wrapped {
+			if display == targetLine {
+				col := base + runeIndexForColumn(wrappedLine, contentX)
+				return Position{Row: row, Col: clamp(col, 0, len(line))}
+			}
+			base += len(wrappedLine)
+			display++
+		}
+	}
+
+	lastRow := len(m.value) - 1
+	return Position{Row: lastRow, Col: len(m.value[lastRow])}
+}
+
+// BeginSelection starts a selection at the given textarea-relative
+// coordinates, discarding any previous selection, and moves the cursor there.
+// Pair it with [Model.ExtendSelection] as the pointer moves and
+// [Model.EndSelection] when the drag finishes.
+//
+// See [Model.PositionAt] for the coordinate convention.
+func (m *Model) BeginSelection(x, y int) {
+	pos := m.PositionAt(x, y)
+	m.selectFrom(pos, pos)
+	m.selecting = true
+	m.moveCursorTo(pos)
+}
+
+// ExtendSelection extends an in-progress selection to the given
+// textarea-relative coordinates and moves the cursor there. It is a no-op
+// unless [Model.BeginSelection] started a drag.
+func (m *Model) ExtendSelection(x, y int) {
+	if !m.selecting {
+		return
+	}
+	pos := m.PositionAt(x, y)
+	m.selHead = pos
+	m.hasSelection = true
+	m.moveCursorTo(pos)
+}
+
+// EndSelection completes an in-progress drag. The selection itself is
+// retained so it can be read with [Model.SelectedText]; a zero-width
+// selection (a plain click) is discarded.
+func (m *Model) EndSelection() {
+	m.selecting = false
+	if m.selAnchor == m.selHead {
+		m.ClearSelection()
+	}
+}
+
+// SelectAll selects the entire buffer.
+func (m *Model) SelectAll() {
+	if len(m.value) == 0 {
+		return
+	}
+	lastRow := len(m.value) - 1
+	m.selectFrom(
+		Position{Row: 0, Col: 0},
+		Position{Row: lastRow, Col: len(m.value[lastRow])},
+	)
+	m.selecting = false
+}
+
+// ClearSelection removes the current selection, if any.
+func (m *Model) ClearSelection() {
+	m.hasSelection = false
+	m.selecting = false
+	m.selAnchor = Position{}
+	m.selHead = Position{}
+}
+
+// HasSelection reports whether a non-empty selection is active.
+func (m Model) HasSelection() bool {
+	return m.hasSelection && m.selAnchor != m.selHead
+}
+
+// Selection returns the selected range, normalized so start sorts before end,
+// and whether a non-empty selection is active.
+func (m Model) Selection() (start, end Position, ok bool) {
+	if !m.HasSelection() {
+		return Position{}, Position{}, false
+	}
+	start, end = m.selAnchor, m.selHead
+	if end.before(start) {
+		start, end = end, start
+	}
+	return start, end, true
+}
+
+// SelectedText returns the selected text, with logical lines joined by "\n".
+// It returns the empty string when nothing is selected.
+func (m Model) SelectedText() string {
+	start, end, ok := m.Selection()
+	if !ok {
+		return ""
+	}
+
+	if start.Row == end.Row {
+		line := m.value[start.Row]
+		return string(line[clamp(start.Col, 0, len(line)):clamp(end.Col, 0, len(line))])
+	}
+
+	var b strings.Builder
+	for row := start.Row; row <= end.Row; row++ {
+		line := m.value[row]
+		switch row {
+		case start.Row:
+			b.WriteString(string(line[clamp(start.Col, 0, len(line)):]))
+		case end.Row:
+			b.WriteString(string(line[:clamp(end.Col, 0, len(line))]))
+		default:
+			b.WriteString(string(line))
+		}
+		if row < end.Row {
+			b.WriteRune('\n')
+		}
+	}
+	return b.String()
+}
+
+// selectFrom sets the selection anchor and head.
+func (m *Model) selectFrom(anchor, head Position) {
+	m.selAnchor = anchor
+	m.selHead = head
+	m.hasSelection = true
+}
+
+// moveCursorTo places the cursor at the given buffer position, clamped to the
+// buffer's bounds.
+func (m *Model) moveCursorTo(pos Position) {
+	if len(m.value) == 0 {
+		return
+	}
+	row := clamp(pos.Row, 0, len(m.value)-1)
+	m.row = row
+	m.col = clamp(pos.Col, 0, len(m.value[row]))
+}
+
+// selectionSpanFor returns the half-open rune range [from, to) of the given
+// logical row that is selected, restricted to the wrapped segment covering
+// [base, base+length). ok is false when the segment holds no selected runes.
+func (m Model) selectionSpanFor(row, base, length int) (from, to int, ok bool) {
+	start, end, active := m.Selection()
+	if !active || row < start.Row || row > end.Row {
+		return 0, 0, false
+	}
+
+	lineLen := len(m.value[row])
+
+	rowFrom, rowTo := 0, lineLen
+	if row == start.Row {
+		rowFrom = clamp(start.Col, 0, lineLen)
+	}
+	if row == end.Row {
+		rowTo = clamp(end.Col, 0, lineLen)
+	}
+
+	from = max(rowFrom, base)
+	to = min(rowTo, base+length)
+	if from >= to {
+		return 0, 0, false
+	}
+	return from - base, to - base, true
+}

--- a/textarea/selection_test.go
+++ b/textarea/selection_test.go
@@ -1,0 +1,283 @@
+package textarea
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+func newSelectionTextarea(t *testing.T, value string) Model {
+	t.Helper()
+	ta := New()
+	ta.Prompt = ""
+	ta.ShowLineNumbers = false
+	ta.SetWidth(20)
+	ta.SetHeight(6)
+	ta.Focus()
+	ta.SetValue(value)
+	return ta
+}
+
+func TestPositionAt(t *testing.T) {
+	t.Parallel()
+
+	ta := newSelectionTextarea(t, "hello\nworld")
+
+	tests := []struct {
+		name string
+		x, y int
+		want Position
+	}{
+		{"origin", 0, 0, Position{Row: 0, Col: 0}},
+		{"mid first line", 3, 0, Position{Row: 0, Col: 3}},
+		{"start second line", 0, 1, Position{Row: 1, Col: 0}},
+		{"mid second line", 2, 1, Position{Row: 1, Col: 2}},
+		{"past end of line clamps to line end", 40, 0, Position{Row: 0, Col: 5}},
+		{"negative y clamps to buffer start", 0, -3, Position{Row: 0, Col: 0}},
+		{"below last line clamps to buffer end", 0, 50, Position{Row: 1, Col: 5}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ta.PositionAt(tt.x, tt.y); got != tt.want {
+				t.Errorf("PositionAt(%d, %d) = %+v, want %+v", tt.x, tt.y, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPositionAtAccountsForGutter(t *testing.T) {
+	t.Parallel()
+
+	ta := New()
+	ta.Prompt = "> "
+	ta.ShowLineNumbers = false
+	ta.SetWidth(20)
+	ta.SetHeight(3)
+	ta.Focus()
+	ta.SetValue("hello")
+
+	if got := ta.PositionAt(2, 0); got != (Position{Row: 0, Col: 0}) {
+		t.Errorf("first text cell = %+v, want row 0 col 0", got)
+	}
+	if got := ta.PositionAt(5, 0); got != (Position{Row: 0, Col: 3}) {
+		t.Errorf("fourth text cell = %+v, want row 0 col 3", got)
+	}
+	if got := ta.PositionAt(0, 0); got != (Position{Row: 0, Col: 0}) {
+		t.Errorf("click in gutter = %+v, want row 0 col 0", got)
+	}
+}
+
+func TestSelectedTextSingleLine(t *testing.T) {
+	t.Parallel()
+
+	ta := newSelectionTextarea(t, "hello world")
+	ta.BeginSelection(0, 0)
+	ta.ExtendSelection(5, 0)
+	ta.EndSelection()
+
+	if !ta.HasSelection() {
+		t.Fatal("expected an active selection")
+	}
+	if got, want := ta.SelectedText(), "hello"; got != want {
+		t.Errorf("SelectedText() = %q, want %q", got, want)
+	}
+}
+
+func TestSelectedTextAcrossLines(t *testing.T) {
+	t.Parallel()
+
+	ta := newSelectionTextarea(t, "one\ntwo\nthree")
+	ta.BeginSelection(2, 0)
+	ta.ExtendSelection(1, 2)
+	ta.EndSelection()
+
+	if got, want := ta.SelectedText(), "e\ntwo\nt"; got != want {
+		t.Errorf("SelectedText() = %q, want %q", got, want)
+	}
+}
+
+func TestSelectedTextBackwardDrag(t *testing.T) {
+	t.Parallel()
+
+	forward := newSelectionTextarea(t, "one\ntwo\nthree")
+	forward.BeginSelection(2, 0)
+	forward.ExtendSelection(1, 2)
+	forward.EndSelection()
+
+	backward := newSelectionTextarea(t, "one\ntwo\nthree")
+	backward.BeginSelection(1, 2)
+	backward.ExtendSelection(2, 0)
+	backward.EndSelection()
+
+	if got, want := backward.SelectedText(), forward.SelectedText(); got != want {
+		t.Errorf("backward drag = %q, want %q (same as forward)", got, want)
+	}
+	if got, want := backward.SelectedText(), "e\ntwo\nt"; got != want {
+		t.Errorf("SelectedText() = %q, want %q", got, want)
+	}
+}
+
+func TestClickWithoutDragMakesNoSelection(t *testing.T) {
+	t.Parallel()
+
+	ta := newSelectionTextarea(t, "hello world")
+	ta.BeginSelection(3, 0)
+	ta.EndSelection()
+
+	if ta.HasSelection() {
+		t.Error("a click without a drag must not leave a selection")
+	}
+	if got := ta.SelectedText(); got != "" {
+		t.Errorf("SelectedText() = %q, want empty", got)
+	}
+}
+
+func TestExtendSelectionRequiresBegin(t *testing.T) {
+	t.Parallel()
+
+	ta := newSelectionTextarea(t, "hello world")
+	ta.ExtendSelection(5, 0)
+
+	if ta.HasSelection() {
+		t.Error("ExtendSelection without BeginSelection must not select")
+	}
+}
+
+func TestClearSelectionAPI(t *testing.T) {
+	t.Parallel()
+
+	ta := newSelectionTextarea(t, "hello world")
+	ta.BeginSelection(0, 0)
+	ta.ExtendSelection(5, 0)
+	ta.EndSelection()
+	if !ta.HasSelection() {
+		t.Fatal("expected a selection to clear")
+	}
+
+	ta.ClearSelection()
+	if ta.HasSelection() {
+		t.Error("HasSelection() = true after ClearSelection()")
+	}
+	if got := ta.SelectedText(); got != "" {
+		t.Errorf("SelectedText() = %q, want empty", got)
+	}
+}
+
+func TestSelectAllAPI(t *testing.T) {
+	t.Parallel()
+
+	ta := newSelectionTextarea(t, "one\ntwo")
+	ta.SelectAll()
+
+	if got, want := ta.SelectedText(), "one\ntwo"; got != want {
+		t.Errorf("SelectedText() = %q, want %q", got, want)
+	}
+}
+
+func TestKeyPressClearsSelection(t *testing.T) {
+	t.Parallel()
+
+	ta := newSelectionTextarea(t, "hello world")
+	ta.BeginSelection(0, 0)
+	ta.ExtendSelection(5, 0)
+	ta.EndSelection()
+	if !ta.HasSelection() {
+		t.Fatal("expected a selection before typing")
+	}
+
+	ta, _ = ta.Update(keyPress('x'))
+
+	if ta.HasSelection() {
+		t.Error("selection must be cleared by keyboard input")
+	}
+}
+
+func TestSelectionRendersWithSelectionStyle(t *testing.T) {
+	t.Parallel()
+
+	ta := newSelectionTextarea(t, "hello world")
+
+	plain := ta.View()
+
+	ta.BeginSelection(0, 0)
+	ta.ExtendSelection(5, 0)
+	ta.EndSelection()
+	selected := ta.View()
+
+	if plain == selected {
+		t.Fatal("view must change when a selection is active")
+	}
+
+	if got, want := strings.TrimSpace(ansi.Strip(selected)), strings.TrimSpace(ansi.Strip(plain)); got != want {
+		t.Errorf("stripped view changed: got %q, want %q", got, want)
+	}
+}
+
+func TestSelectionSurvivesSoftWrap(t *testing.T) {
+	t.Parallel()
+
+	ta := New()
+	ta.Prompt = ""
+	ta.ShowLineNumbers = false
+	ta.SetWidth(10)
+	ta.SetHeight(6)
+	ta.Focus()
+	ta.SetValue("aaaaabbbbbccccc")
+
+	pos := ta.PositionAt(0, 1)
+	if pos.Row != 0 {
+		t.Fatalf("soft wrap must stay on logical row 0, got row %d", pos.Row)
+	}
+	if pos.Col != 10 {
+		t.Errorf("second visual row starts at col 10, got %d", pos.Col)
+	}
+
+	ta.BeginSelection(0, 1)
+	ta.ExtendSelection(5, 1)
+	ta.EndSelection()
+
+	if got, want := ta.SelectedText(), "ccccc"; got != want {
+		t.Errorf("SelectedText() = %q, want %q", got, want)
+	}
+}
+
+func TestSelectionEmptyBuffer(t *testing.T) {
+	t.Parallel()
+
+	ta := newSelectionTextarea(t, "")
+	ta.BeginSelection(0, 0)
+	ta.ExtendSelection(5, 3)
+	ta.EndSelection()
+	ta.SelectAll()
+
+	if ta.HasSelection() {
+		t.Error("empty buffer must not report a selection")
+	}
+	if got := ta.SelectedText(); got != "" {
+		t.Errorf("SelectedText() = %q, want empty", got)
+	}
+	_ = ta.View()
+}
+
+func TestSelectionRange(t *testing.T) {
+	t.Parallel()
+
+	ta := newSelectionTextarea(t, "hello world")
+	ta.BeginSelection(0, 0)
+	ta.ExtendSelection(5, 0)
+	ta.EndSelection()
+
+	start, end, ok := ta.Selection()
+	if !ok {
+		t.Fatal("expected a selection")
+	}
+	if start != (Position{Row: 0, Col: 0}) {
+		t.Errorf("start = %+v, want row 0 col 0", start)
+	}
+	if end != (Position{Row: 0, Col: 5}) {
+		t.Errorf("end = %+v, want row 0 col 5", end)
+	}
+}

--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -1813,6 +1813,13 @@ func (m *Model) deleteSelection() {
 	m.ClearSelection()
 }
 
+// DeleteSelection deletes the currently selected text, positions the cursor
+// at the start of the former selection, and clears the selection state. It
+// is a no-op when there is no active selection.
+func (m *Model) DeleteSelection() {
+	m.deleteSelection()
+}
+
 // CopySelection copies the selected text to the clipboard and returns a
 // command that performs the copy. Returns nil if there is no selection.
 func (m *Model) CopySelection() tea.Cmd {

--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -1427,6 +1427,9 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			}
 
 		default:
+			if msg.Text == "" {
+				break
+			}
 			m.deleteSelection()
 			m.insertRunesFromUserInput([]rune(msg.Text))
 		}

--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -118,7 +118,7 @@ func DefaultKeyMap() KeyMap {
 		SelectCharacterForward:  key.NewBinding(key.WithKeys("shift+right"), key.WithHelp("shift+right", "select character forward")),
 		SelectCharacterBackward: key.NewBinding(key.WithKeys("shift+left"), key.WithHelp("shift+left", "select character backward")),
 		SelectWordForward:       key.NewBinding(key.WithKeys("ctrl+shift+right", "alt+shift+right", "alt+shift+f"), key.WithHelp("alt+shift+right", "select word forward")),
-		SelectWordBackward:      key.NewBinding(key.WithKeys("ctrl+shift+left", "alt+shift+right", "alt+shift+b"), key.WithHelp("alt+shift+left", "select word backward")),
+		SelectWordBackward:      key.NewBinding(key.WithKeys("ctrl+shift+left", "alt+shift+left", "alt+shift+b"), key.WithHelp("alt+shift+left", "select word backward")),
 		SelectLineUp:            key.NewBinding(key.WithKeys("shift+up"), key.WithHelp("shift+up", "select line up")),
 		SelectLineDown:          key.NewBinding(key.WithKeys("shift+down"), key.WithHelp("shift+down", "select line down")),
 		SelectAll:               key.NewBinding(key.WithKeys("ctrl+g"), key.WithHelp("ctrl+g", "select all")),

--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -196,34 +196,9 @@ type CursorStyle struct {
 // states. The appropriate styles will be chosen based on the focus state of
 // the textarea.
 type Styles struct {
-	Focused   StyleState
-	Blurred   StyleState
-	Cursor    CursorStyle
-	Selection SelectionStyle
-}
-
-// SelectionStyle is the style for selected text.
-type SelectionStyle struct {
-	// Foreground is the color of selected text. If nil, the terminal's
-	// default foreground color is used.
-	Foreground color.Color
-
-	// Background is the background color of selected text. If nil, the
-	// terminal's default selection color is used (typically the inverse
-	// of the foreground and background colors).
-	Background color.Color
-}
-
-// computedSelection returns the lipgloss style for selected text.
-func (s SelectionStyle) computedSelection() lipgloss.Style {
-	style := lipgloss.NewStyle()
-	if s.Foreground != nil {
-		style = style.Foreground(s.Foreground)
-	}
-	if s.Background != nil {
-		style = style.Background(s.Background)
-	}
-	return style
+	Focused StyleState
+	Blurred StyleState
+	Cursor  CursorStyle
 }
 
 // StyleState that will be applied to the text area.
@@ -242,6 +217,10 @@ type StyleState struct {
 	EndOfBuffer      lipgloss.Style
 	Placeholder      lipgloss.Style
 	Prompt           lipgloss.Style
+
+	// Selection styles text covered by an active selection. See
+	// [Model.BeginSelection].
+	Selection lipgloss.Style
 }
 
 func (s StyleState) computedCursorLine() lipgloss.Style {
@@ -273,6 +252,10 @@ func (s StyleState) computedPrompt() lipgloss.Style {
 
 func (s StyleState) computedText() lipgloss.Style {
 	return s.Text.Inherit(s.Base).Inline(true)
+}
+
+func (s StyleState) computedSelection() lipgloss.Style {
+	return s.Selection.Inherit(s.Text).Inherit(s.Base).Inline(true)
 }
 
 // line is the input to the text wrapping function. This is stored in a struct
@@ -398,17 +381,18 @@ type Model struct {
 	// rune sanitizer for input.
 	rsan runeutil.Sanitizer
 
-	// Selection state.
-	selectionActive bool
-	selectionStart  position
-	selectionEnd    position
-	mouseSelecting  bool
-}
+	// Selection anchor and head. The anchor is where the selection began;
+	// the head follows the pointer. Either may sort before the other — use
+	// [Model.Selection] for a normalized range.
+	selAnchor Position
+	selHead   Position
 
-// position represents a position in the text buffer.
-type position struct {
-	row int
-	col int
+	// hasSelection reports whether a selection has been set at all.
+	// [Model.HasSelection] additionally requires it to be non-empty.
+	hasSelection bool
+
+	// selecting reports whether a drag is currently in progress.
+	selecting bool
 }
 
 // New creates a new model with default settings.
@@ -460,6 +444,7 @@ func DefaultStyles(isDark bool) Styles {
 		LineNumber:       lipgloss.NewStyle().Foreground(lightDark(lipgloss.Color("249"), lipgloss.Color("7"))),
 		Placeholder:      lipgloss.NewStyle().Foreground(lipgloss.Color("240")),
 		Prompt:           lipgloss.NewStyle().Foreground(lipgloss.Color("7")),
+		Selection:        lipgloss.NewStyle().Background(lightDark(lipgloss.Color("253"), lipgloss.Color("8"))),
 		Text:             lipgloss.NewStyle(),
 	}
 	s.Blurred = StyleState{
@@ -470,15 +455,13 @@ func DefaultStyles(isDark bool) Styles {
 		LineNumber:       lipgloss.NewStyle().Foreground(lightDark(lipgloss.Color("249"), lipgloss.Color("7"))),
 		Placeholder:      lipgloss.NewStyle().Foreground(lipgloss.Color("240")),
 		Prompt:           lipgloss.NewStyle().Foreground(lipgloss.Color("7")),
+		Selection:        lipgloss.NewStyle().Background(lightDark(lipgloss.Color("253"), lipgloss.Color("8"))),
 		Text:             lipgloss.NewStyle().Foreground(lightDark(lipgloss.Color("245"), lipgloss.Color("7"))),
 	}
 	s.Cursor = CursorStyle{
 		Color: lipgloss.Color("7"),
 		Shape: tea.CursorBlock,
 		Blink: true,
-	}
-	s.Selection = SelectionStyle{
-		Background: lightDark(lipgloss.Color("254"), lipgloss.Color("238")),
 	}
 	return s
 }
@@ -1286,7 +1269,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	case tea.KeyPressMsg:
 		switch {
 		case key.Matches(msg, m.KeyMap.DeleteAfterCursor):
-			if m.selectionActive {
+			if m.HasSelection() {
 				m.deleteSelection()
 				break
 			}
@@ -1297,7 +1280,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			}
 			m.deleteAfterCursor()
 		case key.Matches(msg, m.KeyMap.DeleteBeforeCursor):
-			if m.selectionActive {
+			if m.HasSelection() {
 				m.deleteSelection()
 				break
 			}
@@ -1308,7 +1291,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			}
 			m.deleteBeforeCursor()
 		case key.Matches(msg, m.KeyMap.DeleteCharacterBackward):
-			if m.selectionActive {
+			if m.HasSelection() {
 				m.deleteSelection()
 				break
 			}
@@ -1324,7 +1307,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 				}
 			}
 		case key.Matches(msg, m.KeyMap.DeleteCharacterForward):
-			if m.selectionActive {
+			if m.HasSelection() {
 				m.deleteSelection()
 				break
 			}
@@ -1336,7 +1319,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 				break
 			}
 		case key.Matches(msg, m.KeyMap.DeleteWordBackward):
-			if m.selectionActive {
+			if m.HasSelection() {
 				m.deleteSelection()
 				break
 			}
@@ -1346,7 +1329,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			}
 			m.deleteWordLeft()
 		case key.Matches(msg, m.KeyMap.DeleteWordForward):
-			if m.selectionActive {
+			if m.HasSelection() {
 				m.deleteSelection()
 				break
 			}
@@ -1412,29 +1395,29 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			m.transposeLeft()
 
 		case key.Matches(msg, m.KeyMap.SelectCharacterForward):
-			m.startSelection()
+			m.startKeyboardSelection()
 			m.characterRight()
-			m.updateSelection()
+			m.updateKeyboardSelection()
 		case key.Matches(msg, m.KeyMap.SelectCharacterBackward):
-			m.startSelection()
+			m.startKeyboardSelection()
 			m.characterLeft(false)
-			m.updateSelection()
+			m.updateKeyboardSelection()
 		case key.Matches(msg, m.KeyMap.SelectWordForward):
-			m.startSelection()
+			m.startKeyboardSelection()
 			m.wordRight()
-			m.updateSelection()
+			m.updateKeyboardSelection()
 		case key.Matches(msg, m.KeyMap.SelectWordBackward):
-			m.startSelection()
+			m.startKeyboardSelection()
 			m.wordLeft()
-			m.updateSelection()
+			m.updateKeyboardSelection()
 		case key.Matches(msg, m.KeyMap.SelectLineUp):
-			m.startSelection()
+			m.startKeyboardSelection()
 			m.CursorUp()
-			m.updateSelection()
+			m.updateKeyboardSelection()
 		case key.Matches(msg, m.KeyMap.SelectLineDown):
-			m.startSelection()
+			m.startKeyboardSelection()
 			m.CursorDown()
-			m.updateSelection()
+			m.updateKeyboardSelection()
 		case key.Matches(msg, m.KeyMap.SelectAll):
 			m.SelectAll()
 		case key.Matches(msg, m.KeyMap.CopySelection):
@@ -1446,25 +1429,6 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			m.deleteSelection()
 			m.insertRunesFromUserInput([]rune(msg.Text))
 		}
-
-	case tea.MouseClickMsg:
-		mouse := msg.Mouse()
-		if mouse.Button == tea.MouseLeft {
-			m.mouseSelecting = true
-			m.ClearSelection()
-			m.positionCursorFromMouse(mouse.X, mouse.Y)
-			m.startSelection()
-		}
-
-	case tea.MouseMotionMsg:
-		if m.mouseSelecting {
-			mouse := msg.Mouse()
-			m.positionCursorFromMouse(mouse.X, mouse.Y)
-			m.updateSelection()
-		}
-
-	case tea.MouseReleaseMsg:
-		m.mouseSelecting = false
 
 	case pasteMsg:
 		m.deleteSelection()
@@ -1529,6 +1493,11 @@ func (m *Model) view() string {
 			style = styles.computedText()
 		}
 
+		// wrappedBase is the index, within the logical line, of the first rune
+		// of the current wrapped segment. It is what maps a segment back onto
+		// selection coordinates.
+		wrappedBase := 0
+
 		for wl, wrappedLine := range wrappedLines {
 			prompt := m.promptView(displayLine)
 			s.WriteString(style.Render(prompt))
@@ -1565,28 +1534,27 @@ func (m *Model) view() string {
 				padding -= m.width - strwidth
 			}
 
-			// Compute the column offset of this wrapped line within the
-			// original line.
-			wrappedColOffset := 0
-			for i := 0; i < wl; i++ {
-				wrappedColOffset += len(wrappedLines[i])
-			}
-
-			if m.row == l && lineInfo.RowOffset == wl {
-				beforeCursor := string(wrappedLine[:lineInfo.ColumnOffset])
-				s.WriteString(m.renderWithSelection(style, beforeCursor, l, wrappedColOffset))
+			// A selection covering this segment takes precedence over the
+			// inline cursor: during a drag the highlight is the meaningful
+			// affordance, and mixing the two would double-style the same cell.
+			if selFrom, selTo, selected := m.selectionSpanFor(l, wrappedBase, len(wrappedLine)); selected {
+				s.WriteString(style.Render(string(wrappedLine[:selFrom])))
+				s.WriteString(styles.computedSelection().Render(string(wrappedLine[selFrom:selTo])))
+				s.WriteString(style.Render(string(wrappedLine[selTo:])))
+			} else if m.row == l && lineInfo.RowOffset == wl {
+				s.WriteString(style.Render(string(wrappedLine[:lineInfo.ColumnOffset])))
 				if m.col >= len(line) && lineInfo.CharOffset >= m.width {
 					m.virtualCursor.SetChar(" ")
 					s.WriteString(m.virtualCursor.View())
 				} else {
 					m.virtualCursor.SetChar(string(wrappedLine[lineInfo.ColumnOffset]))
 					s.WriteString(style.Render(m.virtualCursor.View()))
-					rest := string(wrappedLine[lineInfo.ColumnOffset+1:])
-					s.WriteString(m.renderWithSelection(style, rest, l, wrappedColOffset+lineInfo.ColumnOffset+1))
+					s.WriteString(style.Render(string(wrappedLine[lineInfo.ColumnOffset+1:])))
 				}
 			} else {
-				s.WriteString(m.renderWithSelection(style, string(wrappedLine), l, wrappedColOffset))
+				s.WriteString(style.Render(string(wrappedLine)))
 			}
+			wrappedBase += len(wrappedLine)
 			s.WriteString(style.Render(strings.Repeat(" ", max(0, padding))))
 			s.WriteRune('\n')
 			newLines++
@@ -1608,53 +1576,6 @@ func (m *Model) view() string {
 	}
 
 	return s.String()
-}
-
-// renderWithSelection renders text with the selection style applied to
-// selected portions. The colOffset is the column offset of the text within
-// the original line (accounting for soft wrapping).
-func (m Model) renderWithSelection(style lipgloss.Style, text string, lineIdx, colOffset int) string {
-	if !m.selectionActive || len(text) == 0 {
-		return style.Render(text)
-	}
-
-	start, end := m.selectionRange()
-	selStyle := m.styles.Selection.computedSelection()
-
-	// No selection on this line.
-	if lineIdx < start.row || lineIdx > end.row {
-		return style.Render(text)
-	}
-
-	runes := []rune(text)
-	var result strings.Builder
-
-	for i, r := range runes {
-		col := colOffset + i
-		inSelection := false
-
-		if lineIdx == start.row && lineIdx == end.row {
-			// Single line selection.
-			inSelection = col >= start.col && col < end.col
-		} else if lineIdx == start.row {
-			// Selection starts on this line.
-			inSelection = col >= start.col
-		} else if lineIdx == end.row {
-			// Selection ends on this line.
-			inSelection = col < end.col
-		} else {
-			// Line is fully within selection.
-			inSelection = true
-		}
-
-		if inSelection {
-			result.WriteString(selStyle.Render(string(r)))
-		} else {
-			result.WriteString(style.Render(string(r)))
-		}
-	}
-
-	return result.String()
 }
 
 // View renders the text area in its current state.
@@ -1848,119 +1769,53 @@ func (m Model) Cursor() *tea.Cursor {
 	return c
 }
 
-// SelectionActive returns whether there is an active text selection.
-func (m Model) SelectionActive() bool {
-	return m.selectionActive
-}
-
-// Selection returns the currently selected text. Returns an empty string if
-// there is no active selection.
-func (m Model) Selection() string {
-	if !m.selectionActive {
-		return ""
-	}
-
-	start, end := m.selectionRange()
-	if start.row == end.row {
-		if start.col >= len(m.value[start.row]) || end.col > len(m.value[start.row]) || start.col > end.col {
-			return ""
-		}
-		return string(m.value[start.row][start.col:end.col])
-	}
-
-	var sb strings.Builder
-	for r := start.row; r <= end.row && r < len(m.value); r++ {
-		line := m.value[r]
-		switch r {
-		case start.row:
-			if start.col < len(line) {
-				sb.WriteString(string(line[start.col:]))
-			}
-		case end.row:
-			if end.col <= len(line) {
-				sb.WriteString(string(line[:end.col]))
-			}
-		default:
-			sb.WriteString(string(line))
-		}
-		if r < end.row {
-			sb.WriteRune('\n')
-		}
-	}
-	return sb.String()
-}
-
-// selectionRange returns the start and end positions of the selection in
-// order (start before end).
-func (m Model) selectionRange() (start, end position) {
-	if m.selectionStart.row < m.selectionEnd.row ||
-		(m.selectionStart.row == m.selectionEnd.row && m.selectionStart.col <= m.selectionEnd.col) {
-		return m.selectionStart, m.selectionEnd
-	}
-	return m.selectionEnd, m.selectionStart
-}
-
-// ClearSelection clears the current selection.
-func (m *Model) ClearSelection() {
-	m.selectionActive = false
-	m.selectionStart = position{}
-	m.selectionEnd = position{}
-}
-
 // deleteSelection deletes the currently selected text, positions the cursor
 // at the start of the former selection, and clears the selection state. It
 // is a no-op when there is no active selection.
 func (m *Model) deleteSelection() {
-	if !m.selectionActive {
+	if !m.HasSelection() {
 		return
 	}
 
-	start, end := m.selectionRange()
+	start, end, _ := m.Selection()
 
-	if start.row == end.row {
-		line := m.value[start.row]
-		endCol := min(end.col, len(line))
-		startCol := min(start.col, endCol)
-		m.value[start.row] = append(line[:startCol], line[endCol:]...)
-		m.row = start.row
+	if start.Row == end.Row {
+		line := m.value[start.Row]
+		endCol := min(end.Col, len(line))
+		startCol := min(start.Col, endCol)
+		m.value[start.Row] = append(line[:startCol], line[endCol:]...)
+		m.row = start.Row
 		m.SetCursorColumn(startCol)
 	} else {
-		headLine := m.value[start.row]
-		tailLine := m.value[end.row]
-		endCol := min(end.col, len(tailLine))
-		startCol := min(start.col, len(headLine))
+		headLine := m.value[start.Row]
+		tailLine := m.value[end.Row]
+		endCol := min(end.Col, len(tailLine))
+		startCol := min(start.Col, len(headLine))
 
 		merged := make([]rune, 0, startCol+len(tailLine)-endCol)
 		merged = append(merged, headLine[:startCol]...)
 		merged = append(merged, tailLine[endCol:]...)
 
-		newValue := make([][]rune, 0, len(m.value)-(end.row-start.row))
-		newValue = append(newValue, m.value[:start.row]...)
+		newValue := make([][]rune, 0, len(m.value)-(end.Row-start.Row))
+		newValue = append(newValue, m.value[:start.Row]...)
 		newValue = append(newValue, merged)
-		newValue = append(newValue, m.value[end.row+1:]...)
+		newValue = append(newValue, m.value[end.Row+1:]...)
 		m.value = newValue
 
-		m.row = start.row
+		m.row = start.Row
 		m.SetCursorColumn(startCol)
 	}
 
 	m.ClearSelection()
 }
 
-// SelectAll selects all text in the textarea.
-func (m *Model) SelectAll() {
-	m.selectionActive = true
-	m.selectionStart = position{row: 0, col: 0}
-	m.selectionEnd = position{row: len(m.value) - 1, col: len(m.value[len(m.value)-1])}
-}
-
 // CopySelection copies the selected text to the clipboard and returns a
 // command that performs the copy. Returns nil if there is no selection.
 func (m *Model) CopySelection() tea.Cmd {
-	if !m.selectionActive {
+	if !m.HasSelection() {
 		return nil
 	}
-	text := m.Selection()
+	text := m.SelectedText()
 	return func() tea.Msg {
 		if err := clipboard.WriteAll(text); err != nil {
 			return copyErrMsg{err}
@@ -1969,94 +1824,20 @@ func (m *Model) CopySelection() tea.Cmd {
 	}
 }
 
-// startSelection begins a new selection at the current cursor position.
-func (m *Model) startSelection() {
-	if !m.selectionActive {
-		m.selectionActive = true
-		m.selectionStart = position{row: m.row, col: m.col}
+// startKeyboardSelection begins a keyboard-driven selection at the current
+// cursor position if one is not already active.
+func (m *Model) startKeyboardSelection() {
+	if !m.hasSelection {
+		m.selAnchor = Position{Row: m.row, Col: m.col}
 	}
-	m.selectionEnd = position{row: m.row, col: m.col}
+	m.hasSelection = true
+	m.selHead = Position{Row: m.row, Col: m.col}
 }
 
-// extendSelection extends the selection to the current cursor position.
-func (m *Model) extendSelection() {
-	if !m.selectionActive {
-		m.selectionStart = position{row: m.row, col: m.col}
-	}
-	m.selectionActive = true
-	m.selectionEnd = position{row: m.row, col: m.col}
-}
-
-// updateSelection updates the selection end to the current cursor position.
-// If no selection is active, starts a new one.
-func (m *Model) updateSelection() {
-	m.extendSelection()
-}
-
-// positionCursorFromMouse positions the cursor based on mouse coordinates.
-// The coordinates are relative to the textarea's view.
-func (m *Model) positionCursorFromMouse(x, y int) {
-	styles := m.activeStyle()
-	baseStyle := styles.Base
-
-	// Adjust for base style margins and borders.
-	x -= baseStyle.GetMarginLeft() + baseStyle.GetPaddingLeft() + baseStyle.GetBorderLeftSize()
-	y -= baseStyle.GetMarginTop() + baseStyle.GetPaddingTop() + baseStyle.GetBorderTopSize()
-
-	// Adjust for viewport scroll offset.
-	y += m.viewport.YOffset()
-
-	// Find the line at the y position.
-	displayLine := 0
-	targetRow := -1
-	targetCol := 0
-
-	for l, line := range m.value {
-		wrappedLines := m.memoizedWrap(line, m.width)
-		for wl := range wrappedLines {
-			if displayLine == y {
-				targetRow = l
-				targetCol = m.columnFromMouseX(x, displayLine, wrappedLines, wl, len(line))
-				break
-			}
-			displayLine++
-		}
-		if targetRow >= 0 {
-			break
-		}
-	}
-
-	if targetRow >= 0 && targetRow < len(m.value) {
-		m.row = targetRow
-		m.SetCursorColumn(targetCol)
-		m.repositionView()
-	}
-}
-
-func (m *Model) columnFromMouseX(x, displayLine int, wrappedLines [][]rune, wl, lineLen int) int {
-	promptWidth := lipgloss.Width(m.promptView(displayLine))
-	lineNumWidth := 0
-	if m.ShowLineNumbers {
-		lineNumWidth = lipgloss.Width(m.lineNumberView(0, false))
-	}
-	col := x - promptWidth - lineNumWidth
-	if col < 0 {
-		col = 0
-	}
-	if wl >= len(wrappedLines) {
-		return col
-	}
-	wrappedLine := wrappedLines[wl]
-	if col > len(wrappedLine) {
-		col = len(wrappedLine)
-	}
-	for i := range wl {
-		col += len(wrappedLines[i])
-	}
-	if col > lineLen {
-		col = lineLen
-	}
-	return col
+// updateKeyboardSelection updates the selection head to the current cursor
+// position after a keyboard movement.
+func (m *Model) updateKeyboardSelection() {
+	m.selHead = Position{Row: m.row, Col: m.col}
 }
 
 func (m Model) memoizedWrap(runes []rune, width int) [][]rune {

--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -117,8 +117,8 @@ func DefaultKeyMap() KeyMap {
 
 		SelectCharacterForward:  key.NewBinding(key.WithKeys("shift+right"), key.WithHelp("shift+right", "select character forward")),
 		SelectCharacterBackward: key.NewBinding(key.WithKeys("shift+left"), key.WithHelp("shift+left", "select character backward")),
-		SelectWordForward:       key.NewBinding(key.WithKeys("ctrl+shift+right", "alt+shift+f"), key.WithHelp("alt+shift+right", "select word forward")),
-		SelectWordBackward:      key.NewBinding(key.WithKeys("ctrl+shift+left", "alt+shift+b"), key.WithHelp("alt+shift+left", "select word backward")),
+		SelectWordForward:       key.NewBinding(key.WithKeys("ctrl+shift+right", "alt+shift+right", "alt+shift+f"), key.WithHelp("alt+shift+right", "select word forward")),
+		SelectWordBackward:      key.NewBinding(key.WithKeys("ctrl+shift+left", "alt+shift+right", "alt+shift+b"), key.WithHelp("alt+shift+left", "select word backward")),
 		SelectLineUp:            key.NewBinding(key.WithKeys("shift+up"), key.WithHelp("shift+up", "select line up")),
 		SelectLineDown:          key.NewBinding(key.WithKeys("shift+down"), key.WithHelp("shift+down", "select line down")),
 		SelectAll:               key.NewBinding(key.WithKeys("ctrl+g"), key.WithHelp("ctrl+g", "select all")),
@@ -2016,33 +2016,7 @@ func (m *Model) positionCursorFromMouse(x, y int) {
 		for wl := range wrappedLines {
 			if displayLine == y {
 				targetRow = l
-				// Calculate column from x position, accounting for prompt
-				// and line numbers.
-				promptWidth := lipgloss.Width(m.promptView(displayLine))
-				lineNumWidth := 0
-				if m.ShowLineNumbers {
-					lineNumWidth = lipgloss.Width(m.lineNumberView(0, false))
-				}
-				col := x - promptWidth - lineNumWidth
-				if col < 0 {
-					col = 0
-				}
-				// Find the actual column in the original line, accounting
-				// for soft wrapping.
-				if wl < len(wrappedLines) {
-					wrappedLine := wrappedLines[wl]
-					if col > len(wrappedLine) {
-						col = len(wrappedLine)
-					}
-					// Sum up columns from previous wrapped lines.
-					for i := 0; i < wl; i++ {
-						col += len(wrappedLines[i])
-					}
-					if col > len(line) {
-						col = len(line)
-					}
-					targetCol = col
-				}
+				targetCol = m.columnFromMouseX(x, displayLine, wrappedLines, wl, len(line))
 				break
 			}
 			displayLine++
@@ -2057,6 +2031,32 @@ func (m *Model) positionCursorFromMouse(x, y int) {
 		m.SetCursorColumn(targetCol)
 		m.repositionView()
 	}
+}
+
+func (m *Model) columnFromMouseX(x, displayLine int, wrappedLines [][]rune, wl, lineLen int) int {
+	promptWidth := lipgloss.Width(m.promptView(displayLine))
+	lineNumWidth := 0
+	if m.ShowLineNumbers {
+		lineNumWidth = lipgloss.Width(m.lineNumberView(0, false))
+	}
+	col := x - promptWidth - lineNumWidth
+	if col < 0 {
+		col = 0
+	}
+	if wl >= len(wrappedLines) {
+		return col
+	}
+	wrappedLine := wrappedLines[wl]
+	if col > len(wrappedLine) {
+		col = len(wrappedLine)
+	}
+	for i := range wl {
+		col += len(wrappedLines[i])
+	}
+	if col > lineLen {
+		col = lineLen
+	}
+	return col
 }
 
 func (m Model) memoizedWrap(runes []rune, width int) [][]rune {

--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -816,6 +816,7 @@ func (m *Model) Reset() {
 	m.viewport.GotoTop()
 	m.SetCursorColumn(0)
 	m.recalculateHeight()
+	m.ClearSelection()
 }
 
 // Word returns the word at the cursor position.

--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -41,6 +41,8 @@ const (
 type (
 	pasteMsg    string
 	pasteErrMsg struct{ error }
+	copyMsg     string
+	copyErrMsg  struct{ error }
 )
 
 // KeyMap is the key bindings for different actions within the textarea.
@@ -71,6 +73,15 @@ type KeyMap struct {
 	CapitalizeWordForward key.Binding
 
 	TransposeCharacterBackward key.Binding
+
+	SelectCharacterForward  key.Binding
+	SelectCharacterBackward key.Binding
+	SelectWordForward       key.Binding
+	SelectWordBackward      key.Binding
+	SelectLineUp            key.Binding
+	SelectLineDown          key.Binding
+	SelectAll               key.Binding
+	CopySelection           key.Binding
 }
 
 // DefaultKeyMap returns the default set of key bindings for navigating and acting
@@ -103,6 +114,15 @@ func DefaultKeyMap() KeyMap {
 		UppercaseWordForward:  key.NewBinding(key.WithKeys("alt+u"), key.WithHelp("alt+u", "uppercase word forward")),
 
 		TransposeCharacterBackward: key.NewBinding(key.WithKeys("ctrl+t"), key.WithHelp("ctrl+t", "transpose character backward")),
+
+		SelectCharacterForward:  key.NewBinding(key.WithKeys("shift+right"), key.WithHelp("shift+right", "select character forward")),
+		SelectCharacterBackward: key.NewBinding(key.WithKeys("shift+left"), key.WithHelp("shift+left", "select character backward")),
+		SelectWordForward:       key.NewBinding(key.WithKeys("ctrl+shift+right", "alt+shift+f"), key.WithHelp("alt+shift+right", "select word forward")),
+		SelectWordBackward:      key.NewBinding(key.WithKeys("ctrl+shift+left", "alt+shift+b"), key.WithHelp("alt+shift+left", "select word backward")),
+		SelectLineUp:            key.NewBinding(key.WithKeys("shift+up"), key.WithHelp("shift+up", "select line up")),
+		SelectLineDown:          key.NewBinding(key.WithKeys("shift+down"), key.WithHelp("shift+down", "select line down")),
+		SelectAll:               key.NewBinding(key.WithKeys("ctrl+g"), key.WithHelp("ctrl+g", "select all")),
+		CopySelection:           key.NewBinding(key.WithKeys("ctrl+shift+c"), key.WithHelp("ctrl+shift+c", "copy selection")),
 	}
 }
 
@@ -176,9 +196,34 @@ type CursorStyle struct {
 // states. The appropriate styles will be chosen based on the focus state of
 // the textarea.
 type Styles struct {
-	Focused StyleState
-	Blurred StyleState
-	Cursor  CursorStyle
+	Focused   StyleState
+	Blurred   StyleState
+	Cursor    CursorStyle
+	Selection SelectionStyle
+}
+
+// SelectionStyle is the style for selected text.
+type SelectionStyle struct {
+	// Foreground is the color of selected text. If nil, the terminal's
+	// default foreground color is used.
+	Foreground color.Color
+
+	// Background is the background color of selected text. If nil, the
+	// terminal's default selection color is used (typically the inverse
+	// of the foreground and background colors).
+	Background color.Color
+}
+
+// computedSelection returns the lipgloss style for selected text.
+func (s SelectionStyle) computedSelection() lipgloss.Style {
+	style := lipgloss.NewStyle()
+	if s.Foreground != nil {
+		style = style.Foreground(s.Foreground)
+	}
+	if s.Background != nil {
+		style = style.Background(s.Background)
+	}
+	return style
 }
 
 // StyleState that will be applied to the text area.
@@ -352,6 +397,18 @@ type Model struct {
 
 	// rune sanitizer for input.
 	rsan runeutil.Sanitizer
+
+	// Selection state.
+	selectionActive bool
+	selectionStart  position
+	selectionEnd    position
+	mouseSelecting  bool
+}
+
+// position represents a position in the text buffer.
+type position struct {
+	row int
+	col int
 }
 
 // New creates a new model with default settings.
@@ -419,6 +476,9 @@ func DefaultStyles(isDark bool) Styles {
 		Color: lipgloss.Color("7"),
 		Shape: tea.CursorBlock,
 		Blink: true,
+	}
+	s.Selection = SelectionStyle{
+		Background: lightDark(lipgloss.Color("254"), lipgloss.Color("238")),
 	}
 	return s
 }
@@ -1221,10 +1281,15 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.PasteMsg:
+		m.deleteSelection()
 		m.insertRunesFromUserInput([]rune(msg.Content))
 	case tea.KeyPressMsg:
 		switch {
 		case key.Matches(msg, m.KeyMap.DeleteAfterCursor):
+			if m.selectionActive {
+				m.deleteSelection()
+				break
+			}
 			m.col = clamp(m.col, 0, len(m.value[m.row]))
 			if m.col >= len(m.value[m.row]) {
 				m.mergeLineBelow(m.row)
@@ -1232,6 +1297,10 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			}
 			m.deleteAfterCursor()
 		case key.Matches(msg, m.KeyMap.DeleteBeforeCursor):
+			if m.selectionActive {
+				m.deleteSelection()
+				break
+			}
 			m.col = clamp(m.col, 0, len(m.value[m.row]))
 			if m.col <= 0 {
 				m.mergeLineAbove(m.row)
@@ -1239,6 +1308,10 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			}
 			m.deleteBeforeCursor()
 		case key.Matches(msg, m.KeyMap.DeleteCharacterBackward):
+			if m.selectionActive {
+				m.deleteSelection()
+				break
+			}
 			m.col = clamp(m.col, 0, len(m.value[m.row]))
 			if m.col <= 0 {
 				m.mergeLineAbove(m.row)
@@ -1251,6 +1324,10 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 				}
 			}
 		case key.Matches(msg, m.KeyMap.DeleteCharacterForward):
+			if m.selectionActive {
+				m.deleteSelection()
+				break
+			}
 			if len(m.value[m.row]) > 0 && m.col < len(m.value[m.row]) {
 				m.value[m.row] = slices.Delete(m.value[m.row], m.col, m.col+1)
 			}
@@ -1259,12 +1336,20 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 				break
 			}
 		case key.Matches(msg, m.KeyMap.DeleteWordBackward):
+			if m.selectionActive {
+				m.deleteSelection()
+				break
+			}
 			if m.col <= 0 {
 				m.mergeLineAbove(m.row)
 				break
 			}
 			m.deleteWordLeft()
 		case key.Matches(msg, m.KeyMap.DeleteWordForward):
+			if m.selectionActive {
+				m.deleteSelection()
+				break
+			}
 			m.col = clamp(m.col, 0, len(m.value[m.row]))
 			if m.col >= len(m.value[m.row]) {
 				m.mergeLineBelow(m.row)
@@ -1272,36 +1357,50 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			}
 			m.deleteWordRight()
 		case key.Matches(msg, m.KeyMap.InsertNewline):
+			m.deleteSelection()
 			if m.atContentLimit() {
 				return m, nil
 			}
 			m.col = clamp(m.col, 0, len(m.value[m.row]))
 			m.splitLine(m.row, m.col)
 		case key.Matches(msg, m.KeyMap.LineEnd):
+			m.ClearSelection()
 			m.CursorEnd()
 		case key.Matches(msg, m.KeyMap.LineStart):
+			m.ClearSelection()
 			m.CursorStart()
 		case key.Matches(msg, m.KeyMap.CharacterForward):
+			m.ClearSelection()
 			m.characterRight()
 		case key.Matches(msg, m.KeyMap.LineNext):
+			m.ClearSelection()
 			m.CursorDown()
 		case key.Matches(msg, m.KeyMap.WordForward):
+			m.ClearSelection()
 			m.wordRight()
 		case key.Matches(msg, m.KeyMap.Paste):
+			m.deleteSelection()
 			return m, Paste
 		case key.Matches(msg, m.KeyMap.CharacterBackward):
+			m.ClearSelection()
 			m.characterLeft(false /* insideLine */)
 		case key.Matches(msg, m.KeyMap.LinePrevious):
+			m.ClearSelection()
 			m.CursorUp()
 		case key.Matches(msg, m.KeyMap.WordBackward):
+			m.ClearSelection()
 			m.wordLeft()
 		case key.Matches(msg, m.KeyMap.InputBegin):
+			m.ClearSelection()
 			m.MoveToBegin()
 		case key.Matches(msg, m.KeyMap.InputEnd):
+			m.ClearSelection()
 			m.MoveToEnd()
 		case key.Matches(msg, m.KeyMap.PageUp):
+			m.ClearSelection()
 			m.PageUp()
 		case key.Matches(msg, m.KeyMap.PageDown):
+			m.ClearSelection()
 			m.PageDown()
 		case key.Matches(msg, m.KeyMap.LowercaseWordForward):
 			m.lowercaseRight()
@@ -1312,14 +1411,69 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		case key.Matches(msg, m.KeyMap.TransposeCharacterBackward):
 			m.transposeLeft()
 
+		case key.Matches(msg, m.KeyMap.SelectCharacterForward):
+			m.startSelection()
+			m.characterRight()
+			m.updateSelection()
+		case key.Matches(msg, m.KeyMap.SelectCharacterBackward):
+			m.startSelection()
+			m.characterLeft(false)
+			m.updateSelection()
+		case key.Matches(msg, m.KeyMap.SelectWordForward):
+			m.startSelection()
+			m.wordRight()
+			m.updateSelection()
+		case key.Matches(msg, m.KeyMap.SelectWordBackward):
+			m.startSelection()
+			m.wordLeft()
+			m.updateSelection()
+		case key.Matches(msg, m.KeyMap.SelectLineUp):
+			m.startSelection()
+			m.CursorUp()
+			m.updateSelection()
+		case key.Matches(msg, m.KeyMap.SelectLineDown):
+			m.startSelection()
+			m.CursorDown()
+			m.updateSelection()
+		case key.Matches(msg, m.KeyMap.SelectAll):
+			m.SelectAll()
+		case key.Matches(msg, m.KeyMap.CopySelection):
+			if cmd := m.CopySelection(); cmd != nil {
+				cmds = append(cmds, cmd)
+			}
+
 		default:
+			m.deleteSelection()
 			m.insertRunesFromUserInput([]rune(msg.Text))
 		}
 
+	case tea.MouseClickMsg:
+		mouse := msg.Mouse()
+		if mouse.Button == tea.MouseLeft {
+			m.mouseSelecting = true
+			m.ClearSelection()
+			m.positionCursorFromMouse(mouse.X, mouse.Y)
+			m.startSelection()
+		}
+
+	case tea.MouseMotionMsg:
+		if m.mouseSelecting {
+			mouse := msg.Mouse()
+			m.positionCursorFromMouse(mouse.X, mouse.Y)
+			m.updateSelection()
+		}
+
+	case tea.MouseReleaseMsg:
+		m.mouseSelecting = false
+
 	case pasteMsg:
+		m.deleteSelection()
 		m.insertRunesFromUserInput([]rune(msg))
 
 	case pasteErrMsg:
+		m.Err = msg
+
+	case copyErrMsg:
 		m.Err = msg
 	}
 
@@ -1410,18 +1564,28 @@ func (m *Model) view() string {
 				wrappedLine = []rune(strings.TrimSuffix(string(wrappedLine), " "))
 				padding -= m.width - strwidth
 			}
+
+			// Compute the column offset of this wrapped line within the
+			// original line.
+			wrappedColOffset := 0
+			for i := 0; i < wl; i++ {
+				wrappedColOffset += len(wrappedLines[i])
+			}
+
 			if m.row == l && lineInfo.RowOffset == wl {
-				s.WriteString(style.Render(string(wrappedLine[:lineInfo.ColumnOffset])))
+				beforeCursor := string(wrappedLine[:lineInfo.ColumnOffset])
+				s.WriteString(m.renderWithSelection(style, beforeCursor, l, wrappedColOffset))
 				if m.col >= len(line) && lineInfo.CharOffset >= m.width {
 					m.virtualCursor.SetChar(" ")
 					s.WriteString(m.virtualCursor.View())
 				} else {
 					m.virtualCursor.SetChar(string(wrappedLine[lineInfo.ColumnOffset]))
 					s.WriteString(style.Render(m.virtualCursor.View()))
-					s.WriteString(style.Render(string(wrappedLine[lineInfo.ColumnOffset+1:])))
+					rest := string(wrappedLine[lineInfo.ColumnOffset+1:])
+					s.WriteString(m.renderWithSelection(style, rest, l, wrappedColOffset+lineInfo.ColumnOffset+1))
 				}
 			} else {
-				s.WriteString(style.Render(string(wrappedLine)))
+				s.WriteString(m.renderWithSelection(style, string(wrappedLine), l, wrappedColOffset))
 			}
 			s.WriteString(style.Render(strings.Repeat(" ", max(0, padding))))
 			s.WriteRune('\n')
@@ -1444,6 +1608,53 @@ func (m *Model) view() string {
 	}
 
 	return s.String()
+}
+
+// renderWithSelection renders text with the selection style applied to
+// selected portions. The colOffset is the column offset of the text within
+// the original line (accounting for soft wrapping).
+func (m Model) renderWithSelection(style lipgloss.Style, text string, lineIdx, colOffset int) string {
+	if !m.selectionActive || len(text) == 0 {
+		return style.Render(text)
+	}
+
+	start, end := m.selectionRange()
+	selStyle := m.styles.Selection.computedSelection()
+
+	// No selection on this line.
+	if lineIdx < start.row || lineIdx > end.row {
+		return style.Render(text)
+	}
+
+	runes := []rune(text)
+	var result strings.Builder
+
+	for i, r := range runes {
+		col := colOffset + i
+		inSelection := false
+
+		if lineIdx == start.row && lineIdx == end.row {
+			// Single line selection.
+			inSelection = col >= start.col && col < end.col
+		} else if lineIdx == start.row {
+			// Selection starts on this line.
+			inSelection = col >= start.col
+		} else if lineIdx == end.row {
+			// Selection ends on this line.
+			inSelection = col < end.col
+		} else {
+			// Line is fully within selection.
+			inSelection = true
+		}
+
+		if inSelection {
+			result.WriteString(selStyle.Render(string(r)))
+		} else {
+			result.WriteString(style.Render(string(r)))
+		}
+	}
+
+	return result.String()
 }
 
 // View renders the text area in its current state.
@@ -1635,6 +1846,217 @@ func (m Model) Cursor() *tea.Cursor {
 	c.Color = m.styles.Cursor.Color
 	c.Shape = m.styles.Cursor.Shape
 	return c
+}
+
+// SelectionActive returns whether there is an active text selection.
+func (m Model) SelectionActive() bool {
+	return m.selectionActive
+}
+
+// Selection returns the currently selected text. Returns an empty string if
+// there is no active selection.
+func (m Model) Selection() string {
+	if !m.selectionActive {
+		return ""
+	}
+
+	start, end := m.selectionRange()
+	if start.row == end.row {
+		if start.col >= len(m.value[start.row]) || end.col > len(m.value[start.row]) || start.col > end.col {
+			return ""
+		}
+		return string(m.value[start.row][start.col:end.col])
+	}
+
+	var sb strings.Builder
+	for r := start.row; r <= end.row && r < len(m.value); r++ {
+		line := m.value[r]
+		switch r {
+		case start.row:
+			if start.col < len(line) {
+				sb.WriteString(string(line[start.col:]))
+			}
+		case end.row:
+			if end.col <= len(line) {
+				sb.WriteString(string(line[:end.col]))
+			}
+		default:
+			sb.WriteString(string(line))
+		}
+		if r < end.row {
+			sb.WriteRune('\n')
+		}
+	}
+	return sb.String()
+}
+
+// selectionRange returns the start and end positions of the selection in
+// order (start before end).
+func (m Model) selectionRange() (start, end position) {
+	if m.selectionStart.row < m.selectionEnd.row ||
+		(m.selectionStart.row == m.selectionEnd.row && m.selectionStart.col <= m.selectionEnd.col) {
+		return m.selectionStart, m.selectionEnd
+	}
+	return m.selectionEnd, m.selectionStart
+}
+
+// ClearSelection clears the current selection.
+func (m *Model) ClearSelection() {
+	m.selectionActive = false
+	m.selectionStart = position{}
+	m.selectionEnd = position{}
+}
+
+// deleteSelection deletes the currently selected text, positions the cursor
+// at the start of the former selection, and clears the selection state. It
+// is a no-op when there is no active selection.
+func (m *Model) deleteSelection() {
+	if !m.selectionActive {
+		return
+	}
+
+	start, end := m.selectionRange()
+
+	if start.row == end.row {
+		line := m.value[start.row]
+		endCol := min(end.col, len(line))
+		startCol := min(start.col, endCol)
+		m.value[start.row] = append(line[:startCol], line[endCol:]...)
+		m.row = start.row
+		m.SetCursorColumn(startCol)
+	} else {
+		headLine := m.value[start.row]
+		tailLine := m.value[end.row]
+		endCol := min(end.col, len(tailLine))
+		startCol := min(start.col, len(headLine))
+
+		merged := make([]rune, 0, startCol+len(tailLine)-endCol)
+		merged = append(merged, headLine[:startCol]...)
+		merged = append(merged, tailLine[endCol:]...)
+
+		newValue := make([][]rune, 0, len(m.value)-(end.row-start.row))
+		newValue = append(newValue, m.value[:start.row]...)
+		newValue = append(newValue, merged)
+		newValue = append(newValue, m.value[end.row+1:]...)
+		m.value = newValue
+
+		m.row = start.row
+		m.SetCursorColumn(startCol)
+	}
+
+	m.ClearSelection()
+}
+
+// SelectAll selects all text in the textarea.
+func (m *Model) SelectAll() {
+	m.selectionActive = true
+	m.selectionStart = position{row: 0, col: 0}
+	m.selectionEnd = position{row: len(m.value) - 1, col: len(m.value[len(m.value)-1])}
+}
+
+// CopySelection copies the selected text to the clipboard and returns a
+// command that performs the copy. Returns nil if there is no selection.
+func (m *Model) CopySelection() tea.Cmd {
+	if !m.selectionActive {
+		return nil
+	}
+	text := m.Selection()
+	return func() tea.Msg {
+		if err := clipboard.WriteAll(text); err != nil {
+			return copyErrMsg{err}
+		}
+		return copyMsg(text)
+	}
+}
+
+// startSelection begins a new selection at the current cursor position.
+func (m *Model) startSelection() {
+	if !m.selectionActive {
+		m.selectionActive = true
+		m.selectionStart = position{row: m.row, col: m.col}
+	}
+	m.selectionEnd = position{row: m.row, col: m.col}
+}
+
+// extendSelection extends the selection to the current cursor position.
+func (m *Model) extendSelection() {
+	if !m.selectionActive {
+		m.selectionStart = position{row: m.row, col: m.col}
+	}
+	m.selectionActive = true
+	m.selectionEnd = position{row: m.row, col: m.col}
+}
+
+// updateSelection updates the selection end to the current cursor position.
+// If no selection is active, starts a new one.
+func (m *Model) updateSelection() {
+	m.extendSelection()
+}
+
+// positionCursorFromMouse positions the cursor based on mouse coordinates.
+// The coordinates are relative to the textarea's view.
+func (m *Model) positionCursorFromMouse(x, y int) {
+	styles := m.activeStyle()
+	baseStyle := styles.Base
+
+	// Adjust for base style margins and borders.
+	x -= baseStyle.GetMarginLeft() + baseStyle.GetPaddingLeft() + baseStyle.GetBorderLeftSize()
+	y -= baseStyle.GetMarginTop() + baseStyle.GetPaddingTop() + baseStyle.GetBorderTopSize()
+
+	// Adjust for viewport scroll offset.
+	y += m.viewport.YOffset()
+
+	// Find the line at the y position.
+	displayLine := 0
+	targetRow := -1
+	targetCol := 0
+
+	for l, line := range m.value {
+		wrappedLines := m.memoizedWrap(line, m.width)
+		for wl := range wrappedLines {
+			if displayLine == y {
+				targetRow = l
+				// Calculate column from x position, accounting for prompt
+				// and line numbers.
+				promptWidth := lipgloss.Width(m.promptView(displayLine))
+				lineNumWidth := 0
+				if m.ShowLineNumbers {
+					lineNumWidth = lipgloss.Width(m.lineNumberView(0, false))
+				}
+				col := x - promptWidth - lineNumWidth
+				if col < 0 {
+					col = 0
+				}
+				// Find the actual column in the original line, accounting
+				// for soft wrapping.
+				if wl < len(wrappedLines) {
+					wrappedLine := wrappedLines[wl]
+					if col > len(wrappedLine) {
+						col = len(wrappedLine)
+					}
+					// Sum up columns from previous wrapped lines.
+					for i := 0; i < wl; i++ {
+						col += len(wrappedLines[i])
+					}
+					if col > len(line) {
+						col = len(line)
+					}
+					targetCol = col
+				}
+				break
+			}
+			displayLine++
+		}
+		if targetRow >= 0 {
+			break
+		}
+	}
+
+	if targetRow >= 0 && targetRow < len(m.value) {
+		m.row = targetRow
+		m.SetCursorColumn(targetCol)
+		m.repositionView()
+	}
 }
 
 func (m Model) memoizedWrap(runes []rune, width int) [][]rune {

--- a/textarea/textarea_test.go
+++ b/textarea/textarea_test.go
@@ -2447,12 +2447,12 @@ func TestSelectionCharacterForward(t *testing.T) {
 		textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyRight, Mod: tea.ModShift})
 	}
 
-	sel := textarea.Selection()
+	sel := textarea.SelectedText()
 	if sel != "hello" {
 		t.Errorf("Expected selection %q, got %q", "hello", sel)
 	}
 
-	if !textarea.SelectionActive() {
+	if !textarea.HasSelection() {
 		t.Error("Expected selection to be active")
 	}
 }
@@ -2471,7 +2471,7 @@ func TestSelectionCharacterBackward(t *testing.T) {
 		textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyLeft, Mod: tea.ModShift})
 	}
 
-	sel := textarea.Selection()
+	sel := textarea.SelectedText()
 	if sel != "hello" {
 		t.Errorf("Expected selection %q, got %q", "hello", sel)
 	}
@@ -2491,7 +2491,7 @@ func TestSelectionWordForward(t *testing.T) {
 	// Select "hello" with alt+shift+right.
 	textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyRight, Mod: tea.ModShift | tea.ModAlt})
 
-	sel := textarea.Selection()
+	sel := textarea.SelectedText()
 	if sel != "hello" {
 		t.Errorf("Expected selection %q, got %q", "hello", sel)
 	}
@@ -2514,7 +2514,7 @@ func TestSelectionMultiLine(t *testing.T) {
 	// Select down one line.
 	textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyDown, Mod: tea.ModShift})
 
-	sel := textarea.Selection()
+	sel := textarea.SelectedText()
 	if sel != "line one\n" {
 		t.Errorf("Expected selection %q, got %q", "line one\n", sel)
 	}
@@ -2524,7 +2524,7 @@ func TestSelectionMultiLine(t *testing.T) {
 		textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyRight, Mod: tea.ModShift})
 	}
 
-	sel = textarea.Selection()
+	sel = textarea.SelectedText()
 	if sel != "line one\nline two" {
 		t.Errorf("Expected selection %q, got %q", "line one\nline two", sel)
 	}
@@ -2541,7 +2541,7 @@ func TestSelectAll(t *testing.T) {
 
 	textarea.SelectAll()
 
-	sel := textarea.Selection()
+	sel := textarea.SelectedText()
 	if sel != "hello world" {
 		t.Errorf("Expected selection %q, got %q", "hello world", sel)
 	}
@@ -2559,13 +2559,13 @@ func TestSelectionClearedOnMovement(t *testing.T) {
 
 	// Select some text.
 	textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyRight, Mod: tea.ModShift})
-	if !textarea.SelectionActive() {
+	if !textarea.HasSelection() {
 		t.Fatal("Expected selection to be active")
 	}
 
 	// Move without shift, selection should clear.
 	textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyRight})
-	if textarea.SelectionActive() {
+	if textarea.HasSelection() {
 		t.Error("Expected selection to be cleared after non-selection movement")
 	}
 }
@@ -2582,13 +2582,13 @@ func TestSelectionClearedOnType(t *testing.T) {
 
 	// Select some text.
 	textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyRight, Mod: tea.ModShift})
-	if !textarea.SelectionActive() {
+	if !textarea.HasSelection() {
 		t.Fatal("Expected selection to be active")
 	}
 
 	// Type a character, selection should clear.
 	textarea, _ = textarea.Update(keyPress('x'))
-	if textarea.SelectionActive() {
+	if textarea.HasSelection() {
 		t.Error("Expected selection to be cleared after typing")
 	}
 }
@@ -2603,17 +2603,17 @@ func TestClearSelection(t *testing.T) {
 	textarea = sendString(textarea, "hello")
 	textarea.SelectAll()
 
-	if !textarea.SelectionActive() {
+	if !textarea.HasSelection() {
 		t.Fatal("Expected selection to be active")
 	}
 
 	textarea.ClearSelection()
 
-	if textarea.SelectionActive() {
+	if textarea.HasSelection() {
 		t.Error("Expected selection to be cleared")
 	}
 
-	if sel := textarea.Selection(); sel != "" {
+	if sel := textarea.SelectedText(); sel != "" {
 		t.Errorf("Expected empty selection, got %q", sel)
 	}
 }
@@ -2653,7 +2653,7 @@ func TestTypingReplacesSelection(t *testing.T) {
 	for range 5 {
 		textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyRight, Mod: tea.ModShift})
 	}
-	if sel := textarea.Selection(); sel != "hello" {
+	if sel := textarea.SelectedText(); sel != "hello" {
 		t.Fatalf("Expected selection %q, got %q", "hello", sel)
 	}
 
@@ -2663,7 +2663,7 @@ func TestTypingReplacesSelection(t *testing.T) {
 	if got := textarea.Value(); got != "X world" {
 		t.Errorf("Expected %q, got %q", "X world", got)
 	}
-	if textarea.SelectionActive() {
+	if textarea.HasSelection() {
 		t.Error("Expected selection to be cleared after typing")
 	}
 }
@@ -2689,7 +2689,7 @@ func TestBackspaceDeletesSelection(t *testing.T) {
 	if got := textarea.Value(); got != "world" {
 		t.Errorf("Expected %q, got %q", "world", got)
 	}
-	if textarea.SelectionActive() {
+	if textarea.HasSelection() {
 		t.Error("Expected selection to be cleared")
 	}
 }
@@ -2785,7 +2785,7 @@ func TestDeleteSelectionMultiLine(t *testing.T) {
 		textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyRight, Mod: tea.ModShift})
 	}
 
-	sel := textarea.Selection()
+	sel := textarea.SelectedText()
 	if sel != "line one\nline two\n" {
 		t.Fatalf("Expected selection %q, got %q", "line one\nline two\n", sel)
 	}
@@ -2813,7 +2813,7 @@ func TestSelectionRangeOrdering(t *testing.T) {
 	}
 
 	// Selection should be "world" even though we selected backwards.
-	sel := textarea.Selection()
+	sel := textarea.SelectedText()
 	if sel != "world" {
 		t.Errorf("Expected selection %q, got %q", "world", sel)
 	}

--- a/textarea/textarea_test.go
+++ b/textarea/textarea_test.go
@@ -2429,3 +2429,392 @@ func stripString(str string) string {
 
 	return strings.Join(lines, "\n")
 }
+
+func TestSelectionCharacterForward(t *testing.T) {
+	textarea := newTextArea()
+	textarea.Prompt = ""
+	textarea.ShowLineNumbers = false
+	textarea.SetWidth(20)
+	textarea.SetHeight(5)
+
+	textarea = sendString(textarea, "hello world")
+
+	// Move cursor to start.
+	textarea.CursorStart()
+
+	// Select "hello" by pressing shift+right 5 times.
+	for range 5 {
+		textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyRight, Mod: tea.ModShift})
+	}
+
+	sel := textarea.Selection()
+	if sel != "hello" {
+		t.Errorf("Expected selection %q, got %q", "hello", sel)
+	}
+
+	if !textarea.SelectionActive() {
+		t.Error("Expected selection to be active")
+	}
+}
+
+func TestSelectionCharacterBackward(t *testing.T) {
+	textarea := newTextArea()
+	textarea.Prompt = ""
+	textarea.ShowLineNumbers = false
+	textarea.SetWidth(20)
+	textarea.SetHeight(5)
+
+	textarea = sendString(textarea, "hello")
+
+	// Cursor is at end. Select "hello" backwards.
+	for range 5 {
+		textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyLeft, Mod: tea.ModShift})
+	}
+
+	sel := textarea.Selection()
+	if sel != "hello" {
+		t.Errorf("Expected selection %q, got %q", "hello", sel)
+	}
+}
+
+func TestSelectionWordForward(t *testing.T) {
+	textarea := newTextArea()
+	textarea.Prompt = ""
+	textarea.ShowLineNumbers = false
+	textarea.SetWidth(20)
+	textarea.SetHeight(5)
+
+	textarea = sendString(textarea, "hello world foo")
+
+	textarea.CursorStart()
+
+	// Select "hello" with alt+shift+right.
+	textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyRight, Mod: tea.ModShift | tea.ModAlt})
+
+	sel := textarea.Selection()
+	if sel != "hello" {
+		t.Errorf("Expected selection %q, got %q", "hello", sel)
+	}
+}
+
+func TestSelectionMultiLine(t *testing.T) {
+	textarea := newTextArea()
+	textarea.Prompt = ""
+	textarea.ShowLineNumbers = false
+	textarea.SetWidth(20)
+	textarea.SetHeight(10)
+
+	textarea = sendString(textarea, "line one")
+	textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	textarea = sendString(textarea, "line two")
+
+	// Go to start.
+	textarea.MoveToBegin()
+
+	// Select down one line.
+	textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyDown, Mod: tea.ModShift})
+
+	sel := textarea.Selection()
+	if sel != "line one\n" {
+		t.Errorf("Expected selection %q, got %q", "line one\n", sel)
+	}
+
+	// Now select to end of line two.
+	for range 8 {
+		textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyRight, Mod: tea.ModShift})
+	}
+
+	sel = textarea.Selection()
+	if sel != "line one\nline two" {
+		t.Errorf("Expected selection %q, got %q", "line one\nline two", sel)
+	}
+}
+
+func TestSelectAll(t *testing.T) {
+	textarea := newTextArea()
+	textarea.Prompt = ""
+	textarea.ShowLineNumbers = false
+	textarea.SetWidth(20)
+	textarea.SetHeight(10)
+
+	textarea = sendString(textarea, "hello world")
+
+	textarea.SelectAll()
+
+	sel := textarea.Selection()
+	if sel != "hello world" {
+		t.Errorf("Expected selection %q, got %q", "hello world", sel)
+	}
+}
+
+func TestSelectionClearedOnMovement(t *testing.T) {
+	textarea := newTextArea()
+	textarea.Prompt = ""
+	textarea.ShowLineNumbers = false
+	textarea.SetWidth(20)
+	textarea.SetHeight(5)
+
+	textarea = sendString(textarea, "hello")
+	textarea.CursorStart()
+
+	// Select some text.
+	textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyRight, Mod: tea.ModShift})
+	if !textarea.SelectionActive() {
+		t.Fatal("Expected selection to be active")
+	}
+
+	// Move without shift, selection should clear.
+	textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+	if textarea.SelectionActive() {
+		t.Error("Expected selection to be cleared after non-selection movement")
+	}
+}
+
+func TestSelectionClearedOnType(t *testing.T) {
+	textarea := newTextArea()
+	textarea.Prompt = ""
+	textarea.ShowLineNumbers = false
+	textarea.SetWidth(20)
+	textarea.SetHeight(5)
+
+	textarea = sendString(textarea, "hello")
+	textarea.CursorStart()
+
+	// Select some text.
+	textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyRight, Mod: tea.ModShift})
+	if !textarea.SelectionActive() {
+		t.Fatal("Expected selection to be active")
+	}
+
+	// Type a character, selection should clear.
+	textarea, _ = textarea.Update(keyPress('x'))
+	if textarea.SelectionActive() {
+		t.Error("Expected selection to be cleared after typing")
+	}
+}
+
+func TestClearSelection(t *testing.T) {
+	textarea := newTextArea()
+	textarea.Prompt = ""
+	textarea.ShowLineNumbers = false
+	textarea.SetWidth(20)
+	textarea.SetHeight(5)
+
+	textarea = sendString(textarea, "hello")
+	textarea.SelectAll()
+
+	if !textarea.SelectionActive() {
+		t.Fatal("Expected selection to be active")
+	}
+
+	textarea.ClearSelection()
+
+	if textarea.SelectionActive() {
+		t.Error("Expected selection to be cleared")
+	}
+
+	if sel := textarea.Selection(); sel != "" {
+		t.Errorf("Expected empty selection, got %q", sel)
+	}
+}
+
+func TestSelectionRendering(t *testing.T) {
+	textarea := newTextArea()
+	textarea.Prompt = ""
+	textarea.ShowLineNumbers = false
+	textarea.SetWidth(20)
+	textarea.SetHeight(5)
+
+	textarea = sendString(textarea, "hello")
+
+	textarea.CursorStart()
+	for range 3 {
+		textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyRight, Mod: tea.ModShift})
+	}
+
+	// Render the view and check it doesn't panic.
+	view := textarea.View()
+	if view == "" {
+		t.Error("Expected non-empty view")
+	}
+}
+
+func TestTypingReplacesSelection(t *testing.T) {
+	textarea := newTextArea()
+	textarea.Prompt = ""
+	textarea.ShowLineNumbers = false
+	textarea.SetWidth(20)
+	textarea.SetHeight(5)
+
+	textarea = sendString(textarea, "hello world")
+	textarea.CursorStart()
+
+	// Select "hello".
+	for range 5 {
+		textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyRight, Mod: tea.ModShift})
+	}
+	if sel := textarea.Selection(); sel != "hello" {
+		t.Fatalf("Expected selection %q, got %q", "hello", sel)
+	}
+
+	// Type 'X' — should replace selection.
+	textarea, _ = textarea.Update(keyPress('X'))
+
+	if got := textarea.Value(); got != "X world" {
+		t.Errorf("Expected %q, got %q", "X world", got)
+	}
+	if textarea.SelectionActive() {
+		t.Error("Expected selection to be cleared after typing")
+	}
+}
+
+func TestBackspaceDeletesSelection(t *testing.T) {
+	textarea := newTextArea()
+	textarea.Prompt = ""
+	textarea.ShowLineNumbers = false
+	textarea.SetWidth(20)
+	textarea.SetHeight(5)
+
+	textarea = sendString(textarea, "hello world")
+	textarea.CursorStart()
+
+	// Select "hello ".
+	for range 6 {
+		textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyRight, Mod: tea.ModShift})
+	}
+
+	// Press backspace — should delete selection.
+	textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+
+	if got := textarea.Value(); got != "world" {
+		t.Errorf("Expected %q, got %q", "world", got)
+	}
+	if textarea.SelectionActive() {
+		t.Error("Expected selection to be cleared")
+	}
+}
+
+func TestDeleteForwardDeletesSelection(t *testing.T) {
+	textarea := newTextArea()
+	textarea.Prompt = ""
+	textarea.ShowLineNumbers = false
+	textarea.SetWidth(20)
+	textarea.SetHeight(5)
+
+	textarea = sendString(textarea, "hello world")
+	textarea.CursorStart()
+
+	for range 5 {
+		textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyRight, Mod: tea.ModShift})
+	}
+
+	textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyDelete})
+
+	if got := textarea.Value(); got != " world" {
+		t.Errorf("Expected %q, got %q", " world", got)
+	}
+}
+
+func TestPasteReplacesSelection(t *testing.T) {
+	textarea := newTextArea()
+	textarea.Prompt = ""
+	textarea.ShowLineNumbers = false
+	textarea.SetWidth(40)
+	textarea.SetHeight(5)
+
+	textarea = sendString(textarea, "hello world")
+	textarea.CursorStart()
+
+	// Select "hello".
+	for range 5 {
+		textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyRight, Mod: tea.ModShift})
+	}
+
+	// Simulate paste via internal message.
+	textarea, _ = textarea.Update(pasteMsg("REPLACED"))
+
+	if got := textarea.Value(); got != "REPLACED world" {
+		t.Errorf("Expected %q, got %q", "REPLACED world", got)
+	}
+}
+
+func TestNewlineReplacesSelection(t *testing.T) {
+	textarea := newTextArea()
+	textarea.Prompt = ""
+	textarea.ShowLineNumbers = false
+	textarea.SetWidth(20)
+	textarea.SetHeight(10)
+
+	textarea = sendString(textarea, "hello world")
+	textarea.CursorStart()
+
+	// Select "hello ".
+	for range 6 {
+		textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyRight, Mod: tea.ModShift})
+	}
+
+	// Press enter — should replace selection with newline.
+	textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	if got := textarea.Value(); got != "\nworld" {
+		t.Errorf("Expected %q, got %q", "\nworld", got)
+	}
+}
+
+func TestDeleteSelectionMultiLine(t *testing.T) {
+	textarea := newTextArea()
+	textarea.Prompt = ""
+	textarea.ShowLineNumbers = false
+	textarea.SetWidth(20)
+	textarea.SetHeight(10)
+
+	textarea = sendString(textarea, "line one")
+	textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	textarea = sendString(textarea, "line two")
+	textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	textarea = sendString(textarea, "line three")
+
+	// Go to start and select through "line two\n".
+	textarea.MoveToBegin()
+	// Move right through "line one\n" (9 chars).
+	for range 9 {
+		textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyRight, Mod: tea.ModShift})
+	}
+	// Move right through "line two\n" (9 chars).
+	for range 9 {
+		textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyRight, Mod: tea.ModShift})
+	}
+
+	sel := textarea.Selection()
+	if sel != "line one\nline two\n" {
+		t.Fatalf("Expected selection %q, got %q", "line one\nline two\n", sel)
+	}
+
+	// Delete the selection.
+	textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+
+	if got := textarea.Value(); got != "line three" {
+		t.Errorf("Expected %q, got %q", "line three", got)
+	}
+}
+
+func TestSelectionRangeOrdering(t *testing.T) {
+	textarea := newTextArea()
+	textarea.Prompt = ""
+	textarea.ShowLineNumbers = false
+	textarea.SetWidth(20)
+	textarea.SetHeight(5)
+
+	textarea = sendString(textarea, "hello world")
+
+	// Select backwards from end.
+	for range 5 {
+		textarea, _ = textarea.Update(tea.KeyPressMsg{Code: tea.KeyLeft, Mod: tea.ModShift})
+	}
+
+	// Selection should be "world" even though we selected backwards.
+	sel := textarea.Selection()
+	if sel != "world" {
+		t.Errorf("Expected selection %q, got %q", "world", sel)
+	}
+}


### PR DESCRIPTION
* Crush PR: https://github.com/charmbracelet/crush/pull/3507

## What? 

Users can now highlight text using keyboard shortcuts (shift+arrows, ctrl+alt+arrows for words, ctrl+g for all) or by clicking and dragging with the mouse (needs wiring). Selected text is visually highlighted with a customizable background color. 

## Why?

The textarea previously had no way to select, copy, or replace portions of text. This made it difficult to edit existing content without retyping it, and impossible to copy text out of the component. These are baseline expectations for any text input, and their absence meant users had to work around the limitation by deleting and re-entering content manually.

Fixes #1027 
Fixes CRUSHGH-1113

This will also partially open the `textarea` element to more uses!