### PR TITLE
fix(list): restore the default quit keys

### DIFF
--- a/list/keys.go
+++ b/list/keys.go
@@ -89,8 +89,8 @@ func DefaultKeyMap() KeyMap {
 
 		// Quitting.
 		Quit: key.NewBinding(
-			key.WithKeys("v"),
-			key.WithHelp("v", "select"),
+			key.WithKeys("q", "esc"),
+			key.WithHelp("q", "quit"),
 		),
 		ForceQuit: key.NewBinding(key.WithKeys("ctrl+c")),
 	}

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -30,6 +30,16 @@ func (d itemDelegate) Render(w io.Writer, m Model, index int, listItem Item) {
 	fmt.Fprint(w, m.Styles.TitleBar.Render(str))
 }
 
+func TestDefaultKeyMapQuit(t *testing.T) {
+	quit := DefaultKeyMap().Quit
+	if !reflect.DeepEqual(quit.Keys(), []string{"q", "esc"}) {
+		t.Fatalf("expected quit keys q and esc, got %v", quit.Keys())
+	}
+	if help := quit.Help(); help.Key != "q" || help.Desc != "quit" {
+		t.Fatalf("expected quit help, got %q, %q", help.Key, help.Desc)
+	}
+}
+
 func TestStatusBarItemName(t *testing.T) {
 	list := New([]Item{item("foo"), item("bar")}, itemDelegate{}, 10, 10)
 	expected := "2 items"


### PR DESCRIPTION
## Problem

The list key map's Quit binding was accidentally changed from q/esc to v while its help text said select. Pressing v therefore quit the list, and the documented default quit keys no longer worked.

Fixes #1045

## Fix

Restore q and esc as the default Quit keys and restore the q, quit help label. Add a regression that checks both the active keys and their displayed help.

## User impact

List users can quit with the established q/esc defaults again, and v is no longer misrepresented as a selection key that exits the component.

## Verification

- Focused regression failed on main with [v] and passes after the fix
- go test ./... — passed
- go vet ./... — passed
- git diff --check — passed