### PR TITLE
feat(textarea): add ByteOffset and SetCursorByteOffset

### DIFF
--- a/textarea/byteoffset.go
+++ b/textarea/byteoffset.go
@@ -1,0 +1,65 @@
+package textarea
+
+// ByteOffset returns the cursor's position as a byte offset into [Model.Value].
+//
+// [Model.Line] and [Model.Column] locate the cursor within the value's grid of
+// rows and runes, which is the wrong coordinate space for a caller that wants
+// to slice, splice, or scan the value as a flat string. Value joins the rows
+// with "\n", so the offset is the byte length of every preceding row plus its
+// separator, then the current row up to the cursor.
+//
+// The returned offset always lands on a UTF-8 boundary.
+func (m Model) ByteOffset() int {
+	var off int
+	for i, row := range m.value {
+		if i == m.row {
+			return off + len(string(row[:clamp(m.col, 0, len(row))]))
+		}
+		off += len(string(row)) + 1 // +1 for the joining newline
+	}
+	return off
+}
+
+// SetCursorByteOffset places the cursor at a byte offset into [Model.Value],
+// the inverse of [Model.ByteOffset]. A negative offset clamps to the start and
+// an offset past the end clamps to the end.
+//
+// An offset landing inside a multi-byte rune, or on the "\n" that Value
+// inserts between rows, is not a position the cursor can occupy; it snaps
+// forward to the next one that is. Round-tripping an offset produced by
+// ByteOffset is therefore always exact.
+func (m *Model) SetCursorByteOffset(off int) {
+	if off < 0 {
+		off = 0
+	}
+
+	var seen int
+	for row, line := range m.value {
+		s := string(line)
+		if off <= seen+len(s) {
+			m.row = row
+			// Count runes up to the offset rather than slicing at it: a
+			// slice landing mid-rune would yield a partial sequence that
+			// decodes to U+FFFD and miscount the column.
+			col := 0
+			for i := range s {
+				if i >= off-seen {
+					break
+				}
+				col++
+			}
+			if off-seen >= len(s) {
+				col = len([]rune(s))
+			}
+			m.SetCursorColumn(col)
+			// Every other cursor mover repositions the viewport; without
+			// it the cursor can land scrolled out of sight after an edit
+			// in a long value.
+			m.repositionView()
+			return
+		}
+		seen += len(s) + 1 // +1 for the joining newline
+	}
+
+	m.MoveToEnd()
+}

