### PR TITLE
fix(list): avoid truncating titles without status

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -1110,7 +1110,9 @@ func (m Model) titleView() string {
 
 		// Status message
 		if m.filterState != Filtering {
-			view += "  " + m.statusMessage
+			if m.statusMessage != "" {
+				view += "  " + m.statusMessage
+			}
 			view = ansi.Truncate(view, m.width-spinnerWidth, ellipsis)
 		}
 	}

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
 )
 
 type item string
@@ -133,5 +134,16 @@ func TestSetFilterState(t *testing.T) {
 
 	if !strings.Contains(footer, expected) {
 		t.Fatalf("Error: expected view to contain '%s'", expected)
+	}
+}
+
+func TestTitleViewWithoutStatusMessageDoesNotTruncate(t *testing.T) {
+	list := New(nil, itemDelegate{}, 20, 10)
+	list.Title = "List Title ABCDEFG"
+	list.Styles.Title = list.Styles.Title.Padding(0)
+	list.Styles.TitleBar = list.Styles.TitleBar.Padding(0)
+
+	if got := ansi.Strip(list.titleView()); got != list.Title {
+		t.Fatalf("expected title %q, got %q", list.Title, got)
 	}
 }


### PR DESCRIPTION
## Summary

Avoid reserving the two-space status separator when the list has no status message. This prevents a title that exactly fits the available width from receiving an unnecessary ellipsis.

Fixes #737.

## Before and after

1. Create a 20-column list with the title `List Title ABCDEFG` and no status message.
2. Remove the title and title-bar padding.
3. Render the title view.

Before this change, the empty status separator causes the full-width title to be truncated. After this change, the complete title is preserved. Non-empty status messages keep the existing separator and truncation behavior.

## Testing

- `go test ./list -run TestTitleViewWithoutStatusMessageDoesNotTruncate -count=1`
- `go test ./... -count=1`
- `go test -race ./... -count=1`

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
