### PR TITLE
feat(textarea): add an optional line highlighter

### DIFF
--- a/textarea/highlighter.go
+++ b/textarea/highlighter.go
@@ -1,0 +1,115 @@
+package textarea
+
+import (
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// LineHighlighter is an optional hook that applies per-token styling to
+// rendered lines. It is consulted once per logical line per render and
+// returns style ranges over the line's runes: range Start (inclusive) and
+// End (exclusive) are rune offsets within the line, and Style is composed
+// with the line's base style by the renderer.
+//
+// The hook runs after wrapping: the textarea asks for ranges on the raw
+// logical line, then intersects those ranges with each wrapped segment at
+// render time. Implementations must therefore return ranges in rune offsets
+// of the logical line they are given — never byte offsets, and never ranges
+// derived from a different string.
+//
+// The cell under the virtual cursor is never styled by ranges: the renderer
+// splits cursor-line content into pre- and post-cursor segments and renders
+// the cursor cell itself separately.
+//
+// Keeping this interface range-based (rather than bubbline's
+// func(string) string ANSI rewriting) means implementations never have to
+// parse or preserve escape sequences, and the textarea's wrap/cursor math
+// always operates on raw runes.
+type LineHighlighter interface {
+	// Highlight returns the style ranges for the given logical line.
+	// lineIdx is the zero-based logical line number; line is the raw rune
+	// content (no trailing newline). Implementations should return nil for
+	// lines with nothing to style.
+	Highlight(lineIdx int, line []rune) []lipgloss.Range
+}
+
+// SetHighlighter installs an optional line highlighter. Pass nil to disable
+// highlighting. The highlighter is consulted at render time only; it does
+// not affect editing, wrapping, or cursor positioning.
+func (m *Model) SetHighlighter(h LineHighlighter) {
+	m.highlighter = h
+}
+
+// highlightRanges returns the highlighter's ranges for a logical line, or
+// nil when no highlighter is installed.
+func (m *Model) highlightRanges(lineIdx int, line []rune) []lipgloss.Range {
+	if m.highlighter == nil {
+		return nil
+	}
+	return m.highlighter.Highlight(lineIdx, line)
+}
+
+// styleSegment renders a wrapped-line segment, applying any highlighter
+// ranges that intersect it. segStart is the rune offset of the segment
+// within its logical line. The cell under the virtual cursor never reaches
+// this function: the renderer splits cursor-line content into pre- and
+// post-cursor segments and renders the cursor cell itself separately, so
+// token styling and cursor styling can never fight over the same cell.
+func styleSegment(
+	base lipgloss.Style,
+	seg []rune,
+	segStart int,
+	lineRanges []lipgloss.Range,
+) string {
+	if len(lineRanges) == 0 || len(seg) == 0 {
+		return base.Render(string(seg))
+	}
+
+	segEnd := segStart + len(seg)
+	var ranges []lipgloss.Range
+	for _, r := range lineRanges {
+		// Intersect the token range with this segment.
+		start := max(r.Start, segStart) - segStart
+		end := min(r.End, segEnd) - segStart
+		if start >= end {
+			continue
+		}
+		ranges = append(ranges, lipgloss.NewRange(start, end, r.Style))
+	}
+
+	if len(ranges) == 0 {
+		return base.Render(string(seg))
+	}
+
+	// StyleRanges composes each range's style over the base-rendered string.
+	// Range offsets are 1-based display cells in lipgloss; map rune offsets
+	// through display widths to stay correct for double-width runes.
+	return lipgloss.StyleRanges(base.Render(string(seg)), toStyleRanges(seg, ranges, base)...)
+}
+
+// toStyleRanges converts rune-offset ranges into the display-cell ranges
+// lipgloss.StyleRanges expects: zero-based and half-open over the cells of
+// the ANSI-stripped string. Each token style inherits the base style's
+// attributes so tokens only override what they set.
+func toStyleRanges(seg []rune, ranges []lipgloss.Range, base lipgloss.Style) []lipgloss.Range {
+	out := make([]lipgloss.Range, 0, len(ranges))
+	for _, r := range ranges {
+		startCell := runeDisplayWidth(seg[:r.Start])
+		endCell := startCell + runeDisplayWidth(seg[r.Start:r.End])
+		style := r.Style.Inherit(base)
+		out = append(out, lipgloss.NewRange(startCell, endCell, style))
+	}
+	return out
+}
+
+// runeDisplayWidth returns the total display width of runes.
+//
+// It must measure the same way lipgloss.StyleRanges resolves the cell
+// offsets it is handed — that goes through ansi.Cut, which segments by
+// grapheme cluster. Summing per-rune widths instead disagrees on every
+// cluster built from more than one rune: an emoji with a skin-tone modifier
+// scores 4 rather than 2, a ZWJ family 7 rather than 2, and the token
+// highlight lands that many cells to the right of the token it belongs to.
+func runeDisplayWidth(r []rune) int {
+	return ansi.StringWidth(string(r))
+}

--- a/textarea/highlighter.go
+++ b/textarea/highlighter.go
@@ -1,0 +1,151 @@
+package textarea
+
+import (
+	"slices"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// LineHighlighter is an optional hook that applies per-token styling to
+// rendered lines. It is consulted once per logical line per render and
+// returns style ranges over the line's runes: range Start (inclusive) and
+// End (exclusive) are rune offsets within the line, and Style is composed
+// with the line's base style by the renderer.
+//
+// The hook runs after wrapping: the textarea asks for ranges on the raw
+// logical line, then intersects those ranges with each wrapped segment at
+// render time. Implementations must therefore return ranges in rune offsets
+// of the logical line they are given — never byte offsets, and never ranges
+// derived from a different string.
+//
+// The cell under the virtual cursor is never styled by ranges: the renderer
+// splits cursor-line content into pre- and post-cursor segments and renders
+// the cursor cell itself separately. An active selection also wins over
+// highlighting, so a selected segment renders in the selection style alone.
+//
+// Keeping this interface range-based, rather than a func(string) string that
+// rewrites the rendered line, means implementations never have to parse or
+// preserve escape sequences, and the textarea's wrap and cursor math always
+// operates on raw runes.
+type LineHighlighter interface {
+	// Highlight returns the style ranges for the given logical line.
+	// lineIdx is the zero-based logical line number; line is the raw rune
+	// content (no trailing newline). Implementations should return nil for
+	// lines with nothing to style.
+	//
+	// Ranges need not be sorted and may overlap or run outside the line: the
+	// renderer clips them to the line, orders them, and keeps the first of
+	// any overlapping pair.
+	Highlight(lineIdx int, line []rune) []lipgloss.Range
+}
+
+// SetHighlighter installs an optional line highlighter. Pass nil to disable
+// highlighting. The highlighter is consulted at render time only; it does
+// not affect editing, wrapping, or cursor positioning.
+func (m *Model) SetHighlighter(h LineHighlighter) {
+	m.highlighter = h
+}
+
+// highlightRanges returns the highlighter's ranges for a logical line, or
+// nil when no highlighter is installed.
+func (m *Model) highlightRanges(lineIdx int, line []rune) []lipgloss.Range {
+	if m.highlighter == nil {
+		return nil
+	}
+	return m.highlighter.Highlight(lineIdx, line)
+}
+
+// styleSegment renders a wrapped-line segment, applying any highlighter
+// ranges that intersect it. segStart is the rune offset of the segment
+// within its logical line. The cell under the virtual cursor never reaches
+// this function: the renderer splits cursor-line content into pre- and
+// post-cursor segments and renders the cursor cell itself separately, so
+// token styling and cursor styling can never fight over the same cell.
+func styleSegment(
+	base lipgloss.Style,
+	seg []rune,
+	segStart int,
+	lineRanges []lipgloss.Range,
+) string {
+	if len(lineRanges) == 0 || len(seg) == 0 {
+		return base.Render(string(seg))
+	}
+
+	segEnd := segStart + len(seg)
+	var ranges []lipgloss.Range
+	for _, r := range lineRanges {
+		// Intersect the token range with this segment.
+		start := max(r.Start, segStart) - segStart
+		end := min(r.End, segEnd) - segStart
+		if start >= end {
+			continue
+		}
+		ranges = append(ranges, lipgloss.NewRange(start, end, r.Style))
+	}
+
+	if len(ranges) == 0 {
+		return base.Render(string(seg))
+	}
+	ranges = normalizeRanges(ranges)
+
+	// StyleRanges composes each range's style over the base-rendered string,
+	// addressing it in display cells rather than runes; map rune offsets
+	// through display widths to stay correct for wide and clustered runes.
+	return lipgloss.StyleRanges(base.Render(string(seg)), toStyleRanges(seg, ranges, base)...)
+}
+
+// normalizeRanges sorts ranges by start offset and drops any that overlap an
+// earlier one.
+//
+// [lipgloss.StyleRanges] walks its ranges in the order given and tracks how
+// far it has consumed, so an out-of-order or overlapping range makes it emit
+// a stretch of the line twice and skip another. The highlighter hook is
+// public, so ranges arrive in whatever order an implementation produced them
+// — normalizing here keeps a careless highlighter from corrupting the render
+// rather than merely mis-colouring it.
+func normalizeRanges(ranges []lipgloss.Range) []lipgloss.Range {
+	if len(ranges) < 2 {
+		return ranges
+	}
+
+	slices.SortStableFunc(ranges, func(a, b lipgloss.Range) int {
+		return a.Start - b.Start
+	})
+
+	out := ranges[:1]
+	for _, r := range ranges[1:] {
+		if r.Start < out[len(out)-1].End {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// toStyleRanges converts rune-offset ranges into the display-cell ranges
+// lipgloss.StyleRanges expects: zero-based and half-open over the cells of
+// the ANSI-stripped string. Each token style inherits the base style's
+// attributes so tokens only override what they set.
+func toStyleRanges(seg []rune, ranges []lipgloss.Range, base lipgloss.Style) []lipgloss.Range {
+	out := make([]lipgloss.Range, 0, len(ranges))
+	for _, r := range ranges {
+		startCell := runeDisplayWidth(seg[:r.Start])
+		endCell := startCell + runeDisplayWidth(seg[r.Start:r.End])
+		style := r.Style.Inherit(base)
+		out = append(out, lipgloss.NewRange(startCell, endCell, style))
+	}
+	return out
+}
+
+// runeDisplayWidth returns the total display width of runes.
+//
+// It must measure the same way lipgloss.StyleRanges resolves the cell
+// offsets it is handed — that goes through ansi.Cut, which segments by
+// grapheme cluster. Summing per-rune widths instead disagrees on every
+// cluster built from more than one rune: an emoji with a skin-tone modifier
+// scores 4 rather than 2, a ZWJ family 7 rather than 2, and the token
+// highlight lands that many cells to the right of the token it belongs to.
+func runeDisplayWidth(r []rune) int {
+	return ansi.StringWidth(string(r))
+}

--- a/textarea/highlighter_test.go
+++ b/textarea/highlighter_test.go
@@ -1,0 +1,261 @@
+package textarea
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// tokenHighlighter is a test LineHighlighter that marks every "@"-prefixed
+// word with a fixed style.
+type tokenHighlighter struct {
+	style lipgloss.Style
+}
+
+func (h tokenHighlighter) Highlight(_ int, line []rune) []lipgloss.Range {
+	var ranges []lipgloss.Range
+	i := 0
+	for i < len(line) {
+		if line[i] == '@' {
+			end := i + 1
+			for end < len(line) && line[end] != ' ' {
+				end++
+			}
+			ranges = append(ranges, lipgloss.NewRange(i, end, h.style))
+			i = end
+			continue
+		}
+		i++
+	}
+	return ranges
+}
+
+func TestStyleSegmentAppliesRanges(t *testing.T) {
+	t.Parallel()
+
+	base := lipgloss.NewStyle()
+	tokenStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+
+	seg := []rune("see @foo.go here")
+	ranges := []lipgloss.Range{lipgloss.NewRange(4, 11, tokenStyle)}
+
+	got := styleSegment(base, seg, 0, ranges)
+
+	if plain := base.Render(string(seg)); got == plain {
+		t.Error("styled segment must differ from the plain render")
+	}
+	if want := "see @foo.go here"; !strings.Contains(ansi.Strip(got), want) {
+		t.Errorf("stripped output = %q, want it to contain %q", ansi.Strip(got), want)
+	}
+}
+
+// TestStyleSegmentStylesExactlyTheToken pins which cells the token style
+// lands on. Regression: the rune-to-cell conversion used to add one, so
+// every token rendered shifted a cell to the right — the trigger character
+// stayed unstyled and the following space picked the style up instead.
+func TestStyleSegmentStylesExactlyTheToken(t *testing.T) {
+	t.Parallel()
+
+	base := lipgloss.NewStyle()
+	tokenStyle := lipgloss.NewStyle().Bold(true)
+
+	seg := []rune("ab @foo cd")
+	got := styleSegment(base, seg, 0, []lipgloss.Range{lipgloss.NewRange(3, 7, tokenStyle)})
+
+	if want := "ab \x1b[1m@foo\x1b[m cd"; got != want {
+		t.Errorf("styleSegment() = %q, want %q", got, want)
+	}
+}
+
+// TestStyleSegmentStylesExactlyTheTokenWideRunes is the same pin with
+// double-width runes ahead of the token, where a rune offset and a cell
+// offset diverge.
+func TestStyleSegmentStylesExactlyTheTokenWideRunes(t *testing.T) {
+	t.Parallel()
+
+	base := lipgloss.NewStyle()
+	tokenStyle := lipgloss.NewStyle().Bold(true)
+
+	// "世界" is two runes but four cells.
+	seg := []rune("世界 @foo")
+	got := styleSegment(base, seg, 0, []lipgloss.Range{lipgloss.NewRange(3, 7, tokenStyle)})
+
+	if want := "世界 \x1b[1m@foo\x1b[m"; got != want {
+		t.Errorf("styleSegment() = %q, want %q", got, want)
+	}
+}
+
+func TestStyleSegmentOffsetsBySegStart(t *testing.T) {
+	t.Parallel()
+
+	base := lipgloss.NewStyle()
+	tokenStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+
+	// Logical line: "see @foo.go here"; the wrapped segment is "foo.go here"
+	// starting at rune 7, so the token range (4,11) intersects as (0,4).
+	seg := []rune("foo.go here")
+	ranges := []lipgloss.Range{lipgloss.NewRange(4, 11, tokenStyle)}
+
+	got := styleSegment(base, seg, 7, ranges)
+
+	if want := "foo.go here"; !strings.Contains(ansi.Strip(got), want) {
+		t.Errorf("stripped output = %q, want it to contain %q", ansi.Strip(got), want)
+	}
+	if plain := base.Render(string(seg)); got == plain {
+		t.Error("a range intersecting the segment must change the render")
+	}
+}
+
+func TestStyleSegmentNoRangesIsPlainRender(t *testing.T) {
+	t.Parallel()
+
+	base := lipgloss.NewStyle()
+	seg := []rune("plain text")
+	want := base.Render(string(seg))
+
+	if got := styleSegment(base, seg, 0, nil); got != want {
+		t.Errorf("nil ranges: got %q, want plain render %q", got, want)
+	}
+
+	outside := []lipgloss.Range{lipgloss.NewRange(50, 60, lipgloss.NewStyle().Bold(true))}
+	if got := styleSegment(base, seg, 0, outside); got != want {
+		t.Errorf("range outside segment: got %q, want plain render %q", got, want)
+	}
+}
+
+func TestViewWithHighlighterStylesTokens(t *testing.T) {
+	t.Parallel()
+
+	const value = "see @foo.go and @bar.md"
+
+	m := New()
+	m.SetValue(value)
+	m.SetWidth(80)
+	m.SetHighlighter(tokenHighlighter{style: lipgloss.NewStyle().Foreground(lipgloss.Color("2"))})
+
+	plain := New()
+	plain.SetValue(value)
+	plain.SetWidth(80)
+
+	highlighted := m.View()
+	if highlighted == plain.View() {
+		t.Error("highlighter should change the rendered view")
+	}
+	// Content must survive styling: stripping ANSI yields the same text.
+	if got, want := ansi.Strip(highlighted), ansi.Strip(plain.View()); got != want {
+		t.Errorf("stripped view = %q, want %q", got, want)
+	}
+}
+
+func TestViewWithoutHighlighterUnchanged(t *testing.T) {
+	t.Parallel()
+
+	m := New()
+	m.SetValue("see @foo.go")
+	m.SetWidth(80)
+
+	before := m.View()
+	m.SetHighlighter(nil)
+	if got := m.View(); got != before {
+		t.Error("a nil highlighter must leave rendering unchanged")
+	}
+}
+
+func TestViewHighlighterOnCursorLine(t *testing.T) {
+	t.Parallel()
+
+	m := New()
+	m.Focus()
+	m.SetValue("go @foo.go now")
+	m.SetWidth(80)
+	m.SetHighlighter(tokenHighlighter{style: lipgloss.NewStyle().Foreground(lipgloss.Color("2"))})
+
+	// Move the cursor into the middle of the token to exercise the
+	// pre/post-cursor split paths.
+	m.SetCursorColumn(5)
+
+	// Cursor-line rendering must not corrupt content.
+	if want := "go @foo.go now"; !strings.Contains(ansi.Strip(m.View()), want) {
+		t.Errorf("stripped view missing %q", want)
+	}
+}
+
+func TestViewHighlighterTokenSurvivesWrap(t *testing.T) {
+	t.Parallel()
+
+	m := New()
+	// Force a wrap inside the token: width 10 splits "ab @longtoken cd"
+	// across several segments.
+	m.SetValue("ab @longtoken cd")
+	m.SetWidth(10)
+	m.SetHeight(6)
+	m.SetHighlighter(tokenHighlighter{style: lipgloss.NewStyle().Foreground(lipgloss.Color("2"))})
+
+	highlighted := m.View()
+	stripped := ansi.Strip(highlighted)
+
+	// Every token character still renders after wrapping + styling. The wrap
+	// splits the token across segments, so assert on the wrap chunks.
+	for _, part := range []string{"ab", "@lon", "gtok", "en", "cd"} {
+		if !strings.Contains(stripped, part) {
+			t.Errorf("wrapped output missing %q", part)
+		}
+	}
+	if !strings.Contains(highlighted, "\x1b[") {
+		t.Error("expected ANSI styling in output")
+	}
+}
+
+// TestRuneDisplayWidthMatchesGraphemeSegmentation pins the measurement
+// contract with lipgloss.StyleRanges.
+//
+// StyleRanges resolves the cell offsets it is handed with ansi.Cut, which
+// segments by grapheme cluster. Summing per-rune widths disagrees on every
+// cluster built from more than one rune, and the highlight then lands that
+// many cells right of its token.
+func TestRuneDisplayWidthMatchesGraphemeSegmentation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+	}{
+		{"ascii", "hello"},
+		{"cjk double width", "日本語"},
+		{"emoji with skin tone modifier", "👍🏽"},
+		{"zwj family", "👨‍👩‍👧"},
+		{"emoji then token", "👍🏽 @file.go"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got, want := runeDisplayWidth([]rune(tc.in)), ansi.StringWidth(tc.in); got != want {
+				t.Errorf("runeDisplayWidth(%q) = %d, want %d (grapheme-cluster segmentation)",
+					tc.in, got, want)
+			}
+		})
+	}
+}
+
+// TestHighlightRangesLandOnTokenAfterEmoji is the user-visible form of the
+// bug: with per-rune widths the styled span started two cells past the '@'.
+func TestHighlightRangesLandOnTokenAfterEmoji(t *testing.T) {
+	t.Parallel()
+
+	// "👍🏽 @file.go" — the token starts after a 2-cell grapheme and a space,
+	// so at cell 3. Per-rune summing put it at 5.
+	const line = "👍🏽 @file.go"
+
+	at := strings.IndexRune(line, '@')
+	if at <= 0 {
+		t.Fatalf("test string must contain '@', got byte index %d", at)
+	}
+	atRune := len([]rune(line[:at]))
+
+	if got, want := runeDisplayWidth([]rune(line)[:atRune]), 3; got != want {
+		t.Errorf("token starts at cell %d, want %d (the cell ansi.Cut would land on)", got, want)
+	}
+}

--- a/textarea/highlighter_test.go
+++ b/textarea/highlighter_test.go
@@ -1,0 +1,333 @@
+package textarea
+
+import (
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// tokenHighlighter is a test LineHighlighter that marks every "@"-prefixed
+// word with a fixed style.
+type tokenHighlighter struct {
+	style lipgloss.Style
+}
+
+func (h tokenHighlighter) Highlight(_ int, line []rune) []lipgloss.Range {
+	var ranges []lipgloss.Range
+	i := 0
+	for i < len(line) {
+		if line[i] == '@' {
+			end := i + 1
+			for end < len(line) && line[end] != ' ' {
+				end++
+			}
+			ranges = append(ranges, lipgloss.NewRange(i, end, h.style))
+			i = end
+			continue
+		}
+		i++
+	}
+	return ranges
+}
+
+func TestStyleSegmentAppliesRanges(t *testing.T) {
+	t.Parallel()
+
+	base := lipgloss.NewStyle()
+	tokenStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+
+	seg := []rune("see @foo.go here")
+	ranges := []lipgloss.Range{lipgloss.NewRange(4, 11, tokenStyle)}
+
+	got := styleSegment(base, seg, 0, ranges)
+
+	if plain := base.Render(string(seg)); got == plain {
+		t.Error("styled segment must differ from the plain render")
+	}
+	if want := "see @foo.go here"; !strings.Contains(ansi.Strip(got), want) {
+		t.Errorf("stripped output = %q, want it to contain %q", ansi.Strip(got), want)
+	}
+}
+
+// TestStyleSegmentStylesExactlyTheToken pins which cells the token style
+// lands on. Regression: the rune-to-cell conversion used to add one, so
+// every token rendered shifted a cell to the right — the trigger character
+// stayed unstyled and the following space picked the style up instead.
+func TestStyleSegmentStylesExactlyTheToken(t *testing.T) {
+	t.Parallel()
+
+	base := lipgloss.NewStyle()
+	tokenStyle := lipgloss.NewStyle().Bold(true)
+
+	seg := []rune("ab @foo cd")
+	got := styleSegment(base, seg, 0, []lipgloss.Range{lipgloss.NewRange(3, 7, tokenStyle)})
+
+	if want := "ab \x1b[1m@foo\x1b[m cd"; got != want {
+		t.Errorf("styleSegment() = %q, want %q", got, want)
+	}
+}
+
+// TestStyleSegmentStylesExactlyTheTokenWideRunes is the same pin with
+// double-width runes ahead of the token, where a rune offset and a cell
+// offset diverge.
+func TestStyleSegmentStylesExactlyTheTokenWideRunes(t *testing.T) {
+	t.Parallel()
+
+	base := lipgloss.NewStyle()
+	tokenStyle := lipgloss.NewStyle().Bold(true)
+
+	// "世界" is two runes but four cells.
+	seg := []rune("世界 @foo")
+	got := styleSegment(base, seg, 0, []lipgloss.Range{lipgloss.NewRange(3, 7, tokenStyle)})
+
+	if want := "世界 \x1b[1m@foo\x1b[m"; got != want {
+		t.Errorf("styleSegment() = %q, want %q", got, want)
+	}
+}
+
+func TestStyleSegmentOffsetsBySegStart(t *testing.T) {
+	t.Parallel()
+
+	base := lipgloss.NewStyle()
+	tokenStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+
+	// Logical line: "see @foo.go here"; the wrapped segment is "foo.go here"
+	// starting at rune 7, so the token range (4,11) intersects as (0,4).
+	seg := []rune("foo.go here")
+	ranges := []lipgloss.Range{lipgloss.NewRange(4, 11, tokenStyle)}
+
+	got := styleSegment(base, seg, 7, ranges)
+
+	if want := "foo.go here"; !strings.Contains(ansi.Strip(got), want) {
+		t.Errorf("stripped output = %q, want it to contain %q", ansi.Strip(got), want)
+	}
+	if plain := base.Render(string(seg)); got == plain {
+		t.Error("a range intersecting the segment must change the render")
+	}
+}
+
+func TestStyleSegmentNoRangesIsPlainRender(t *testing.T) {
+	t.Parallel()
+
+	base := lipgloss.NewStyle()
+	seg := []rune("plain text")
+	want := base.Render(string(seg))
+
+	if got := styleSegment(base, seg, 0, nil); got != want {
+		t.Errorf("nil ranges: got %q, want plain render %q", got, want)
+	}
+
+	outside := []lipgloss.Range{lipgloss.NewRange(50, 60, lipgloss.NewStyle().Bold(true))}
+	if got := styleSegment(base, seg, 0, outside); got != want {
+		t.Errorf("range outside segment: got %q, want plain render %q", got, want)
+	}
+}
+
+func TestViewWithHighlighterStylesTokens(t *testing.T) {
+	t.Parallel()
+
+	const value = "see @foo.go and @bar.md"
+
+	m := New()
+	m.SetValue(value)
+	m.SetWidth(80)
+	m.SetHighlighter(tokenHighlighter{style: lipgloss.NewStyle().Foreground(lipgloss.Color("2"))})
+
+	plain := New()
+	plain.SetValue(value)
+	plain.SetWidth(80)
+
+	highlighted := m.View()
+	if highlighted == plain.View() {
+		t.Error("highlighter should change the rendered view")
+	}
+	// Content must survive styling: stripping ANSI yields the same text.
+	if got, want := ansi.Strip(highlighted), ansi.Strip(plain.View()); got != want {
+		t.Errorf("stripped view = %q, want %q", got, want)
+	}
+}
+
+func TestViewWithoutHighlighterUnchanged(t *testing.T) {
+	t.Parallel()
+
+	m := New()
+	m.SetValue("see @foo.go")
+	m.SetWidth(80)
+
+	before := m.View()
+	m.SetHighlighter(nil)
+	if got := m.View(); got != before {
+		t.Error("a nil highlighter must leave rendering unchanged")
+	}
+}
+
+func TestViewHighlighterOnCursorLine(t *testing.T) {
+	t.Parallel()
+
+	m := New()
+	m.Focus()
+	m.SetValue("go @foo.go now")
+	m.SetWidth(80)
+	m.SetHighlighter(tokenHighlighter{style: lipgloss.NewStyle().Foreground(lipgloss.Color("2"))})
+
+	// Move the cursor into the middle of the token to exercise the
+	// pre/post-cursor split paths.
+	m.SetCursorColumn(5)
+
+	// Cursor-line rendering must not corrupt content.
+	if want := "go @foo.go now"; !strings.Contains(ansi.Strip(m.View()), want) {
+		t.Errorf("stripped view missing %q", want)
+	}
+}
+
+func TestViewHighlighterTokenSurvivesWrap(t *testing.T) {
+	t.Parallel()
+
+	m := New()
+	// Force a wrap inside the token: width 10 splits "ab @longtoken cd"
+	// across several segments.
+	m.SetValue("ab @longtoken cd")
+	m.SetWidth(10)
+	m.SetHeight(6)
+	m.SetHighlighter(tokenHighlighter{style: lipgloss.NewStyle().Foreground(lipgloss.Color("2"))})
+
+	highlighted := m.View()
+	stripped := ansi.Strip(highlighted)
+
+	// Every token character still renders after wrapping + styling. The wrap
+	// splits the token across segments, so assert on the wrap chunks.
+	for _, part := range []string{"ab", "@lon", "gtok", "en", "cd"} {
+		if !strings.Contains(stripped, part) {
+			t.Errorf("wrapped output missing %q", part)
+		}
+	}
+	if !strings.Contains(highlighted, "\x1b[") {
+		t.Error("expected ANSI styling in output")
+	}
+}
+
+// TestRuneDisplayWidthMatchesGraphemeSegmentation pins the measurement
+// contract with lipgloss.StyleRanges.
+//
+// StyleRanges resolves the cell offsets it is handed with ansi.Cut, which
+// segments by grapheme cluster. Summing per-rune widths disagrees on every
+// cluster built from more than one rune, and the highlight then lands that
+// many cells right of its token.
+func TestRuneDisplayWidthMatchesGraphemeSegmentation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+	}{
+		{"ascii", "hello"},
+		{"cjk double width", "日本語"},
+		{"emoji with skin tone modifier", "👍🏽"},
+		{"zwj family", "👨‍👩‍👧"},
+		{"emoji then token", "👍🏽 @file.go"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got, want := runeDisplayWidth([]rune(tc.in)), ansi.StringWidth(tc.in); got != want {
+				t.Errorf("runeDisplayWidth(%q) = %d, want %d (grapheme-cluster segmentation)",
+					tc.in, got, want)
+			}
+		})
+	}
+}
+
+// TestHighlightRangesLandOnTokenAfterEmoji is the user-visible form of the
+// bug: with per-rune widths the styled span started two cells past the '@'.
+func TestHighlightRangesLandOnTokenAfterEmoji(t *testing.T) {
+	t.Parallel()
+
+	// "👍🏽 @file.go" — the token starts after a 2-cell grapheme and a space,
+	// so at cell 3. Per-rune summing put it at 5.
+	const line = "👍🏽 @file.go"
+
+	at := strings.IndexRune(line, '@')
+	if at <= 0 {
+		t.Fatalf("test string must contain '@', got byte index %d", at)
+	}
+	atRune := len([]rune(line[:at]))
+
+	if got, want := runeDisplayWidth([]rune(line)[:atRune]), 3; got != want {
+		t.Errorf("token starts at cell %d, want %d (the cell ansi.Cut would land on)", got, want)
+	}
+}
+
+// TestNormalizeRangesOrdersAndDropsOverlaps pins the guard on
+// lipgloss.StyleRanges, which walks ranges in order and tracks how far it has
+// consumed. Out-of-order or overlapping input makes it emit part of the line
+// twice and drop another part, so a careless highlighter would corrupt the
+// render rather than merely mis-colour it.
+func TestNormalizeRangesOrdersAndDropsOverlaps(t *testing.T) {
+	t.Parallel()
+
+	base := lipgloss.NewStyle()
+	bold := lipgloss.NewStyle().Bold(true)
+	seg := []rune("ab @foo cd @bar")
+
+	tests := []struct {
+		name   string
+		ranges []lipgloss.Range
+	}{
+		{
+			name: "descending",
+			ranges: []lipgloss.Range{
+				lipgloss.NewRange(11, 15, bold),
+				lipgloss.NewRange(3, 7, bold),
+			},
+		},
+		{
+			name: "overlapping",
+			ranges: []lipgloss.Range{
+				lipgloss.NewRange(3, 7, bold),
+				lipgloss.NewRange(5, 9, bold),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := ansi.Strip(styleSegment(base, seg, 0, tc.ranges))
+			if want := string(seg); got != want {
+				t.Errorf("stripped output = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+// TestViewSelectionWinsOverHighlighter pins the precedence between the two
+// span-styling features: a selected segment renders in the selection style
+// alone, so the two never stack on the same cell.
+func TestViewSelectionWinsOverHighlighter(t *testing.T) {
+	t.Parallel()
+
+	const value = "see @foo.go here"
+
+	withHighlighter := func() Model {
+		m := New()
+		m.SetValue(value)
+		m.SetWidth(80)
+		m.SetHighlighter(tokenHighlighter{style: lipgloss.NewStyle().Foreground(lipgloss.Color("2"))})
+		return m
+	}
+
+	m := withHighlighter()
+	m.SelectAll()
+
+	plain := New()
+	plain.SetValue(value)
+	plain.SetWidth(80)
+	plain.SelectAll()
+
+	if got, want := m.View(), plain.View(); got != want {
+		t.Errorf("selected view with highlighter = %q, want it identical to %q", got, want)
+	}
+}

--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -352,6 +352,10 @@ type Model struct {
 
 	// rune sanitizer for input.
 	rsan runeutil.Sanitizer
+
+	// highlighter is the optional per-line token highlighter installed via
+	// SetHighlighter. Consulted at render time only.
+	highlighter LineHighlighter
 }
 
 // New creates a new model with default settings.
@@ -1375,6 +1379,15 @@ func (m *Model) view() string {
 			style = styles.computedText()
 		}
 
+		// Consult the optional token highlighter once per logical line.
+		// Ranges are rune offsets within the logical line; each wrapped
+		// segment intersects them at render time.
+		var lineRanges []lipgloss.Range
+		if m.highlighter != nil {
+			lineRanges = m.highlightRanges(l, line)
+		}
+
+		segStart := 0
 		for wl, wrappedLine := range wrappedLines {
 			prompt := m.promptView(displayLine)
 			s.WriteString(style.Render(prompt))
@@ -1399,6 +1412,9 @@ func (m *Model) view() string {
 
 			strwidth := uniseg.StringWidth(string(wrappedLine))
 			padding := m.width - strwidth
+			// segLen is captured before the trailing-space trim below so
+			// segStart tracking stays aligned with the raw logical line.
+			segLen := len(wrappedLine)
 			// If the trailing space causes the line to be wider than the
 			// width, we should not draw it to the screen since it will result
 			// in an extra space at the end of the line which can look off when
@@ -1411,21 +1427,22 @@ func (m *Model) view() string {
 				padding -= m.width - strwidth
 			}
 			if m.row == l && lineInfo.RowOffset == wl {
-				s.WriteString(style.Render(string(wrappedLine[:lineInfo.ColumnOffset])))
+				s.WriteString(styleSegment(style, wrappedLine[:lineInfo.ColumnOffset], segStart, lineRanges))
 				if m.col >= len(line) && lineInfo.CharOffset >= m.width {
 					m.virtualCursor.SetChar(" ")
 					s.WriteString(m.virtualCursor.View())
 				} else {
 					m.virtualCursor.SetChar(string(wrappedLine[lineInfo.ColumnOffset]))
 					s.WriteString(style.Render(m.virtualCursor.View()))
-					s.WriteString(style.Render(string(wrappedLine[lineInfo.ColumnOffset+1:])))
+					s.WriteString(styleSegment(style, wrappedLine[lineInfo.ColumnOffset+1:], segStart+lineInfo.ColumnOffset+1, lineRanges))
 				}
 			} else {
-				s.WriteString(style.Render(string(wrappedLine)))
+				s.WriteString(styleSegment(style, wrappedLine, segStart, lineRanges))
 			}
 			s.WriteString(style.Render(strings.Repeat(" ", max(0, padding))))
 			s.WriteRune('\n')
 			newLines++
+			segStart += segLen
 		}
 	}
 

--- a/textarea/textarea.go
+++ b/textarea/textarea.go
@@ -393,6 +393,10 @@ type Model struct {
 
 	// selecting reports whether a drag is currently in progress.
 	selecting bool
+
+	// highlighter is the optional per-line token highlighter installed via
+	// SetHighlighter. Consulted at render time only.
+	highlighter LineHighlighter
 }
 
 // New creates a new model with default settings.
@@ -1501,9 +1505,14 @@ func (m *Model) view() string {
 			style = styles.computedText()
 		}
 
+		// Consult the optional token highlighter once per logical line.
+		// Ranges are rune offsets within the logical line; each wrapped
+		// segment intersects them at render time.
+		lineRanges := m.highlightRanges(l, line)
+
 		// wrappedBase is the index, within the logical line, of the first rune
 		// of the current wrapped segment. It is what maps a segment back onto
-		// selection coordinates.
+		// selection and highlight coordinates.
 		wrappedBase := 0
 
 		for wl, wrappedLine := range wrappedLines {
@@ -1530,6 +1539,11 @@ func (m *Model) view() string {
 
 			strwidth := uniseg.StringWidth(string(wrappedLine))
 			padding := m.width - strwidth
+			// segLen is captured before the trailing-space trim below so
+			// wrappedBase keeps counting runes of the raw logical line: the
+			// trimmed space is a rune of that line, and dropping it from the
+			// tally shifts every later segment one rune to the left.
+			segLen := len(wrappedLine)
 			// If the trailing space causes the line to be wider than the
 			// width, we should not draw it to the screen since it will result
 			// in an extra space at the end of the line which can look off when
@@ -1542,27 +1556,28 @@ func (m *Model) view() string {
 				padding -= m.width - strwidth
 			}
 
-			// A selection covering this segment takes precedence over the
-			// inline cursor: during a drag the highlight is the meaningful
-			// affordance, and mixing the two would double-style the same cell.
+			// A selection covering this segment takes precedence over both the
+			// inline cursor and any token highlighting: during a drag the
+			// selection is the meaningful affordance, and stacking them would
+			// double-style the same cell.
 			if selFrom, selTo, selected := m.selectionSpanFor(l, wrappedBase, len(wrappedLine)); selected {
 				s.WriteString(style.Render(string(wrappedLine[:selFrom])))
 				s.WriteString(styles.computedSelection().Render(string(wrappedLine[selFrom:selTo])))
 				s.WriteString(style.Render(string(wrappedLine[selTo:])))
 			} else if m.row == l && lineInfo.RowOffset == wl {
-				s.WriteString(style.Render(string(wrappedLine[:lineInfo.ColumnOffset])))
+				s.WriteString(styleSegment(style, wrappedLine[:lineInfo.ColumnOffset], wrappedBase, lineRanges))
 				if m.col >= len(line) && lineInfo.CharOffset >= m.width {
 					m.virtualCursor.SetChar(" ")
 					s.WriteString(m.virtualCursor.View())
 				} else {
 					m.virtualCursor.SetChar(string(wrappedLine[lineInfo.ColumnOffset]))
 					s.WriteString(style.Render(m.virtualCursor.View()))
-					s.WriteString(style.Render(string(wrappedLine[lineInfo.ColumnOffset+1:])))
+					s.WriteString(styleSegment(style, wrappedLine[lineInfo.ColumnOffset+1:], wrappedBase+lineInfo.ColumnOffset+1, lineRanges))
 				}
 			} else {
-				s.WriteString(style.Render(string(wrappedLine)))
+				s.WriteString(styleSegment(style, wrappedLine, wrappedBase, lineRanges))
 			}
-			wrappedBase += len(wrappedLine)
+			wrappedBase += segLen
 			s.WriteString(style.Render(strings.Repeat(" ", max(0, padding))))
 			s.WriteRune('\n')
 			newLines++


### PR DESCRIPTION
Feature request: #1043 — opened as an issue rather than a Discussion; happy to move it if the team prefers the Ideas board.

---

There is no way to style parts of a line in a textarea. Apps that want token highlighting in their prompt — `@file` mentions, `/command` names, anything lexical — have to either post-process the rendered string (fighting ANSI escapes the textarea just emitted) or fork the render loop wholesale.

Add a `LineHighlighter` hook:

```go
type LineHighlighter interface {
    Highlight(lineIdx int, line []rune) []lipgloss.Range
}

func (m *Model) SetHighlighter(h LineHighlighter)
```

The hook is consulted once per logical line per render and returns style ranges over that line's runes. The renderer intersects those ranges with each wrapped segment, so implementations never think about wrapping and never see a segment boundary.

Keeping the interface range-based, rather than a `func(string) string` that rewrites ANSI, means implementations never parse or preserve escape sequences, and the textarea's wrap and cursor math keeps operating on raw runes.

Neither the cell under the virtual cursor nor a selected segment is styled by ranges. The renderer already splits cursor-line content into pre- and post-cursor segments, and an active selection short-circuits the segment entirely, so no two span-styling features can fight over the same cell.

With no highlighter installed the render path is byte-identical to before — `styleSegment` short-circuits to the plain render when there are no ranges.

Two subtleties worth stating, because both are easy to get wrong:

**Grapheme clusters.** Rune offsets are converted to display cells with `ansi.StringWidth` rather than by summing per-rune widths. `lipgloss.StyleRanges` resolves the cell offsets it is handed via `ansi.Cut`, which segments by grapheme cluster. Per-rune summing disagrees on every cluster built from more than one rune — an emoji with a skin-tone modifier scores 4 instead of 2, a ZWJ family 7 instead of 2 — and the highlight then lands that many cells right of its token.

**Range order.** `StyleRanges` walks its ranges in the order given, tracking how far it has consumed. Ranges arriving out of order or overlapping make it emit part of the line twice and drop another part, so a careless highlighter would corrupt content rather than merely mis-colour it. `normalizeRanges` sorts and de-overlaps before handing them over, and the hook's contract says callers need not do it themselves.

Tests pin all three behaviours.

**One line outside the new feature**, called out so it is not missed in review: `wrappedBase` now advances by the segment length captured *before* the trailing-space trim. That space is a rune of the logical line, so counting the trimmed length shifted every later segment of that line one rune left — for the new highlight ranges and, already, for selection spans. Happy to split it into its own PR if you'd rather.

No new dependencies.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features). — filed as #1043 instead; say the word and I'll move it to Discussions.

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Claude Code](https://claude.com/claude-code).