--- a/textarea/byteoffset.go
+++ b/textarea/byteoffset.go
@@ -24,10 +24,13 @@ func (m Model) ByteOffset() int {
 // the inverse of [Model.ByteOffset]. A negative offset clamps to the start and
 // an offset past the end clamps to the end.
 //
-// An offset landing inside a multi-byte rune, or on the "\n" that Value
-// inserts between rows, is not a position the cursor can occupy; it snaps
-// forward to the next one that is. Round-tripping an offset produced by
-// ByteOffset is therefore always exact.
+// One offset is not a position the cursor can occupy: one landing inside a
+// multi-byte rune. It snaps forward to the next one that is, so round-tripping
+// an offset produced by ByteOffset is always exact.
+//
+// The "\n" Value inserts between rows belongs to no row, but it costs no
+// position either: the offset of that byte is the end of the row before it,
+// and the offset after it is the start of the row that follows.
 func (m *Model) SetCursorByteOffset(off int) {
 	if off < 0 {
 		off = 0

--- a/textarea/byteoffset_test.go
+++ b/textarea/byteoffset_test.go
@@ -1,0 +1,197 @@
+package textarea
+
+import (
+	"testing"
+	"unicode/utf8"
+)
+
+func TestByteOffsetSingleLine(t *testing.T) {
+	t.Parallel()
+
+	m := New()
+	m.SetValue("hello")
+
+	for _, col := range []int{0, 1, 5} {
+		m.SetCursorColumn(col)
+		if got := m.ByteOffset(); got != col {
+			t.Errorf("col %d: ByteOffset() = %d, want %d", col, got, col)
+		}
+	}
+}
+
+func TestByteOffsetCountsPrecedingRowsAndNewlines(t *testing.T) {
+	t.Parallel()
+
+	m := New()
+	m.SetValue("ab\ncd\nef")
+
+	// Row 2 col 1 → "ab"(2) + "\n"(1) + "cd"(2) + "\n"(1) + "e"(1) = 7.
+	m.CursorDown()
+	m.CursorDown()
+	m.SetCursorColumn(1)
+
+	if got, want := m.ByteOffset(), 7; got != want {
+		t.Errorf("ByteOffset() = %d, want %d", got, want)
+	}
+	if got, want := m.Value()[m.ByteOffset():], "f"; got != want {
+		t.Errorf("Value()[off:] = %q, want %q", got, want)
+	}
+}
+
+// TestByteOffsetIsBytesNotRunes is the distinction the API exists for:
+// Column counts runes, ByteOffset counts bytes, and they diverge the moment
+// a multi-byte rune precedes the cursor.
+func TestByteOffsetIsBytesNotRunes(t *testing.T) {
+	t.Parallel()
+
+	m := New()
+	m.SetValue("世界x")
+	m.SetCursorColumn(2) // after both CJK runes
+
+	if got, want := m.Column(), 2; got != want {
+		t.Errorf("Column() = %d, want %d", got, want)
+	}
+	// Each CJK rune is 3 bytes in UTF-8.
+	if got, want := m.ByteOffset(), 6; got != want {
+		t.Errorf("ByteOffset() = %d, want %d", got, want)
+	}
+	if got, want := m.Value()[m.ByteOffset():], "x"; got != want {
+		t.Errorf("Value()[off:] = %q, want %q", got, want)
+	}
+}
+
+// TestByteOffsetSlicesValueCleanly is the property callers actually rely on:
+// the offset is a valid index into Value() at every cursor position, and the
+// two halves rejoin to the original.
+func TestByteOffsetSlicesValueCleanly(t *testing.T) {
+	t.Parallel()
+
+	const value = "ab 世界\n👍🏽 cd\n\nef"
+
+	m := New()
+	m.SetValue(value)
+
+	for row := range m.value {
+		m.row = row
+		for col := 0; col <= len(m.value[row]); col++ {
+			m.SetCursorColumn(col)
+			off := m.ByteOffset()
+
+			v := m.Value()
+			if off < 0 || off > len(v) {
+				t.Fatalf("row %d col %d: offset %d out of range for %d bytes", row, col, off, len(v))
+			}
+			if !utf8.RuneStart(v[off%max(len(v), 1)]) && off != len(v) {
+				t.Errorf("row %d col %d: offset %d lands mid-rune", row, col, off)
+			}
+			if got := v[:off] + v[off:]; got != v {
+				t.Errorf("row %d col %d: split/rejoin = %q, want %q", row, col, got, v)
+			}
+		}
+	}
+}
+
+func TestSetCursorByteOffsetRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	const value = "ab 世界\n👍🏽 cd\n\nef"
+
+	m := New()
+	m.SetValue(value)
+
+	for row := range m.value {
+		m.row = row
+		for col := 0; col <= len(m.value[row]); col++ {
+			m.SetCursorColumn(col)
+			wantRow, wantCol, off := m.Line(), m.Column(), m.ByteOffset()
+
+			// Move somewhere else, then restore purely from the offset.
+			m.MoveToBegin()
+			m.SetCursorByteOffset(off)
+
+			if m.Line() != wantRow || m.Column() != wantCol {
+				t.Errorf("offset %d: restored to row %d col %d, want row %d col %d",
+					off, m.Line(), m.Column(), wantRow, wantCol)
+			}
+			if got := m.ByteOffset(); got != off {
+				t.Errorf("offset %d round-tripped to %d", off, got)
+			}
+		}
+	}
+}
+
+func TestSetCursorByteOffsetClamps(t *testing.T) {
+	t.Parallel()
+
+	m := New()
+	m.SetValue("ab\ncd")
+
+	m.SetCursorByteOffset(-5)
+	if m.Line() != 0 || m.Column() != 0 {
+		t.Errorf("negative offset: row %d col %d, want row 0 col 0", m.Line(), m.Column())
+	}
+
+	m.SetCursorByteOffset(9999)
+	if got, want := m.ByteOffset(), len(m.Value()); got != want {
+		t.Errorf("past-end offset: ByteOffset() = %d, want %d", got, want)
+	}
+}
+
+// TestSetCursorByteOffsetMidRuneSnapsForward pins the documented behavior for
+// an offset that is not a cursor position. Slicing the row at a mid-rune byte
+// would produce a partial UTF-8 sequence, decode it to U+FFFD, and land the
+// cursor a rune short.
+func TestSetCursorByteOffsetMidRuneSnapsForward(t *testing.T) {
+	t.Parallel()
+
+	m := New()
+	m.SetValue("世界") // two 3-byte runes
+
+	for _, off := range []int{1, 2} {
+		m.MoveToBegin()
+		m.SetCursorByteOffset(off)
+		if got, want := m.Column(), 1; got != want {
+			t.Errorf("mid-rune offset %d: Column() = %d, want %d", off, got, want)
+		}
+		if got, want := m.ByteOffset(), 3; got != want {
+			t.Errorf("mid-rune offset %d: ByteOffset() = %d, want %d", off, got, want)
+		}
+	}
+}
+
+// TestSetCursorByteOffsetOnNewlineSnapsForward covers the other non-position:
+// the "\n" Value inserts between rows is not part of any row.
+func TestSetCursorByteOffsetOnNewlineSnapsForward(t *testing.T) {
+	t.Parallel()
+
+	m := New()
+	m.SetValue("ab\ncd")
+
+	// Offset 2 is the end of row 0; offset 3 is the start of row 1. The
+	// separator itself occupies neither.
+	m.SetCursorByteOffset(2)
+	if m.Line() != 0 || m.Column() != 2 {
+		t.Errorf("offset 2: row %d col %d, want row 0 col 2", m.Line(), m.Column())
+	}
+
+	m.SetCursorByteOffset(3)
+	if m.Line() != 1 || m.Column() != 0 {
+		t.Errorf("offset 3: row %d col %d, want row 1 col 0", m.Line(), m.Column())
+	}
+}
+
+func TestSetCursorByteOffsetEmptyValue(t *testing.T) {
+	t.Parallel()
+
+	m := New()
+
+	m.SetCursorByteOffset(0)
+	if got := m.ByteOffset(); got != 0 {
+		t.Errorf("ByteOffset() = %d, want 0", got)
+	}
+
+	m.SetCursorByteOffset(10)
+	if got := m.ByteOffset(); got != 0 {
+		t.Errorf("past-end on empty value: ByteOffset() = %d, want 0", got)
+	}
+}

--- a/textarea/byteoffset_test.go
+++ b/textarea/byteoffset_test.go
@@ -159,9 +159,10 @@ func TestSetCursorByteOffsetMidRuneSnapsForward(t *testing.T) {
 	}
 }
 
-// TestSetCursorByteOffsetOnNewlineSnapsForward covers the other non-position:
-// the "\n" Value inserts between rows is not part of any row.
-func TestSetCursorByteOffsetOnNewlineSnapsForward(t *testing.T) {
+// TestSetCursorByteOffsetAtRowSeparator covers the "\n" Value inserts between
+// rows. It belongs to no row, but it costs no cursor position either: the
+// offsets on either side of it are both ordinary positions, so nothing snaps.
+func TestSetCursorByteOffsetAtRowSeparator(t *testing.T) {
 	t.Parallel()
 
 	m := New()


### PR DESCRIPTION
Feature request: #1044 — opened as an issue rather than a Discussion; happy to move it if the team prefers the Ideas board.

---

`Line()` and `Column()` locate the cursor in the value's grid of rows and runes. That is the wrong coordinate space for a caller that wants to treat `Value()` as a flat string — slicing around the cursor, scanning backwards for a token boundary, splicing a completion in. Converting grid coordinates to a byte index means re-deriving the join `Value()` already performed, and every caller writes the same loop.

Add the pair:

```go
func (m Model) ByteOffset() int
func (m *Model) SetCursorByteOffset(off int)
```

One offset is not a position the cursor can occupy: one landing inside a multi-byte rune. `SetCursorByteOffset` snaps it forward to the next one that is, so round-tripping an offset from `ByteOffset` is always exact. A negative offset clamps to the start, a past-the-end offset to the end.

The `"\n"` `Value()` inserts between rows belongs to no row, but it costs no position either: the offset of that byte is the end of the row before it, and the offset after it is the start of the row that follows. Both are ordinary cursor positions. A test covers each side.

Getting the mid-rune case wrong is quiet and surprising: slicing the row at the requested byte yields a partial UTF-8 sequence, which decodes to U+FFFD and counts as a whole rune, so asking for byte 2 of `"世界"` lands the cursor at byte 6 — past the rune the caller was pointing into, not before it. Counting rune starts up to the offset instead lands it at byte 3. A test pins this.

`SetCursorByteOffset` repositions the viewport like every other cursor mover, so restoring a saved offset after an edit cannot leave the cursor scrolled out of sight.

No new dependencies, and no change to existing behaviour — two new methods in a new file.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] I have created a discussion that was approved by a maintainer (for new features). — filed as #1044 instead; say the word and I'll move it to Discussions.

🤖 Posted on behalf of `@joestump` by [`claude-opus-5`](https://openrouter.ai/anthropic/claude-opus-5) using [Claude Code](https://claude.com/claude-code).
